### PR TITLE
Fix maze restart bug

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4155,7 +4155,11 @@ async function startGame(isRestart = false) {
 
     if (gameMode === 'maze') {
         if (isRestart && (screenState.mazeResultType === 'partial' || screenState.mazeResultType === 'perfect')) {
-            displayMazeLevel = currentMazeLevel - 1;
+            if (currentMazeLevel > 1) {
+                currentMazeLevel--;
+                saveGameSettings();
+            }
+            displayMazeLevel = currentMazeLevel;
         } else {
             displayMazeLevel = currentMazeLevel;
         }


### PR DESCRIPTION
## Summary
- keep the maze level consistent when restarting

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_b_6847098b46288333b8d363d2bd197d97