### PR TITLE
Keep same tile count on all devices

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1305,6 +1305,7 @@
         // Configuración del juego
         let GRID_SIZE = 20;
         const TILE_COUNT = 24;
+        const MIN_GRID_SIZE = 10;
         let tileCountX;
         let tileCountY;
         const DEFAULT_INITIAL_SNAKE_LENGTH = 3; // Used for free mode
@@ -1833,22 +1834,18 @@
                 topInfoBar.offsetHeight -
                 setupControls.offsetHeight;
 
-            GRID_SIZE = 20;
-
-            let tileCount = Math.floor(
-                Math.min(availableWidth, availableHeight) / GRID_SIZE
+            GRID_SIZE = Math.floor(
+                Math.min(availableWidth, availableHeight) / TILE_COUNT
             );
-
-            const minTiles = 10;
-            if (tileCount < minTiles) {
-                tileCount = minTiles;
+            if (GRID_SIZE < MIN_GRID_SIZE) {
+                GRID_SIZE = MIN_GRID_SIZE;
             }
 
-            canvasEl.width = tileCount * GRID_SIZE;
-            canvasEl.height = tileCount * GRID_SIZE;
+            canvasEl.width = TILE_COUNT * GRID_SIZE;
+            canvasEl.height = TILE_COUNT * GRID_SIZE;
 
-            tileCountX = tileCount;
-            tileCountY = tileCount;
+            tileCountX = TILE_COUNT;
+            tileCountY = TILE_COUNT;
 
             // If a panel is open, re-calculate its position after resize
             if (!settingsPanel.classList.contains("settings-panel-hidden")) {


### PR DESCRIPTION
## Summary
- ensure tile count stays fixed regardless of screen size by computing `GRID_SIZE`
  from available space while keeping a constant `TILE_COUNT`
- set minimum grid size to avoid tiny tiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68470cce46ec8333807170b8f11595fd