### PR TITLE
Fix mirror effect persistence

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1555,6 +1555,15 @@
         let mirrorSpawnTimeoutId;
         let controlsInverted = false;
         let mirrorEffect = { active: false, startTime: 0 };
+        
+        function updateMirrorEffect() {
+            if (!mirrorEffect.active) return;
+            const elapsed = Date.now() - mirrorEffect.startTime;
+            if (elapsed >= MIRROR_EFFECT_DURATION) {
+                mirrorEffect.active = false;
+                controlsInverted = false;
+            }
+        }
         let speedBoost = { active: false, color: '', change: 0, startTime: 0 };
 
 
@@ -3637,6 +3646,7 @@
        function update() {
             if (gameOver || tileCountX <= 0 || tileCountY <= 0) return;
             updateSpeedBoost();
+            updateMirrorEffect();
 
             direction = nextDirection; // Actualizar la dirección actual con la siguiente dirección almacenada
 
@@ -3675,7 +3685,6 @@
                 clearInterval(foodVisualTimerIntervalId);
                 foodTimeRemaining = 0;
                 generateFood();
-                controlsInverted = false;
 
                 if (gameMode === 'levels') {
                     const absoluteLevelIndex = (currentWorld - 1) * LEVELS_PER_WORLD + (currentLevelInWorld - 1);


### PR DESCRIPTION
## Summary
- keep world 7 mirror effect active until the 3-second timer ends
- don't cancel the effect when eating normal food

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6844b1b58ef48333a6413b86b7834d60