### PR TITLE
Improve mobile layout in settings

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -733,14 +733,29 @@
             }
              #settings-panel .control-group {
                 min-height: 50px;
+                justify-content: flex-start;
+                padding-top: 6px;
+                padding-bottom: 6px;
             }
-             #settings-panel #difficultySelector, 
+             #settings-panel #difficultySelector,
              #settings-panel #worldsSelector,
              #settings-panel #audioToggleSelector,
              #settings-panel #skinSelector,
              #settings-panel #foodSelector,
              #settings-panel #gameModeSelector,
-             #settings-panel #musicVolumeSlider { font-size: 0.7em; }
+             #settings-panel #musicVolumeSlider {
+                font-size: 0.7em;
+                margin-top: 2px;
+             }
+             #settings-panel .control-label-icon-row { margin-bottom: 2px; }
+             .setting-info-button {
+                width: 36px;
+                height: 32px;
+             }
+             .setting-info-icon {
+                width: 20px;
+                height: 20px;
+             }
 
 
              #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 1em; } 


### PR DESCRIPTION
## Summary
- tweak CSS for better mobile layout in the settings panel
- reduce spacing and shrink info button size

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_683a1e678bd0832cae3b75900248827b