### PR TITLE
Add mode carousel animation

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1743,6 +1743,10 @@
         let modeSelectIndex = 0;
         const MODE_SELECT_ORDER = ['intro', 'levels', 'freeMode', 'classification', 'maze'];
         let showModeSelect = false;
+        const MODE_TRANSITION_DURATION = 300; // ms
+        let modeTransitionStart = null;
+        let modeTransitionDir = 0;
+        let modeTransitionFrom = 0;
 
         const DIFFICULTY_SETTINGS = {
             easy: { speed: 200, initialLifespan: 11000 }, 
@@ -3775,23 +3779,47 @@
             }
         }
 
+        function getModeImage(mode) {
+            if (mode === 'intro') return modeSelectIntroImg;
+            if (mode === 'levels') return modeSelectLevelsImg;
+            if (mode === 'freeMode') return modeSelectFreeImg;
+            if (mode === 'classification') return modeSelectClassificationImg;
+            return modeSelectMazeImg;
+        }
+
         function drawModeSelection() {
             modeLeftButton.classList.remove('hidden');
             modeRightButton.classList.remove('hidden');
-            let img;
-            const mode = MODE_SELECT_ORDER[modeSelectIndex];
-            if (mode === 'intro') img = modeSelectIntroImg;
-            else if (mode === 'levels') img = modeSelectLevelsImg;
-            else if (mode === 'freeMode') img = modeSelectFreeImg;
-            else if (mode === 'classification') img = modeSelectClassificationImg;
-            else img = modeSelectMazeImg;
-            if (img && img.complete && img.naturalHeight !== 0) {
-                ctx.drawImage(img, 0, 0, canvasEl.width, canvasEl.height);
+
+            const now = performance.now();
+            let progress = 1;
+            if (modeTransitionStart !== null) {
+                progress = Math.min((now - modeTransitionStart) / MODE_TRANSITION_DURATION, 1);
+            }
+
+            const fromImg = getModeImage(MODE_SELECT_ORDER[modeTransitionStart !== null ? modeTransitionFrom : modeSelectIndex]);
+            const toImg = getModeImage(MODE_SELECT_ORDER[modeSelectIndex]);
+
+            if (modeTransitionStart !== null && progress < 1) {
+                const offset = canvasEl.width * progress;
+                const dir = modeTransitionDir;
+                if (fromImg && fromImg.complete && fromImg.naturalHeight !== 0) {
+                    ctx.drawImage(fromImg, -dir * offset, 0, canvasEl.width, canvasEl.height);
+                }
+                if (toImg && toImg.complete && toImg.naturalHeight !== 0) {
+                    ctx.drawImage(toImg, canvasEl.width * dir - dir * offset, 0, canvasEl.width, canvasEl.height);
+                }
+                requestAnimationFrame(draw);
             } else {
-                ctx.fillStyle = 'white';
-                ctx.textAlign = 'center';
-                ctx.font = `${Math.floor(canvasEl.width / 15)}px 'Press Start 2P'`;
-                ctx.fillText('Selecciona modo', canvasEl.width / 2, canvasEl.height / 2);
+                modeTransitionStart = null;
+                if (toImg && toImg.complete && toImg.naturalHeight !== 0) {
+                    ctx.drawImage(toImg, 0, 0, canvasEl.width, canvasEl.height);
+                } else {
+                    ctx.fillStyle = 'white';
+                    ctx.textAlign = 'center';
+                    ctx.font = `${Math.floor(canvasEl.width / 15)}px 'Press Start 2P'`;
+                    ctx.fillText('Selecciona modo', canvasEl.width / 2, canvasEl.height / 2);
+                }
             }
         }
 
@@ -5278,6 +5306,7 @@ async function startGame(isRestart = false) {
                 gameModeSelector.value = selectedMode;
                 gameMode = selectedMode;
                 showModeSelect = false;
+                modeTransitionStart = null;
 
                 screenState.showCoverForWorld = 0;
                 screenState.showLevelCompleteCover = 0;
@@ -5376,14 +5405,21 @@ async function startGame(isRestart = false) {
         leftButton.addEventListener("click", () => changeDirection("left"));
         rightButton.addEventListener("click", () => changeDirection("right"));
 
-        modeLeftButton.addEventListener("click", () => {
-            modeSelectIndex = (modeSelectIndex - 1 + MODE_SELECT_ORDER.length) % MODE_SELECT_ORDER.length;
+        function startModeTransition(dir) {
+            if (modeTransitionStart !== null) return;
+            modeTransitionDir = dir;
+            modeTransitionFrom = modeSelectIndex;
+            modeSelectIndex = (modeSelectIndex + dir + MODE_SELECT_ORDER.length) % MODE_SELECT_ORDER.length;
+            modeTransitionStart = performance.now();
             draw();
+        }
+
+        modeLeftButton.addEventListener("click", () => {
+            startModeTransition(-1);
             if (areSfxEnabled) playSound('modeSwitch');
         });
         modeRightButton.addEventListener("click", () => {
-            modeSelectIndex = (modeSelectIndex + 1) % MODE_SELECT_ORDER.length;
-            draw();
+            startModeTransition(1);
             if (areSfxEnabled) playSound('modeSwitch');
         });
 
@@ -5692,6 +5728,7 @@ async function startGame(isRestart = false) {
                         if (gameContainer) gameContainer.classList.remove('hidden');
                         modeSelectIndex = 0;
                         showModeSelect = true;
+                        modeTransitionStart = null;
                         screenState.showCoverForWorld = 0;
                         screenState.showLevelCompleteCover = 0;
                         screenState.showWorldCompleteCover = 0;


### PR DESCRIPTION
## Summary
- add animation state variables for the mode selector
- implement slide transition when switching between game modes
- reset animation state when leaving or entering mode selection

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685baebf53e08333816376d75de28a42