### PR TITLE
Update maze selector to show all levels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4201,10 +4201,11 @@
 
         function populateMazeLevelSelector() {
             mazeLevelSelector.innerHTML = '';
-            for (let i = 1; i <= currentMazeLevel; i++) {
+            for (let i = 1; i <= MAZE_LEVEL_COUNT; i++) {
                 const option = document.createElement('option');
                 option.value = i;
                 option.textContent = `Nivel ${i}`;
+                option.disabled = i > currentMazeLevel;
                 if (i === currentMazeLevel) {
                     option.selected = true;
                 }


### PR DESCRIPTION
## Summary
- show all maze levels in the settings screen and disable those not yet unlocked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c9454e22c83338c169a86f3ef50ab