### PR TITLE
Fix restart button layout in maze mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -563,7 +563,7 @@
             display: flex;
             gap: 4px;
         }
-        #start-button-wrapper.split #startButton { flex-grow: 3; }
+        #start-button-wrapper.split #startButton { flex-grow: 2; }
         #start-button-wrapper.split #restartMazeButton { flex-grow: 1; }
         #config-button-wrapper {
             flex-grow: 1;


### PR DESCRIPTION
## Summary
- adjust CSS to better distribute start and restart buttons when `restartMazeButton` is visible

## Testing
- `grep -n "start-button-wrapper.split" -n "Snake Github.html" | head`


------
https://chatgpt.com/codex/tasks/task_b_6845d40427e0833397e603462af65739