### PR TITLE
Fix maze mode cover not shown after reload

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4928,12 +4928,14 @@ async function startGame(isRestart = false) {
 
             // Set initial display state based on loaded gameMode (already done in loadGameSettings -> updateGameModeUI)
             // but ensure correct cover screen is shown
-            if (gameMode === 'levels') { 
+            if (gameMode === 'levels') {
                 screenState.showCoverForWorld = currentWorld; // currentWorld from loaded settings
             } else if (gameMode === 'freeMode') {
                 screenState.showFreeModeCover = true;
-                 // Ensure gameOver is false if free mode cover is shown before first game
-                if (snake.length === 0) gameOver = false; 
+                // Ensure gameOver is false if free mode cover is shown before first game
+                if (snake.length === 0) gameOver = false;
+            } else if (gameMode === 'maze') {
+                screenState.showMazeCover = true;
             }
             updateGameModeUI(); // Refresh UI based on potentially new screenState
 


### PR DESCRIPTION
## Summary
- when game is in Maze mode and page is reloaded, show maze mode cover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684b3cbd2ca0833397a0382dd330018f