### PR TITLE
Add 'time is up' screen

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1296,6 +1296,7 @@
         const mazePerfectImg = new Image();
         const mazeCompleteImg = new Image();
         const mazeAllStarsImg = new Image();
+        const timeoutImg = new Image();
 
         const worldCoverImages = {
             1: new Image(),
@@ -1367,7 +1368,7 @@
         };
 
         let worldImagesLoaded = 0;
-        const totalWorldImagesToLoad = Object.keys(worldImagesConfig).length * 4 + 8;
+        const totalWorldImagesToLoad = Object.keys(worldImagesConfig).length * 4 + 9;
         // --- FIN: Declaración de Objetos Image ---
 
         // --- Música de fondo y SFX ---
@@ -1726,8 +1727,9 @@
         let nextDirection = "right"; // Buffer para la siguiente dirección (MANTENIDO DE LA VERSIÓN ANTERIOR)
         let score = 0;
         let totalCoins = 0;
-        let gameOver = false; 
-        let gameIntervalId; 
+        let gameOver = false;
+        let gameOverByTimeout = false;
+        let gameIntervalId;
         let gameTimeRemaining; 
         let gameTimerIntervalId; 
         let gameMode = 'levels'; // Default to levels
@@ -1754,6 +1756,7 @@
             showLevelCompleteCover: 0,
             showWorldCompleteCover: 0,
             showDefeatCoverForWorld: 0,
+            showTimeoutCover: false,
             showFreeModeCover: false,
             showClassificationCover: false,
             showMazeCover: false,
@@ -1930,6 +1933,7 @@
             mazePerfectImg.src = 'https://i.imgur.com/YKVlhix.png';
             mazeCompleteImg.src = 'https://i.imgur.com/0s9b6JB.png';
             mazeAllStarsImg.src = 'https://i.imgur.com/grMD2kr.png';
