### PR TITLE
Remove intro slide after mode change

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1743,6 +1743,7 @@
         let modeSelectIndex = 0;
         const MODE_SELECT_ORDER = ['intro', 'levels', 'freeMode', 'classification', 'maze'];
         let showModeSelect = false;
+        let introOptionAvailable = true; // controls visibility of the intro slide
         const MODE_TRANSITION_DURATION = 300; // ms
         let modeTransitionStart = null;
         let modeTransitionDir = 0;
@@ -5301,6 +5302,7 @@ async function startGame(isRestart = false) {
         function handleStartClick() {
             if (showModeSelect) {
                 if (MODE_SELECT_ORDER[modeSelectIndex] === 'intro') return;
+                introOptionAvailable = false; // remove intro option after selecting a mode
                 if (areSfxEnabled) playSound('modeSelect');
                 const selectedMode = MODE_SELECT_ORDER[modeSelectIndex];
                 gameModeSelector.value = selectedMode;
@@ -5409,7 +5411,14 @@ async function startGame(isRestart = false) {
             if (modeTransitionStart !== null) return;
             modeTransitionDir = dir;
             modeTransitionFrom = modeSelectIndex;
-            modeSelectIndex = (modeSelectIndex + dir + MODE_SELECT_ORDER.length) % MODE_SELECT_ORDER.length;
+
+            do {
+                modeSelectIndex = (modeSelectIndex + dir + MODE_SELECT_ORDER.length) % MODE_SELECT_ORDER.length;
+                if (introOptionAvailable && MODE_SELECT_ORDER[modeSelectIndex] !== 'intro') {
+                    introOptionAvailable = false; // once user moves away from intro, remove it
+                }
+            } while (!introOptionAvailable && MODE_SELECT_ORDER[modeSelectIndex] === 'intro');
+
             modeTransitionStart = performance.now();
             draw();
         }
@@ -5728,6 +5737,7 @@ async function startGame(isRestart = false) {
                         if (gameContainer) gameContainer.classList.remove('hidden');
                         modeSelectIndex = 0;
                         showModeSelect = true;
+                        introOptionAvailable = true; // reset intro visibility on fresh start
                         modeTransitionStart = null;
                         screenState.showCoverForWorld = 0;
                         screenState.showLevelCompleteCover = 0;


### PR DESCRIPTION
## Summary
- add session flag to manage intro slide visibility
- skip the intro slide after the player selects another mode
- restore intro slide when game starts again from splash screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685bb34a29748333a375bb702c0246e4