### PR TITLE
Fix overflow in desktop splash screen

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -826,6 +826,16 @@
                 margin-bottom: 2px;
             }
         }
+
+        @media screen and (min-width: 800px) {
+            #splash-screen {
+                overflow-y: auto;
+            }
+            #splash-content {
+                height: auto;
+                max-height: none;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- adjust overflow rules for desktop view so bottom image is visible

## Testing
- `npx --version` *(fails: `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`)*

------
https://chatgpt.com/codex/tasks/task_b_683ca612e928832c85937bf0414ef67f