### PR TITLE
Fix zero-lifespan food visibility

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2220,7 +2220,7 @@
                 foodIsVisible = (Math.floor(foodTimeRemaining / blinkInterval) % 2 !== 0);
             }
 
-            if (foodIsVisible && foodTimeRemaining > 0) {
+            if (foodIsVisible && (foodTimeRemaining > 0 || currentFoodItem.initialLifespanForThisFood === 0)) {
                 if (foodImg && foodImg.complete && foodImg.naturalHeight !== 0) {
                     const drawSize = GRID_SIZE * foodData.scale;
                     const offset = (drawSize - GRID_SIZE) / 2;


### PR DESCRIPTION
## Summary
- draw food when its lifespan is zero so it appears in early worlds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6843b9859f748333a9fa349df1919924