### PR TITLE
Match overlay width to info panels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -578,22 +578,22 @@
         .settings-panel-hidden, .info-panel-hidden, .specific-info-panel-hidden { 
             display: none !important;
         }
-        #settings-panel, #info-panel, #specific-info-panel { 
+        #settings-panel, #info-panel, #specific-info-panel {
             position: fixed;
             left: 50%;
-            transform: translateX(-50%) scale(0.95); 
-            background-color: #1F2937; 
+            transform: translateX(-50%) scale(0.95);
+            background-color: #1F2937;
             padding: 25px;
             border-radius: 12px;
             box-shadow: 0 10px 30px rgba(0,0,0,0.6);
-            z-index: 1001; 
-            width: 90%;
-            max-width: 400px; 
+            z-index: 1001;
+            width: 100%;
+            max-width: 520px;
             display: flex;
             flex-direction: column;
             gap: 15px;
-            border: 2px solid #4b5563; 
-            overflow-y: auto; 
+            border: 2px solid #4b5563;
+            overflow-y: auto;
             opacity: 0; 
             transition: opacity 0.3s ease-out, transform 0.3s ease-out; 
         }


### PR DESCRIPTION
## Summary
- widen the settings and info overlays so they match the width of other panels on desktop

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683d422d95a0832c950a4c75ee048799