### PR TITLE
Add cube rotation effect on game selection

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -910,6 +910,22 @@
                 padding-bottom: 20px;
             }
         }
+
+        /* Efecto de rotación para la selección de juego */
+        #game-mode-control-group {
+            perspective: 600px;
+        }
+
+        #gameModeSelector.cube-rotate {
+            animation: cubeRotate 0.6s ease-in-out;
+            transform-style: preserve-3d;
+        }
+
+        @keyframes cubeRotate {
+            0% { transform: rotateY(0deg); }
+            50% { transform: rotateY(90deg); }
+            100% { transform: rotateY(0deg); }
+        }
     </style>
 </head>
 <body>
@@ -5172,6 +5188,8 @@ async function startGame(isRestart = false) {
         });
         
         gameModeSelector.addEventListener('change', () => {
+            gameModeSelector.classList.add('cube-rotate');
+            setTimeout(() => { gameModeSelector.classList.remove('cube-rotate'); }, 600);
             const previousMode = gameMode;
             gameMode = gameModeSelector.value; // Update gameMode first
 


### PR DESCRIPTION
## Summary
- enable 3D cube transition when changing game mode in *Snake Github.html*

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685bab1d2b908333816cdfc65016c1c6