+            timeoutImg.src = 'https://i.imgur.com/uEjzFbY.png';
 
 
             const allWorldImages = [
@@ -1939,7 +1943,7 @@
                 ...Object.values(defeatImages),
                 freeModeCoverImg, classificationModeCoverImg, mazeModeCoverImg,
                 mazeFailImg, mazePartialImg, mazePerfectImg, mazeCompleteImg,
-                mazeAllStarsImg
+                mazeAllStarsImg, timeoutImg
             ];
 
             allWorldImages.forEach(img => {
@@ -2204,6 +2208,7 @@
                 const isWorldCompleteScreen = screenState.showWorldCompleteCover > 0;
                 const isLevelCompleteScreen = screenState.showLevelCompleteCover > 0 && !screenState.gameActuallyStarted;
                 const isDefeatScreen = screenState.showDefeatCoverForWorld > 0 && !screenState.gameActuallyStarted;
+                const isTimeoutScreen = screenState.showTimeoutCover && !screenState.gameActuallyStarted;
                 const isFreeModeCoverActive = screenState.showFreeModeCover && !screenState.gameActuallyStarted;
                 const isClassificationCoverActive = screenState.showClassificationCover && !screenState.gameActuallyStarted;
                 const isMazeCoverActive = screenState.showMazeCover && !screenState.gameActuallyStarted;
@@ -2222,7 +2227,7 @@
                     // Text is set by handleLevelsModeEnd
                 } else if (isWorldCompleteScreen) {
                     // Text is set by handleLevelsModeEnd
-                } else if (isDefeatScreen) {
+                } else if (isDefeatScreen || isTimeoutScreen) {
                     startButton.textContent = "Reintentar";
                 } else if (isMazeResultScreen) {
                     // Text already set by handleMazeModeEnd
@@ -2240,7 +2245,7 @@
                     startButton.textContent = "Empezar";
                 }
                 
-                const isAnyCoverScreenActive = isWorldIntroCover || isWorldCompleteScreen || isLevelCompleteScreen || isDefeatScreen || isFreeModeCoverActive || isClassificationCoverActive || isMazeCoverActive || isMazeResultScreen || isModeSelectActive;
+                const isAnyCoverScreenActive = isWorldIntroCover || isWorldCompleteScreen || isLevelCompleteScreen || isDefeatScreen || isTimeoutScreen || isFreeModeCoverActive || isClassificationCoverActive || isMazeCoverActive || isMazeResultScreen || isModeSelectActive;
                 if (!isAnyCoverScreenActive && !gameOver) {
                      if (isMusicEnabled && generalBackgroundMusic && generalBackgroundMusic.paused) {
                         if (inGameBackgroundMusic && !inGameBackgroundMusic.paused) inGameBackgroundMusic.pause();
@@ -2340,6 +2345,7 @@
                     screenState.showLevelCompleteCover = 0;
                     screenState.showWorldCompleteCover = 0;
                     screenState.showDefeatCoverForWorld = 0;
+                    screenState.showTimeoutCover = false;
                     screenState.showFreeModeCover = false;
                     screenState.showClassificationCover = false;
                 } else if (gameMode === 'freeMode') {
@@ -2375,6 +2381,7 @@
                     screenState.showLevelCompleteCover = 0;
                     screenState.showWorldCompleteCover = 0;
                     screenState.showDefeatCoverForWorld = 0;
+                    screenState.showTimeoutCover = false;
                     screenState.showFreeModeCover = false;
                     
                     // Score and streak should have been reset when settings panel was opened if game was over
@@ -2417,6 +2424,7 @@
                     screenState.showLevelCompleteCover = 0;
                     screenState.showWorldCompleteCover = 0;
                     screenState.showDefeatCoverForWorld = 0;
+                    screenState.showTimeoutCover = false;
                     screenState.showFreeModeCover = false;
                     screenState.showClassificationCover = false;
                 } else if (gameMode === 'freeMode') {
@@ -3556,12 +3564,14 @@
                 screenState.showLevelCompleteCover = 0;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
             } else if (gameMode === 'classification') {
                 screenState.showClassificationCover = false;
                 screenState.showCoverForWorld = 0;
                 screenState.showLevelCompleteCover = 0;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
             }
 
 
@@ -3596,6 +3606,12 @@
             } else if (gameMode === 'maze') {
                 levelEffectivelyWon = handleMazeModeEnd(score, gameTimeRemaining);
             }
+
+            if (!levelEffectivelyWon && gameOverByTimeout && (gameMode === 'levels' || gameMode === 'maze')) {
+                screenState.showTimeoutCover = true;
+                screenState.showDefeatCoverForWorld = 0;
+            }
+            gameOverByTimeout = false;
 
             playSoundForGameOver(levelEffectivelyWon);
             draw(); 
@@ -3687,7 +3703,7 @@
 
         function drawDefeatScreen(worldNumber) { // New function for defeat screen
             if (!ctx || !canvasEl) return;
-            ctx.fillStyle = "#374151"; 
+            ctx.fillStyle = "#374151";
             ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
 
             const img = defeatImages[worldNumber];
@@ -3706,6 +3722,22 @@
                 } else if (img.naturalHeight === 0) {
                     console.warn(`Imagen de derrota para Mundo ${worldNumber} parece estar corrupta o no es una imagen válida.`);
                 }
+            }
+        }
+
+        function drawTimeoutScreen() {
+            if (!ctx || !canvasEl) return;
+            ctx.fillStyle = "#374151";
+            ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
+
+            const img = timeoutImg;
+            if (img && img.complete && img.naturalHeight !== 0) {
+                ctx.drawImage(img, 0, 0, canvasEl.width, canvasEl.height);
+            } else {
+                ctx.fillStyle = "white";
+                ctx.textAlign = "center";
+                ctx.font = `${Math.floor(canvasEl.width / 15)}px 'Press Start 2P'`;
+                ctx.fillText('¡Tiempo agotado!', canvasEl.width / 2, canvasEl.height / 2);
             }
         }
         function drawFreeModeCover() { // New function for free mode cover
@@ -3897,7 +3929,12 @@
                 updateMainButtonStates();
                 return;
             }
