### PR TITLE
Update free mode selection cover image

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1945,7 +1945,7 @@
         function loadModeSelectionImages() {
             modeSelectIntroImg.src = 'https://i.imgur.com/W34ctvU.png';
             modeSelectLevelsImg.src = 'https://i.imgur.com/1Dp5GTu.png';
-            modeSelectFreeImg.src = 'https://i.imgur.com/6cMWnrC.png';
+            modeSelectFreeImg.src = 'https://i.imgur.com/IIc2Xb7.png';
             modeSelectMazeImg.src = 'https://i.imgur.com/WY3lrHv.png';
 
             [modeSelectIntroImg, modeSelectLevelsImg, modeSelectFreeImg, modeSelectMazeImg].forEach(img => {


### PR DESCRIPTION
## Summary
- use the same cover image for Free Mode in both the mode selection screen and the actual mode

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685b896775d08333bf3d366cc08ab131