### PR TITLE
Improve mode switch sound

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1835,6 +1835,7 @@
         let synthsInitialized = false; // Flag to track synth initialization
         let synthEat, synthEatNoise, synthBadEat, synthWarning, synthTimeout, synthGameOver, synthStartGame, synthWin, synthCoinNoise, synthCoinChime;
         let synthModeSwitch, synthModeSelect;
+        let modeSwitchFilter;
 
 
         // --- Configuración para la animación de parpadeo del high score ---
@@ -4665,7 +4666,8 @@
             synthCoinNoise.volume.value = -8;
             synthCoinChime = new Tone.Synth({ oscillator: { type: 'triangle' }, envelope: { attack: 0.01, decay: 0.1, sustain: 0, release: 0.1 } }).toDestination();
             synthCoinChime.volume.value = -2;
-            synthModeSwitch = new Tone.NoiseSynth({ noise: { type: 'white' }, envelope: { attack: 0.005, decay: 0.1, sustain: 0, release: 0.1 } }).toDestination();
+            modeSwitchFilter = new Tone.Filter({ type: "highpass", frequency: 200 }).toDestination();
+            synthModeSwitch = new Tone.NoiseSynth({ noise: { type: "white" }, envelope: { attack: 0.01, decay: 0.3, sustain: 0, release: 0.2 } }).connect(modeSwitchFilter);
             synthModeSwitch.volume.value = -5;
             synthModeSelect = new Tone.NoiseSynth({ noise: { type: 'white' }, envelope: { attack: 0.005, decay: 0.2, sustain: 0, release: 0.2 } }).toDestination();
             synthModeSelect.volume.value = -3;
@@ -4995,6 +4997,8 @@ async function startGame(isRestart = false) {
                     synthCoinNoise.triggerAttackRelease(duration, now);
                     synthCoinChime.triggerAttackRelease("C6", "16n", now + Math.max(0, duration - 0.1));
                 } else if (type === 'modeSwitch' && synthModeSwitch) {
+                    modeSwitchFilter.frequency.setValueAtTime(200, now);
+                    modeSwitchFilter.frequency.linearRampToValueAtTime(1000, now + 0.15);
                     synthModeSwitch.triggerAttackRelease(0.15, now);
                 } else if (type === 'modeSelect' && synthModeSelect) {
                     synthModeSelect.triggerAttackRelease(0.25, now);


### PR DESCRIPTION
## Summary
- add dedicated filter for mode switch effect
- sweep filter to create a whoosh sound when selecting game mode

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_685ba89853d483338e70596da14ecc8c