### PR TITLE
Fix maze level obstacle reset

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4353,11 +4353,11 @@ async function startGame(isRestart = false) {
                 startWorld6LightningMechanics();
                 startWorld7MirrorMechanics();
             } else if (gameMode === 'maze') {
-                startMazeLevel();
                 stopWorld5Obstacles();
                 stopWorld6Obstacles();
                 stopWorld6LightningMechanics();
                 stopWorld7MirrorMechanics();
+                startMazeLevel();
             } else {
                 stopWorld5Obstacles();
                 stopWorld6Obstacles();


### PR DESCRIPTION
## Summary
- ensure maze obstacles aren't cleared when starting maze levels

## Testing
- `npx htmlhint --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6845e61f4ae48333bf34e8fce2abf192