### PR TITLE
Fix desktop canvas scaling

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1146,7 +1146,7 @@
         const infoPanel = document.getElementById("info-panel");
         const infoPanelContent = document.getElementById("info-panel-content"); 
         const closeInfoButton = document.getElementById("close-info-button");
-        const topInfoBar = document.getElementById('top-info-bar'); 
+        const topInfoBar = document.getElementById('top-info-bar');
         const actionButtonsRow = document.getElementById('action-buttons-row');
 
         // New DOM elements for specific info panel
@@ -1597,26 +1597,32 @@
             const containerComputedStyle = getComputedStyle(gameContainer);
             const canvasComputedStyle = getComputedStyle(canvasEl);
 
-            const containerPadding = 2 * parseFloat(containerComputedStyle.paddingLeft);
-            let availableWidth = gameContainer.clientWidth - containerPadding;
+           const containerPadding = 2 * parseFloat(containerComputedStyle.paddingLeft);
+           let availableWidth = gameContainer.clientWidth - containerPadding;
 
-            const canvasBorderWidth = 2 * parseFloat(canvasComputedStyle.borderLeftWidth);
-            availableWidth -= canvasBorderWidth;
+           const canvasBorderWidth = 2 * parseFloat(canvasComputedStyle.borderLeftWidth);
+           availableWidth -= canvasBorderWidth;
+
+            const availableHeight =
+                gameContainer.clientHeight -
+                topInfoBar.offsetHeight -
+                actionButtonsRow.offsetHeight;
 
             const isDesktop = window.matchMedia('(hover: hover) and (pointer: fine)').matches;
 
             if (isDesktop) {
-                let newGridSize = Math.floor(availableWidth / TILE_COUNT);
+                let newGridSize = Math.floor(
+                    Math.min(availableWidth, availableHeight) / TILE_COUNT
+                );
                 const minGridSize = 10;
                 if (newGridSize < minGridSize) {
                     newGridSize = minGridSize;
                 }
 
                 GRID_SIZE = newGridSize;
-                const newCanvasSize = GRID_SIZE * TILE_COUNT;
 
-                canvasEl.width = newCanvasSize;
-                canvasEl.height = newCanvasSize;
+                canvasEl.width = GRID_SIZE * TILE_COUNT;
+                canvasEl.height = GRID_SIZE * TILE_COUNT;
 
                 tileCountX = TILE_COUNT;
                 tileCountY = TILE_COUNT;


### PR DESCRIPTION
## Summary
- tweak `resizeGameElements` to exclude settings panels from canvas height

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_683d98b16db48333ae3701af882079c3