-            if (screenState.showDefeatCoverForWorld > 0 && gameMode === 'levels' && !screenState.gameActuallyStarted) { 
+            if (screenState.showTimeoutCover && !screenState.gameActuallyStarted) {
+                drawTimeoutScreen();
+                updateMainButtonStates();
+                return;
+            }
+            if (screenState.showDefeatCoverForWorld > 0 && gameMode === 'levels' && !screenState.gameActuallyStarted) {
                 drawDefeatScreen(screenState.showDefeatCoverForWorld);
                 updateMainButtonStates();
                 return;
@@ -4728,6 +4765,7 @@ async function startGame(isRestart = false) {
     blinkAnimation.active = false;
     blinkAnimation.rowIndex = -1;
     streakAnimation.active = false;
+    gameOverByTimeout = false;
 
     // Reset any lingering speed boost or mirror effect from a previous game
     speedBoost = { active: false, color: '', change: 0, startTime: 0 };
@@ -4747,8 +4785,9 @@ async function startGame(isRestart = false) {
         
             // Reset all visual state flags that are managed before game loop starts
             screenState.showCoverForWorld = 0;
-            screenState.showLevelCompleteCover = 0; 
+            screenState.showLevelCompleteCover = 0;
             screenState.showDefeatCoverForWorld = 0;
+            screenState.showTimeoutCover = false;
             screenState.showWorldCompleteCover = 0;
             screenState.showFreeModeCover = false;
             screenState.showMazeCover = false;
@@ -4929,7 +4968,11 @@ async function startGame(isRestart = false) {
                     gameTimeRemaining -= 1000;
                     updateTimeLengthDisplay();
                     if (gameTimeRemaining <= 0) {
-                        if (!gameOver) { gameOver = true; finalizeGameOver(); } 
+                        if (!gameOver) {
+                            gameOver = true;
+                            gameOverByTimeout = true;
+                            finalizeGameOver();
+                        }
                         clearInterval(gameTimerIntervalId);
                     }
                 }, 1000);
@@ -5188,9 +5231,10 @@ async function startGame(isRestart = false) {
                 
                 screenState.showCoverForWorld = currentWorld;
                 screenState.gameActuallyStarted = false; 
-                screenState.showWorldCompleteCover = 0; 
-                screenState.showLevelCompleteCover = 0; 
+                screenState.showWorldCompleteCover = 0;
+                screenState.showLevelCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showFreeModeCover = false;
 
                 saveGameSettings(); 
@@ -5264,6 +5308,7 @@ async function startGame(isRestart = false) {
                 screenState.gameActuallyStarted = false;
                 screenState.showLevelCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showFreeModeCover = false;
                 screenState.showClassificationCover = false;
@@ -5274,6 +5319,7 @@ async function startGame(isRestart = false) {
                 screenState.showCoverForWorld = 0;
                 screenState.showLevelCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showFreeModeCover = true; // Show free mode cover
                 screenState.showClassificationCover = false;
@@ -5292,6 +5338,7 @@ async function startGame(isRestart = false) {
                 screenState.showCoverForWorld = 0;
                 screenState.showLevelCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showFreeModeCover = false;
                 screenState.showClassificationCover = true;
@@ -5318,6 +5365,7 @@ async function startGame(isRestart = false) {
                 screenState.showCoverForWorld = 0;
                 screenState.showLevelCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showFreeModeCover = false;
                 screenState.showClassificationCover = false;
@@ -5352,6 +5400,7 @@ async function startGame(isRestart = false) {
                 screenState.showLevelCompleteCover = 0;
                 screenState.showWorldCompleteCover = 0;
                 screenState.showDefeatCoverForWorld = 0;
+                screenState.showTimeoutCover = false;
                 screenState.showFreeModeCover = false;
                 screenState.showClassificationCover = false;
                 screenState.showMazeCover = false;
@@ -5640,7 +5689,7 @@ async function startGame(isRestart = false) {
                     if (generalBackgroundMusic && generalBackgroundMusic.paused) {
                         generalBackgroundMusic.play().catch(e => console.warn("Reproducción automática de música general (initializeGameLogic) fallida:", e));
                     }
-                } else if (!isMusicEnabled || screenState.showCoverForWorld || screenState.showWorldCompleteCover || screenState.showLevelCompleteCover || screenState.showDefeatCoverForWorld || screenState.showFreeModeCover || screenState.showClassificationCover || screenState.showMazeCover || screenState.mazeResultType) { // Pause if music disabled or any cover shown
+                } else if (!isMusicEnabled || screenState.showCoverForWorld || screenState.showWorldCompleteCover || screenState.showLevelCompleteCover || screenState.showDefeatCoverForWorld || screenState.showTimeoutCover || screenState.showFreeModeCover || screenState.showClassificationCover || screenState.showMazeCover || screenState.mazeResultType) { // Pause if music disabled or any cover shown
                     if (generalBackgroundMusic) generalBackgroundMusic.pause();
                     if (inGameBackgroundMusic) inGameBackgroundMusic.pause();
                 }
@@ -5658,9 +5707,10 @@ async function startGame(isRestart = false) {
 
             // Reset screen states for a fresh start after splash
             screenState.gameActuallyStarted = false; 
-            screenState.showWorldCompleteCover = 0; 
-            screenState.showLevelCompleteCover = 0; 
+            screenState.showWorldCompleteCover = 0;
+            screenState.showLevelCompleteCover = 0;
             screenState.showDefeatCoverForWorld = 0;
+            screenState.showTimeoutCover = false;
             screenState.showFreeModeCover = false;
             screenState.showClassificationCover = false;
 
@@ -5782,6 +5832,7 @@ async function startGame(isRestart = false) {
                         screenState.showLevelCompleteCover = 0;
                         screenState.showWorldCompleteCover = 0;
                         screenState.showDefeatCoverForWorld = 0;
+                        screenState.showTimeoutCover = false;
                         screenState.showFreeModeCover = false;
                         screenState.showMazeCover = false;
                         screenState.mazeResultType = '';


### PR DESCRIPTION
## Summary
- add new timeout image and load it with other game art
- track game overs caused by timeout
- show a dedicated timeout screen instead of defeat when time runs out
- reset timeout screen state when starting or leaving games

## Testing
- `tidy -errors "Snake Github.html"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c0e7461208333bc06d586d6d593d6