### PR TITLE
Fix maze result controls persisting after mode change

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4580,7 +4580,14 @@ async function startGame(isRestart = false) {
         });
         
         gameModeSelector.addEventListener('change', () => {
+            const previousMode = gameMode;
             gameMode = gameModeSelector.value; // Update gameMode first
+
+            if (previousMode === 'maze' && gameMode !== 'maze') {
+                screenState.mazeResultType = '';
+                restartMazeButton.classList.add('hidden');
+                startButtonWrapperEl.classList.remove('split');
+            }
 
             if (gameMode === 'levels') {
                 // Set display variables to current game state for levels mode


### PR DESCRIPTION
## Summary
- reset maze result state when switching away from Maze mode

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6845de11dacc8333a82a0808929cbf5b