### PR TITLE
Update maze star thresholds

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1356,7 +1356,8 @@
             300, 400, 500, 600, 700,
         ];
 
-        const MAZE_STAR_TARGETS = [100, 300, 500, 800, 1000];
+        // Star thresholds for Maze Mode (puntos objetivo para cada estrella)
+        const MAZE_STAR_TARGETS = [25, 50, 100, 200, 300];
         let mazeStarsEarned = 0;
 
         const MAZE_LEVEL_COUNT = 10;


### PR DESCRIPTION
## Summary
- adjust star targets for Maze Mode so they require 25, 50, 100, 200 and 300 points

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_684560e4ee1c8333a19ccf4b7e55f7b4