### PR TITLE
Increase star size in progress panel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -224,8 +224,8 @@
             max-width: 260px; 
         }
         .star-svg {
-            width: 38px; 
-            height: 38px; 
+            width: 42px;
+            height: 42px;
         }
 
         /* --- INICIO DE CSS CORREGIDO PARA #high-score-display --- */
@@ -777,7 +777,7 @@
             #current-world-info-group .info-label { font-size: 0.6em; }
             #current-world-info-group .info-value { font-size: 0.8em; }
             #star-progress-wrapper { min-height: 50px; padding: 6px;}
-            .star-svg { width: 30px; height: 30px; } 
+            .star-svg { width: 32px; height: 32px; }
             #star-progress-container { max-width: 200px; gap: 10px;} 
 
 
@@ -855,7 +855,7 @@
             #current-world-info-group .info-label { font-size: 0.55em; }
             #current-world-info-group .info-value { font-size: 0.7em; }
             #current-world-info-group { min-width: 60px;}
-            .star-svg { width: 24px; height: 24px; } 
+            .star-svg { width: 27px; height: 27px; }
             #star-progress-container { max-width: 170px; gap: 8px;} 
 
 


### PR DESCRIPTION
## Summary
- tweak `.star-svg` widths and heights so stars appear larger

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c579227bc8333a693b493426f1437