### PR TITLE
Fix maze victory after timeout

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3416,7 +3416,7 @@
 
             const levelIndex = displayMazeLevel - 1;
             const previousStars = mazePreviousStars;
-            const improved = mazeStarsEarned > previousStars && timeRemaining > 0;
+            const improved = mazeStarsEarned > previousStars;
 
             if (improved && mazeStarsEarned >= MAZE_STAR_TARGETS.length) {
                 levelWon = true;


### PR DESCRIPTION
## Summary
- show victory screens in Maze mode even if the timer runs out

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685c0b6f87748333a247a9c8570e48ff