### PR TITLE
Ensure splash screen fits desktop viewport

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -826,6 +826,17 @@
                 margin-bottom: 2px;
             }
         }
+
+        @media screen and (min-width: 800px) {
+            #splash-content { padding: 10px 0; }
+            #splash-top-image { max-height: 22vh; }
+            #splash-start-button { margin: 10px 0; }
+            #splash-bottom-image {
+                max-height: 20vh;
+                padding-top: 20px;
+                padding-bottom: 20px;
+            }
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- adjust CSS to make splash screen fit within desktop viewport

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683cab82a9c0832ca689dd9ee7798bbe