### PR TITLE
Fix labyrinth music URL

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1390,7 +1390,7 @@
         };
 
         const MODE_MUSIC_URLS = {
-            maze: 'https://raw.githubusercontent.com/GamificAitor/JuegosEducativos/4d5668697896de0068c5e942daf03042543721b5/Serpiente%20de%20Ne%C3%B3n%20-%20Laberinto.mp3',
+            maze: 'https://raw.githubusercontent.com/GamificAitor/JuegosEducativos/b9120ef7b4b0c7e0d2e9eb9b268a387c60fac871/Modo%20Laberinto.mp3',
             freeMode: 'https://raw.githubusercontent.com/GamificAitor/JuegosEducativos/bc07b0e83b7df448cb82a9a6b8a5ae4196d06758/Modo%20libre%20-%20Serpiente%20de%20Ne%C3%B3n.mp3',
             classification: 'https://raw.githubusercontent.com/GamificAitor/JuegosEducativos/ecfea23c17b11d743d5bade6b5ef8e025ea1fff6/Modo%20clasificaci%C3%B3n%20-%20Serpiente%20de%20Ne%C3%B3n.mp3'
         };


### PR DESCRIPTION
## Summary
- update the maze mode music track URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685bdb795cd08333b8a49a0e5ac24c0b