### PR TITLE
Fix mobile scaling while keeping desktop grid

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1223,9 +1223,10 @@
 
 
         // Configuración del juego
-        const GRID_SIZE = 20; 
-        let tileCountX; 
-        let tileCountY; 
+        let GRID_SIZE = 20;
+        const TILE_COUNT = 24;
+        let tileCountX;
+        let tileCountY;
         const INITIAL_SNAKE_LENGTH = 3; 
         const MAX_STREAK = 5; 
         
@@ -1596,23 +1597,44 @@
             const containerComputedStyle = getComputedStyle(gameContainer);
             const canvasComputedStyle = getComputedStyle(canvasEl);
 
-            const containerPadding = 2 * parseFloat(containerComputedStyle.paddingLeft); 
+            const containerPadding = 2 * parseFloat(containerComputedStyle.paddingLeft);
             let availableWidth = gameContainer.clientWidth - containerPadding;
-            
+
             const canvasBorderWidth = 2 * parseFloat(canvasComputedStyle.borderLeftWidth);
             availableWidth -= canvasBorderWidth;
 
-            let newCanvasSize = Math.floor(availableWidth / GRID_SIZE) * GRID_SIZE;
+            const isDesktop = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
 
-            const minTiles = 10; 
-            const minCanvasSize = minTiles * GRID_SIZE;
-            newCanvasSize = Math.max(newCanvasSize, minCanvasSize); 
-            
-            canvasEl.width = newCanvasSize;
-            canvasEl.height = newCanvasSize; 
+            if (isDesktop) {
+                let newGridSize = Math.floor(availableWidth / TILE_COUNT);
+                const minGridSize = 10;
+                if (newGridSize < minGridSize) {
+                    newGridSize = minGridSize;
+                }
 
-            tileCountX = canvasEl.width / GRID_SIZE;
-            tileCountY = canvasEl.height / GRID_SIZE;
+                GRID_SIZE = newGridSize;
+                const newCanvasSize = GRID_SIZE * TILE_COUNT;
+
+                canvasEl.width = newCanvasSize;
+                canvasEl.height = newCanvasSize;
+
+                tileCountX = TILE_COUNT;
+                tileCountY = TILE_COUNT;
+            } else {
+                GRID_SIZE = 20;
+
+                let newCanvasSize = Math.floor(availableWidth / GRID_SIZE) * GRID_SIZE;
+
+                const minTiles = 10;
+                const minCanvasSize = minTiles * GRID_SIZE;
+                newCanvasSize = Math.max(newCanvasSize, minCanvasSize);
+
+                canvasEl.width = newCanvasSize;
+                canvasEl.height = newCanvasSize;
+
+                tileCountX = canvasEl.width / GRID_SIZE;
+                tileCountY = canvasEl.height / GRID_SIZE;
+            }
 
             // If a panel is open, re-calculate its position after resize
             if (!settingsPanel.classList.contains("settings-panel-hidden")) {


### PR DESCRIPTION
## Summary
- preserve the original mobile canvas size calculations
- keep dynamic grid sizing for desktop based on tile count

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683d71ceb0148333a507ef460128185e