### PR TITLE
Fix splash content height on desktop

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -48,11 +48,11 @@
         #splash-content {
             width: 100%;
             max-width: 520px;
-            height: 100%;
+            max-height: 100vh;
+            overflow-y: auto;
             display: flex;
             background-color: #02010a;
             z-index: 2000;
-            display: flex;
             flex-direction: column;
             justify-content: space-between;
             align-items: center;
@@ -66,6 +66,8 @@
             width: 90%;
             max-width: 520px; /* Límite para PC, un poco más grande que el juego */
             height: auto;
+            flex-shrink: 1;
+            max-height: 35vh;
             object-fit: contain;
             box-sizing: border-box;
         }
@@ -74,6 +76,8 @@
             cursor: pointer;
             width: auto;
             height: auto;
+            flex-shrink: 1;
+            max-height: 15vh;
             max-width: min(60vw, 150px); /* Responsivo pero con límite en PC */
             object-fit: contain;
             z-index: 2001;
@@ -89,7 +93,8 @@
             width: 100%;
             max-width: 520px; /* Límite para PC, un poco más grande que el juego */
             height: auto;
-            max-height: calc(25vh + 60px);
+            flex-shrink: 1;
+            max-height: 25vh;
             object-fit: contain;
             box-sizing: border-box;
             padding-top: 20px;


### PR DESCRIPTION
## Summary
- ensure splash screen stays within viewport
- allow splash images to shrink on large screens

## Testing
- `git status --short`