### PR TITLE
Fix default Snake skin name mapping

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1155,6 +1155,7 @@
 
         // Mapping para nombres de jugadores en el ranking
         const SKIN_DISPLAY_NAMES = {
+            snake: "Snake",
             Snake: "Snake",
             rubiSnake: "RubiSnake",
             aitorSnake: "AitorSnake",


### PR DESCRIPTION
## Summary
- handle lowercase 'snake' skin value in ranking display

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683a167a21d4832cb20a16e16bc0b04e