### PR TITLE
Fix spacing of selectors in mobile settings panel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -441,7 +441,8 @@
             -moz-appearance: none; 
             -webkit-appearance: none; 
             appearance: none; 
-            margin-top: 4px; 
+            margin-top: 4px;
+            margin-bottom: 4px;
         }
         
         #difficultySelector option, #worldsSelector option, #audioToggleSelector option, #skinSelector option, #foodSelector option, #gameModeSelector option {
@@ -494,7 +495,8 @@
             border-radius: 5px;
             outline: none;
             transition: opacity .2s;
-             margin-top: 4px; 
+             margin-top: 4px;
+            margin-bottom: 4px;
         }
         #musicVolumeSlider::-webkit-slider-thumb {
             -webkit-appearance: none;
@@ -746,6 +748,7 @@
              #settings-panel #musicVolumeSlider {
                 font-size: 0.7em;
                 margin-top: 2px;
+                margin-bottom: 2px;
              }
              #settings-panel .control-label-icon-row { margin-bottom: 2px; }
              .setting-info-button {


### PR DESCRIPTION
## Summary
- adjust margin for selectors so they sit higher within their containers
- apply the same fix for the music volume slider
- keep mobile media query in sync with new spacing

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_683a2639692c832cb47ebdf50ac05ffb