### PR TITLE
Update world 2 images

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1493,12 +1493,12 @@
         // --- Funciones de Carga y Aplicación de Jugadores ---
         function loadWorldImages() {
             worldCoverImages[1].src = 'https://i.imgur.com/h7iNXJT.png';
-            worldCoverImages[2].src = 'https://i.imgur.com/auJR4Im.png';
+            worldCoverImages[2].src = 'https://i.imgur.com/Y76HoJR.png';
             worldCoverImages[3].src = 'https://i.imgur.com/Iv2Pzet.png';
             worldCoverImages[4].src = 'https://i.imgur.com/X6KtQtD.png';
             worldCoverImages[5].src = 'https://i.imgur.com/LYCR9nT.png';
             worldCoverImages[6].src = 'https://i.imgur.com/t07LsqT.png';
-            worldCoverImages[2].src = 'https://i.imgur.com/4pKJmP2.png';
+            worldCoverImages[2].src = 'https://i.imgur.com/Y76HoJR.png';
             worldCoverImages[3].src = 'https://i.imgur.com/Iv2Pzet.png';
             worldCoverImages[4].src = 'https://i.imgur.com/X6KtQtD.png';
             worldCoverImages[5].src = 'https://i.imgur.com/LYCR9nT.png';
@@ -1507,12 +1507,12 @@
             worldCoverImages[8].src = 'https://i.imgur.com/JYjHEgy.png';
 
             worldCompleteImages[1].src = 'https://i.imgur.com/nkdJEmV.png';
-            worldCompleteImages[2].src = 'https://i.imgur.com/7XOV2tg.png';
+            worldCompleteImages[2].src = 'https://i.imgur.com/RpIGI2q.png';
             worldCompleteImages[3].src = 'https://i.imgur.com/tDOyHXc.png';
             worldCompleteImages[4].src = 'https://i.imgur.com/uoSRiRo.png';
             worldCompleteImages[5].src = 'https://i.imgur.com/PnP5i1q.png';
             worldCompleteImages[6].src = 'https://i.imgur.com/Dpv1WBM.png';
-            worldCompleteImages[2].src = 'https://i.imgur.com/rYz9bjn.png';
+            worldCompleteImages[2].src = 'https://i.imgur.com/RpIGI2q.png';
             worldCompleteImages[3].src = 'https://i.imgur.com/tDOyHXc.png';
             worldCompleteImages[4].src = 'https://i.imgur.com/uoSRiRo.png';
             worldCompleteImages[5].src = 'https://i.imgur.com/PnP5i1q.png';
@@ -1521,7 +1521,7 @@
             worldCompleteImages[8].src = 'https://i.imgur.com/4XIUM5E.png';
 
             levelCompleteImages[1].src = 'https://i.imgur.com/gijG9ec.png';
-            levelCompleteImages[2].src = 'https://i.imgur.com/YKVlhix.png';
+            levelCompleteImages[2].src = 'https://i.imgur.com/aXJoj0F.png';
             levelCompleteImages[3].src = 'https://i.imgur.com/2ZlgclU.png';
             levelCompleteImages[4].src = 'https://i.imgur.com/GniQn3h.png';
             levelCompleteImages[5].src = 'https://i.imgur.com/YtiDSF1.png';
@@ -1530,7 +1530,7 @@
             levelCompleteImages[8].src = 'https://i.imgur.com/7iK51vy.png';
 
             defeatImages[1].src = 'https://i.imgur.com/FZTIteF.png';
-            defeatImages[2].src = 'https://i.imgur.com/3snKeSJ.png';
+            defeatImages[2].src = 'https://i.imgur.com/4DPMHU2.png';
             defeatImages[3].src = 'https://i.imgur.com/Y4kPsNM.png';
             defeatImages[4].src = 'https://i.imgur.com/3FilGNV.png';
             defeatImages[5].src = 'https://i.imgur.com/ADe82lc.png';


### PR DESCRIPTION
## Summary
- update World 2 cover image
- update World 2 victory, level-complete and defeat images

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68431e42c0d88333b63db1dc73937a12