### PR TITLE
Update world cover images

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1787,19 +1787,19 @@
         
         // --- Funciones de Carga y Aplicación de Jugadores ---
         function loadWorldImages() {
-            worldCoverImages[1].src = 'https://i.imgur.com/h7iNXJT.png';
-            worldCoverImages[2].src = 'https://i.imgur.com/Y76HoJR.png';
-            worldCoverImages[3].src = 'https://i.imgur.com/Iv2Pzet.png';
-            worldCoverImages[4].src = 'https://i.imgur.com/X6KtQtD.png';
-            worldCoverImages[5].src = 'https://i.imgur.com/LYCR9nT.png';
-            worldCoverImages[6].src = 'https://i.imgur.com/t07LsqT.png';
-            worldCoverImages[2].src = 'https://i.imgur.com/Y76HoJR.png';
-            worldCoverImages[3].src = 'https://i.imgur.com/Iv2Pzet.png';
-            worldCoverImages[4].src = 'https://i.imgur.com/X6KtQtD.png';
-            worldCoverImages[5].src = 'https://i.imgur.com/LYCR9nT.png';
-            worldCoverImages[6].src = 'https://i.imgur.com/t07LsqT.png';
-            worldCoverImages[7].src = 'https://i.imgur.com/j27VS0G.png';
-            worldCoverImages[8].src = 'https://i.imgur.com/JYjHEgy.png';
+            worldCoverImages[1].src = 'https://i.imgur.com/XuoZro6.png';
+            worldCoverImages[2].src = 'https://i.imgur.com/RUDshhv.png';
+            worldCoverImages[3].src = 'https://i.imgur.com/3bpQJ2c.png';
+            worldCoverImages[4].src = 'https://i.imgur.com/vEqjfil.png';
+            worldCoverImages[5].src = 'https://i.imgur.com/e1PtokJ.png';
+            worldCoverImages[6].src = 'https://i.imgur.com/fMBXP4Z.png';
+            worldCoverImages[2].src = 'https://i.imgur.com/RUDshhv.png';
+            worldCoverImages[3].src = 'https://i.imgur.com/3bpQJ2c.png';
+            worldCoverImages[4].src = 'https://i.imgur.com/vEqjfil.png';
+            worldCoverImages[5].src = 'https://i.imgur.com/e1PtokJ.png';
+            worldCoverImages[6].src = 'https://i.imgur.com/fMBXP4Z.png';
+            worldCoverImages[7].src = 'https://i.imgur.com/DNGzDhl.png';
+            worldCoverImages[8].src = 'https://i.imgur.com/g3uQW4f.png';
 
             worldCompleteImages[1].src = 'https://i.imgur.com/nkdJEmV.png';
             worldCompleteImages[2].src = 'https://i.imgur.com/RpIGI2q.png';


### PR DESCRIPTION
## Summary
- update world cover image URLs in `Snake Github.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684e8024a93c83339b48a3cb0c2e3695