### PR TITLE
Handle unselected game mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -990,6 +990,7 @@
                         </button>
                     </div>
                     <select id="gameModeSelector">
+                        <option value="" disabled hidden selected>Sin seleccionar</option>
                         <option value="levels">Modo Aventura</option>
                         <option value="freeMode">Modo Libre</option>
                         <option value="classification">Modo Clasificación</option>
@@ -1733,7 +1734,7 @@
         let gameIntervalId;
         let gameTimeRemaining; 
         let gameTimerIntervalId; 
-        let gameMode = 'levels'; // Default to levels
+        let gameMode = ''; // No mode selected initially
         let isNewHighScore = false; // Flag for new high score
         
         let currentFoodItem = {}; 
@@ -4499,7 +4500,10 @@
         }
         
         function updateTimeLengthDisplay() {
-            if (gameMode === 'levels' || gameMode === 'maze') {
+            if (!gameMode) {
+                timeLengthLabelEl.textContent = "Tiempo:";
+                timeLengthValueEl.textContent = 0;
+            } else if (gameMode === 'levels' || gameMode === 'maze') {
                 timeLengthLabelEl.textContent = "Tiempo:";
                 timeLengthValueEl.textContent = Math.max(0, Math.ceil(gameTimeRemaining / 1000));
             } else { // freeMode or classification
@@ -4534,7 +4538,25 @@
             const isGameCurrentlyRunning = !!gameIntervalId;
             const isSettingsPanelCurrentlyOpen = !settingsPanel.classList.contains("settings-panel-hidden");
 
-            if (gameMode === 'levels') {
+            if (!gameMode) {
+                progressPanel.classList.remove('hidden');
+                starProgressContainer.classList.add('hidden');
+                highScoreDisplay.classList.add('hidden');
+                progressPanelLeftLabel.textContent = "Nivel:";
+                progressPanelLeftValue.textContent = "No disponible";
+
+                difficultyLabel.textContent = "Nivel:";
+                difficultySelector.classList.add('hidden');
+                worldsSelector.classList.add('hidden');
+                mazeLevelSelector.classList.add('hidden');
+
+                if (isSettingsPanelCurrentlyOpen) {
+                    difficultySelector.disabled = true;
+                    worldsSelector.disabled = true;
+                    mazeLevelSelector.disabled = true;
+                    difficultyControlGroup.classList.remove("interactive-mode");
+                }
+            } else if (gameMode === 'levels') {
                 progressPanel.classList.remove('hidden');
                 starProgressContainer.classList.remove('hidden');
                 highScoreDisplay.classList.add('hidden');
@@ -4644,9 +4666,12 @@
                 }
             }
 
-            updateTargetScoreDisplay(); 
+            updateTargetScoreDisplay();
 
-            if (gameMode === 'levels' || gameMode === 'maze') {
+            if (!gameMode) {
+                timeLengthLabelEl.textContent = "Tiempo:";
+                timeLengthValueEl.textContent = 0;
+            } else if (gameMode === 'levels' || gameMode === 'maze') {
                 timeLengthLabelEl.textContent = "Tiempo:";
                 if (!screenState.gameActuallyStarted && !gameOver) {
                      timeLengthValueEl.textContent = Math.ceil(LEVEL_TIME_LIMIT / 1000);
@@ -4655,7 +4680,7 @@
                 } else {
                      timeLengthValueEl.textContent = Math.ceil(LEVEL_TIME_LIMIT / 1000);
                 }
-            } else { // freeMode
+            } else { // freeMode or classification
                 timeLengthLabelEl.textContent = "Longitud:";
                 timeLengthValueEl.textContent = snake.length > 0 ? snake.length : initialSnakeLength;
             }
@@ -5593,12 +5618,11 @@ async function startGame(isRestart = false) {
             const savedCoins = parseInt(localStorage.getItem('snakeGameCoins'), 10);
             totalCoins = Number.isFinite(savedCoins) && savedCoins >= 0 ? savedCoins : 0;
             
-            const savedGameMode = localStorage.getItem('snakeGameMode');
-            if (savedGameMode && (savedGameMode === 'levels' || savedGameMode === 'freeMode' || savedGameMode === 'classification' || savedGameMode === 'maze')) {
-                 gameModeSelector.value = savedGameMode;
-            } else {
-                gameModeSelector.value = 'levels';
-            }
+            // Always start with no mode selected, regardless of any previously
+            // saved preference. Users must actively choose their mode each time
+            // they open the game.
+            gameModeSelector.value = '';
+            gameMode = '';
             
             // Levels mode specific
             const savedCurrentWorld = parseInt(localStorage.getItem('snakeCurrentWorld'), 10);
@@ -5742,7 +5766,7 @@ async function startGame(isRestart = false) {
             screenState.showFreeModeCover = false;
             screenState.showClassificationCover = false;
 
-            // Set initial display state based on loaded gameMode (already done in loadGameSettings -> updateGameModeUI)
+            // Set initial display state based on current gameMode
             // but ensure correct cover screen is shown
             if (gameMode === 'levels') {
                 screenState.showCoverForWorld = currentWorld; // currentWorld from loaded settings


### PR DESCRIPTION
## Summary
- always reset to no selected game mode on load
- update comment about initial display state
- show time instead of length when no game mode is selected
- label level info as unavailable in settings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685fbcceb2ac8333b2a29bf81914d26b