### PR TITLE
Apply Pixelify Sans to maze level selector

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0, viewport-fit=cover">
     <title>Snake Mobile</title>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.js"></script>
     <style>
@@ -511,7 +512,14 @@
             text-align-last: left;
         }
         select option {
-            direction: ltr; 
+            direction: ltr;
+        }
+
+        #mazeLevelSelector,
+        #mazeLevelSelector option {
+            font-family: 'Pixelify Sans', sans-serif;
+            font-size: 1em;
+            line-height: 38px;
         }
 
 
@@ -820,6 +828,12 @@
                 margin-top: 2px;
                 margin-bottom: 2px;
              }
+
+             #settings-panel #mazeLevelSelector,
+             #settings-panel #mazeLevelSelector option {
+                font-size: 0.8em;
+                line-height: 30px;
+             }
              #settings-panel .control-label-icon-row { margin-bottom: 0px; }
              .setting-info-button {
                 width: 36px;
@@ -895,6 +909,10 @@
                 height: 30px;
                 margin-top: 2px;
                 margin-bottom: 2px;
+            }
+            #settings-panel #mazeLevelSelector,
+            #settings-panel #mazeLevelSelector option {
+                line-height: 30px;
             }
         }
 
@@ -4682,8 +4700,8 @@
                 const option = document.createElement('option');
                 option.value = i;
                 const starsEarned = mazeLevelStars[i - 1] || 0;
-                const starSymbols = '⭐'.repeat(starsEarned) + '☆'.repeat(MAZE_STAR_TARGETS.length - starsEarned);
-                option.textContent = `Nivel ${i} ${starSymbols}`;
+                const starSymbols = '⭐'.repeat(starsEarned) + '☆️'.repeat(MAZE_STAR_TARGETS.length - starsEarned);
+                option.textContent = `Nivel ${i}\u00A0\u00A0${starSymbols}`;
                 option.disabled = i > currentMazeLevel;
                 if (i === displayMazeLevel) {
                     option.selected = true;


### PR DESCRIPTION
## Summary
- import Pixelify Sans
- style `#mazeLevelSelector` with the new font, larger size, and centered line height
- keep improved star display for maze levels
- adjust the selector's size inside the settings panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685faa7d6fb083338a3684e501e8d074