### PR TITLE
Fix info panel not preserving maze result screen

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2133,18 +2133,22 @@
 
         function openInfoPanel() {
             togglePanel(infoPanel, infoPanelContent, true);
-             if (gameOver && !gameIntervalId) { 
-                if (ctx && canvasEl) { 
-                    ctx.fillStyle = "#374151"; 
+            if (gameOver && !gameIntervalId) {
+                if (ctx && canvasEl) {
+                    ctx.fillStyle = "#374151";
                     ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
                 }
-                score = 0; 
-                streakMultiplier = 1; 
+                score = 0;
+                streakMultiplier = 1;
 
-                if (gameMode === 'levels') {
+                if (gameMode === 'levels' || gameMode === 'maze') {
                     screenState.showCoverForWorld = currentWorld;
                     screenState.gameActuallyStarted = false;
-                } else { // freeMode
+                    screenState.showLevelCompleteCover = 0;
+                    screenState.showWorldCompleteCover = 0;
+                    screenState.showDefeatCoverForWorld = 0;
+                    screenState.showFreeModeCover = false;
+                } else if (gameMode === 'freeMode') {
                     screenState.showFreeModeCover = true;
                     screenState.gameActuallyStarted = false;
                     snake = []; // Vaciar la serpiente


### PR DESCRIPTION
## Summary
- keep maze result image when opening info panel after a game

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_6845dc9f427483338b024f73e3958b5c