### PR TITLE
Fix mode selection overlay

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -281,14 +281,55 @@
 
 
         canvas {
-            background-color: #374151; 
-            border: 4px solid #4b5563; 
-            display: block; 
-            margin: 0 auto 5px auto; 
-            max-width: 100%; 
-            border-radius: 8px; 
-            aspect-ratio: 1 / 1; 
+            background-color: #374151;
+            border: 4px solid #4b5563;
+            display: block;
+            margin: 0 auto 5px auto;
+            max-width: 100%;
+            border-radius: 8px;
+            aspect-ratio: 1 / 1;
         }
+
+        #play-area {
+            position: relative;
+        }
+
+        #game-canvas-wrapper {
+            position: relative;
+            display: inline-block;
+            overflow: hidden;
+        }
+
+        #mode-selection-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            z-index: 50;
+            pointer-events: none;
+        }
+
+        #mode-selection-overlay img {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+            pointer-events: none;
+        }
+
+        .mode-nav-button {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            padding: 0;
+            pointer-events: auto;
+        }
+
+        #mode-left-button { left: 0; }
+        #mode-right-button { right: 0; }
 
         #mobile-controls {
             display: flex;
@@ -371,9 +412,15 @@
         .control-button:hover { background-color: #4a5568; }
         
         .arrow-svg {
-            width: 60%; 
+            width: 60%;
             height: 60%;
-            fill: currentColor; 
+            fill: currentColor;
+        }
+
+        #mode-left-button,
+        #mode-right-button {
+            width: 40px;
+            height: 100%;
         }
         
         #setup-controls {
@@ -947,9 +994,21 @@
             </div>
         </div>
         
-        <canvas id="gameCanvas"></canvas>
+        <div id="game-canvas-wrapper">
+            <canvas id="gameCanvas"></canvas>
 
-        <div id="setup-controls"> 
+            <div id="mode-selection-overlay" class="hidden">
+                <button id="mode-left-button" class="control-button mode-nav-button" aria-label="Anterior">
+                    <svg class="arrow-svg" viewBox="0 0 24 24"><path d="M15.41 7.41L10.83 12l4.58 4.59L14 18l-6-6 6-6z"/></svg>
+                </button>
+                <img id="mode-selection-image" src="https://i.imgur.com/W34ctvU.png" alt="Selección de modo" />
+                <button id="mode-right-button" class="control-button mode-nav-button" aria-label="Siguiente">
+                    <svg class="arrow-svg" viewBox="0 0 24 24"><path d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"/></svg>
+                </button>
+            </div>
+        </div>
+
+        <div id="setup-controls">
             <div id="settings-panel" class="settings-panel-hidden">
                 <div class="settings-header">
                     <h2>Configuración</h2>
@@ -1222,6 +1281,47 @@
         const specificInfoTitle = document.getElementById("specific-info-title");
         const specificInfoContent = document.getElementById("specific-info-content");
         const closeSpecificInfoButton = document.getElementById("close-specific-info-button");
+
+        const modeOverlay = document.getElementById("mode-selection-overlay");
+        const modeImageEl = document.getElementById("mode-selection-image");
+        const modeLeftButton = document.getElementById("mode-left-button");
+        const modeRightButton = document.getElementById("mode-right-button");
+
+        const modeSelectionImages = [
+            'https://i.imgur.com/W34ctvU.png',
+            'https://i.imgur.com/1Dp5GTu.png',
+            'https://i.imgur.com/WY3lrHv.png',
+            'https://i.imgur.com/6cMWnrC.png'
+        ];
+        const modeSelectionMap = [null, 'levels', 'maze', 'freeMode'];
+        let modeSelectionIndex = 0;
+        let isModeSelectionActive = false;
+
+        function updateModeSelectionDisplay() {
+            if (modeImageEl) modeImageEl.src = modeSelectionImages[modeSelectionIndex];
+            if (startButton) startButton.disabled = modeSelectionIndex === 0;
+        }
+
+        function openModeSelection() {
+            if (!modeOverlay) return;
+            isModeSelectionActive = true;
+            modeSelectionIndex = 0;
+            modeOverlay.classList.remove('hidden');
+            startButton.textContent = 'Seleccionar';
+            updateModeSelectionDisplay();
+        }
+
+        if (modeLeftButton && modeRightButton) {
+            modeLeftButton.addEventListener('click', () => {
+                modeSelectionIndex = (modeSelectionIndex - 1 + modeSelectionImages.length) % modeSelectionImages.length;
+                updateModeSelectionDisplay();
+            });
+            modeRightButton.addEventListener('click', () => {
+                modeSelectionIndex = (modeSelectionIndex + 1) % modeSelectionImages.length;
+                updateModeSelectionDisplay();
+            });
+        }
+
 
 
         // --- INICIO: Declaración de Objetos Image ---
@@ -5048,7 +5148,20 @@ async function startGame(isRestart = false) {
         rightButton.addEventListener("click", () => changeDirection("right"));
 
 
-        startButton.addEventListener("click", () => startGame(false));
+        startButton.addEventListener("click", () => {
+            if (isModeSelectionActive) {
+                if (modeSelectionIndex === 0) return;
+                gameModeSelector.value = modeSelectionMap[modeSelectionIndex];
+                updateGameModeUI();
+                saveGameSettings();
+                modeOverlay.classList.add('hidden');
+                isModeSelectionActive = false;
+                startButton.textContent = 'Empezar';
+                initializeGameLogic();
+                return;
+            }
+            startGame(false);
+        });
         restartMazeButton.addEventListener("click", () => startGame(true));
         
         window.addEventListener('resize', resizeGameElements); 
@@ -5344,7 +5457,7 @@ async function startGame(isRestart = false) {
 
                         if (splashScreen) splashScreen.classList.add('hidden');
                         if (gameContainer) gameContainer.classList.remove('hidden');
-                        initializeGameLogic(); // This will handle playing HTML5 audio if enabled
+                        openModeSelection();
                     } catch (error) {
                         console.error("Error within splash start button click handler:", error);
                     }
@@ -5353,7 +5466,7 @@ async function startGame(isRestart = false) {
                 console.error("Botón de inicio del splash no encontrado!");
                 if (splashScreen) splashScreen.classList.add('hidden');
                 if (gameContainer) gameContainer.classList.remove('hidden');
-                initializeGameLogic();
+                openModeSelection();
             }
         };
     </script>


### PR DESCRIPTION
## Summary
- scope mode selection overlay to the canvas so images and arrows fit inside the play area
- update game mode UI when confirming a selection

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685b7c732d248333842d4adf19013dfd