### PR TITLE
Fix maze level display reset when switching modes

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4589,6 +4589,8 @@ async function startGame(isRestart = false) {
                 screenState.mazeResultType = '';
                 restartMazeButton.classList.add('hidden');
                 startButtonWrapperEl.classList.remove('split');
+                // Ensure maze level display is synced when leaving maze mode
+                displayMazeLevel = currentMazeLevel;
             }
 
             if (gameMode === 'levels') {
@@ -4627,6 +4629,8 @@ async function startGame(isRestart = false) {
                     ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
                 }
             } else { // maze mode
+                // Sync displayed level with actual progress when entering maze mode
+                displayMazeLevel = currentMazeLevel;
                 displayTargetScore = MAZE_STAR_TARGETS[0];
                 mazeStarsEarned = 0;
 


### PR DESCRIPTION
## Summary
- sync maze level to current progress when leaving maze mode
- ensure maze level shows correctly when re-entering maze mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6845e3bf01008333b252e5fd804c61d6