### PR TITLE
Fix title panel height

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -167,6 +167,8 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            padding: 8px 10px;
+            min-height: 55px;
             width: 100%;
             margin: 0 auto 5px auto;
             position: relative;


### PR DESCRIPTION
## Summary
- keep the Snake Mobile title area the same height as the progress panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685fc9785324833397711f6bd7eaae65