### PR TITLE
Fix Maze level selection

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4206,7 +4206,7 @@
                 option.value = i;
                 option.textContent = `Nivel ${i}`;
                 option.disabled = i > currentMazeLevel;
-                if (i === currentMazeLevel) {
+                if (i === displayMazeLevel) {
                     option.selected = true;
                 }
                 mazeLevelSelector.appendChild(option);
@@ -4310,12 +4310,8 @@ async function startGame(isRestart = false) {
 
     if (gameMode === 'maze') {
         if (isRestart && (screenState.mazeResultType === 'partial' || screenState.mazeResultType === 'perfect')) {
-            if (currentMazeLevel > 1) {
-                currentMazeLevel--;
-                saveGameSettings();
-            }
-            displayMazeLevel = currentMazeLevel;
-        } else {
+            displayMazeLevel = Math.max(1, currentMazeLevel - 1);
+        } else if (screenState.mazeResultType === 'partial' || screenState.mazeResultType === 'perfect') {
             displayMazeLevel = currentMazeLevel;
         }
     }
@@ -4390,7 +4386,7 @@ async function startGame(isRestart = false) {
                     console.warn("Attempting to start a level beyond defined targets. Using last target score.");
                 }
             } else if (gameMode === 'maze') {
-                mazeStarsEarned = mazeLevelStars[currentMazeLevel - 1] || 0;
+                mazeStarsEarned = mazeLevelStars[displayMazeLevel - 1] || 0;
                 if (mazeStarsEarned < MAZE_STAR_TARGETS.length) {
                     displayTargetScore = MAZE_STAR_TARGETS[mazeStarsEarned];
                 } else {
@@ -4751,9 +4747,8 @@ async function startGame(isRestart = false) {
                     return;
                 }
 
-                currentMazeLevel = newLevel;
-                displayMazeLevel = currentMazeLevel;
-                mazeStarsEarned = mazeLevelStars[currentMazeLevel - 1] || 0;
+                displayMazeLevel = newLevel;
+                mazeStarsEarned = mazeLevelStars[newLevel - 1] || 0;
                 if (mazeStarsEarned < MAZE_STAR_TARGETS.length) {
                     displayTargetScore = MAZE_STAR_TARGETS[mazeStarsEarned];
                 } else {
@@ -4829,7 +4824,7 @@ async function startGame(isRestart = false) {
             } else { // maze mode
                 // Sync displayed level with actual progress when entering maze mode
                 displayMazeLevel = currentMazeLevel;
-                mazeStarsEarned = mazeLevelStars[currentMazeLevel - 1] || 0;
+                mazeStarsEarned = mazeLevelStars[displayMazeLevel - 1] || 0;
                 if (mazeStarsEarned < MAZE_STAR_TARGETS.length) {
                     displayTargetScore = MAZE_STAR_TARGETS[mazeStarsEarned];
                 } else {
@@ -5018,7 +5013,7 @@ async function startGame(isRestart = false) {
                     displayTargetScore = TARGET_SCORES_LEVELS[TARGET_SCORES_LEVELS.length -1];
                 }
             } else if (gameMode === 'maze') {
-                mazeStarsEarned = mazeLevelStars[currentMazeLevel - 1] || 0;
+                mazeStarsEarned = mazeLevelStars[displayMazeLevel - 1] || 0;
                 if (mazeStarsEarned < MAZE_STAR_TARGETS.length) {
                     displayTargetScore = MAZE_STAR_TARGETS[mazeStarsEarned];
                 } else {


### PR DESCRIPTION
## Summary
- keep unlocked maze stages selectable when replaying earlier stages
- ensure star display and target score use the selected level

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c97124f5883338a0b8ddea96b8550