### PR TITLE
Implement persistent coin counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Open `Snake Github.html` directly in your favorite web browser. You can either d
 - **Skins** – Change the appearance of your snake with different skins.
 - **Audio** – Toggle music and sound effects, and adjust volume.
 - **Maze Stars** – Each maze level tracks the stars you've earned so you can work toward a perfect 5-star score over multiple attempts.
+- **Coins** – Earn coins at the end of every game. Your total coins accumulate across all game modes and sessions.
 
 ## Local Storage & Dependencies
 

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1601,7 +1601,8 @@
         let snake = []; 
         let direction = "right"; 
         let nextDirection = "right"; // Buffer para la siguiente dirección (MANTENIDO DE LA VERSIÓN ANTERIOR)
-        let score = 0; 
+        let score = 0;
+        let totalCoins = 0;
         let gameOver = false; 
         let gameIntervalId; 
         let gameTimeRemaining; 
@@ -2021,7 +2022,7 @@
         }
 
         function resetGameUIDisplays() {
-            coinValueDisplay.textContent = "0";
+            updateCoinDisplay();
             scoreValueDisplay.textContent = "0";
             if (gameMode === 'levels' || gameMode === 'maze') {
                 timeLengthValueEl.textContent = Math.ceil(LEVEL_TIME_LIMIT / 1000);
@@ -3377,8 +3378,14 @@
 
             playSoundForGameOver(levelEffectivelyWon);
             draw(); 
-            managePostGameOverMusicAndAnimation(); 
-            updateUIOnGameOver(); 
+            managePostGameOverMusicAndAnimation();
+
+            const earnedCoins = Math.floor(score / POINTS_PER_COIN);
+            totalCoins += earnedCoins;
+            updateCoinDisplay();
+            localStorage.setItem('snakeGameCoins', totalCoins.toString());
+
+            updateUIOnGameOver();
 
             if (gameMode === 'levels' || gameMode === 'maze') {
                 saveGameSettings(); // Guardamos el estado actualizado (nivel/mundo avanzado)
@@ -4086,9 +4093,11 @@
         }
         
         function updateScoreDisplay() {
-            const coins = Math.floor(score / POINTS_PER_COIN);
-            coinValueDisplay.textContent = coins;
             scoreValueDisplay.textContent = score;
+        }
+
+        function updateCoinDisplay() {
+            coinValueDisplay.textContent = totalCoins;
         }
 
         function updateTargetScoreDisplay() {
@@ -5008,6 +5017,9 @@ async function startGame(isRestart = false) {
                 musicVolumeSlider.value = 50;
             }
             if (musicVolumeValue) musicVolumeValue.textContent = musicVolumeSlider.value;
+
+            const savedCoins = parseInt(localStorage.getItem('snakeGameCoins'), 10);
+            totalCoins = Number.isFinite(savedCoins) && savedCoins >= 0 ? savedCoins : 0;
             
             const savedGameMode = localStorage.getItem('snakeGameMode');
             if (savedGameMode && (savedGameMode === 'levels' || savedGameMode === 'freeMode' || savedGameMode === 'maze')) {
@@ -5099,6 +5111,7 @@ async function startGame(isRestart = false) {
 
             console.log("Configuraciones cargadas de localStorage y aplicadas a selectores.");
             updateGameModeUI(); // This will use the newly set display variables
+            updateCoinDisplay();
         }
 
 


### PR DESCRIPTION
## Summary
- track total coins across games
- load and display the stored coin total
- award coins only after a game ends
- document the new coin feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d3733f0d083339199f1e8a84dfa8e