### PR TITLE
Improve visibility of streak text

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1765,9 +1765,9 @@
             ctx.fillStyle = streakAnimation.color;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'bottom';
-            ctx.font = `${Math.floor(GRID_SIZE * 0.8)}px 'Press Start 2P'`;
+            ctx.font = `${Math.floor(GRID_SIZE * 0.7)}px 'Press Start 2P'`;
             const x = head.x * GRID_SIZE + GRID_SIZE / 2;
-            const y = head.y * GRID_SIZE - 2;
+            const y = head.y * GRID_SIZE - 6;
             ctx.fillText(streakAnimation.value, x, y);
             ctx.restore();
         }


### PR DESCRIPTION
## Summary
- shrink the streak font a bit
- add more padding above the snake head so streak text isn't too close

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684d313b9b948333aa62f87125e81b50