### PR TITLE
Improve fake food visuals and add hurt sound

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1530,7 +1530,7 @@
         let isMusicEnabled = true; 
         let areSfxEnabled = true; 
         let synthsInitialized = false; // Flag to track synth initialization
-        let synthEat, synthEatNoise, synthWarning, synthTimeout, synthGameOver, synthStartGame, synthWin; 
+        let synthEat, synthEatNoise, synthBadEat, synthWarning, synthTimeout, synthGameOver, synthStartGame, synthWin;
 
 
         // --- Configuración para la animación de parpadeo del high score ---
@@ -2429,7 +2429,7 @@
             if (img && img.complete && img.naturalHeight !== 0) {
                 const size = GRID_SIZE * foodData.scale;
                 const off = (size - GRID_SIZE) / 2;
-                drawImageWithTint(ctx, img, item.x * GRID_SIZE - off, item.y * GRID_SIZE - off, size, size, 'rgba(255,0,0,0.5)');
+                drawImageWithTint(ctx, img, item.x * GRID_SIZE - off, item.y * GRID_SIZE - off, size, size, 'rgba(255,0,0,0.3)');
             } else {
                 ctx.fillStyle = '#ff0000';
                 ctx.fillRect(item.x * GRID_SIZE + 2, item.y * GRID_SIZE + 2, GRID_SIZE - 4, GRID_SIZE - 4);
@@ -3250,6 +3250,7 @@
                     score = Math.max(0, score - 30);
                     streakMultiplier = 1;
                     removeFalseFoodItem(ff);
+                    if (areSfxEnabled) playSound('badEat');
                 }
             }
             
@@ -3463,11 +3464,13 @@
 
             console.log("Initializing Tone.js Synths...");
             synthEat = new Tone.MonoSynth({ oscillator: { type: 'triangle' }, envelope: { attack: 0.005, decay: 0.04, sustain: 0.01, release: 0.08 }, filterEnvelope: { attack: 0.002, decay: 0.01, sustain: 0, release: 0.02, baseFrequency: 1500, octaves: 1.5, exponent: 2 } }).toDestination();
-            synthEat.volume.value = 0; 
+            synthEat.volume.value = 0;
             synthEatNoise = new Tone.NoiseSynth({ noise: { type: 'white' }, envelope: { attack: 0.001, decay: 0.02, sustain: 0, release: 0.01 } }).toDestination();
-            synthEatNoise.volume.value = -10; 
+            synthEatNoise.volume.value = -10;
+            synthBadEat = new Tone.MonoSynth({ oscillator: { type: 'triangle' }, envelope: { attack: 0.005, decay: 0.1, sustain: 0.01, release: 0.15 }, filterEnvelope: { attack: 0.002, decay: 0.02, sustain: 0, release: 0.05, baseFrequency: 500, octaves: 1.2, exponent: 2 } }).toDestination();
+            synthBadEat.volume.value = 0;
             synthWarning = new Tone.Synth({ oscillator: { type: 'sine' }, envelope: { attack: 0.01, decay: 0.05, sustain: 0, release: 0.1 } }).toDestination();
-            synthWarning.volume.value = 0; 
+            synthWarning.volume.value = 0;
             synthTimeout = new Tone.Synth({ oscillator: { type: 'square' }, envelope: { attack: 0.01, decay: 0.2, sustain: 0, release: 0.1 } }).toDestination();
             synthTimeout.volume.value = 0; 
             synthGameOver = new Tone.Synth({ oscillator: { type: 'triangle' }, envelope: { attack: 0.01, decay: 0.1, sustain: 0.2, release: 0.3 } }).toDestination();
@@ -3703,7 +3706,13 @@
                 if (type === 'eat') {
                     if (synthEat) { const baseNote = "D5"; const targetNote = "A4"; const duration = 0.07; synthEat.triggerAttack(baseNote, now); synthEat.frequency.linearRampToValueAtTime(targetNote, now + duration * 0.7); synthEat.triggerRelease(now + duration); }
                     if (synthEatNoise) { synthEatNoise.triggerAttackRelease("64n", now + 0.005); }
-                } else if (type === 'warning' && synthWarning) { synthWarning.triggerAttackRelease("A4", "32n", now); 
+                } else if (type === 'badEat' && synthBadEat) {
+                    const duration = 0.1;
+                    synthBadEat.triggerAttack("G4", now);
+                    synthBadEat.frequency.linearRampToValueAtTime("C4", now + duration * 0.7);
+                    synthBadEat.triggerRelease(now + duration);
+                    if (synthEatNoise) { synthEatNoise.triggerAttackRelease("64n", now + 0.005); }
+                } else if (type === 'warning' && synthWarning) { synthWarning.triggerAttackRelease("A4", "32n", now);
                 } else if (type === 'timeout' && synthTimeout) { synthTimeout.triggerAttackRelease("F#3", "8n", now);
                 } else if (type === 'gameOver' && synthGameOver) { synthGameOver.triggerAttackRelease("G3", "8n", now); synthGameOver.triggerAttackRelease("E3", "8n", now + 0.15); synthGameOver.triggerAttackRelease("C3", "4n", now + 0.3);
                 } else if (type === 'startGame' && synthStartGame) { synthStartGame.triggerAttackRelease("C4", "16n", now); synthStartGame.triggerAttackRelease("E4", "16n", now + 0.1); synthStartGame.triggerAttackRelease("G4", "8n", now + 0.2); 


### PR DESCRIPTION
## Summary
- reduce opacity of the fake food tint
- trigger new sound when snake eats fake food
- implement `synthBadEat` and add new `badEat` sound handling

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_b_6843effbcc348333a467558ac24b897c