### PR TITLE
Mostrar estrellas en la lista de niveles del laberinto

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4204,7 +4204,9 @@
             for (let i = 1; i <= MAZE_LEVEL_COUNT; i++) {
                 const option = document.createElement('option');
                 option.value = i;
-                option.textContent = `Nivel ${i}`;
+                const starsEarned = mazeLevelStars[i - 1] || 0;
+                const starSymbols = '★'.repeat(starsEarned) + '☆'.repeat(MAZE_STAR_TARGETS.length - starsEarned);
+                option.textContent = `Nivel ${i} ${starSymbols}`;
                 option.disabled = i > currentMazeLevel;
                 if (i === displayMazeLevel) {
                     option.selected = true;


### PR DESCRIPTION
## Summary
- incluir estrellas obtenidas en las opciones del selector de nivel de Modo Laberinto

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684c98df6db48333920b429907cd737c