### PR TITLE
Fix title panel height

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -167,6 +167,8 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            padding: 8px 10px;
+            min-height: 55px;
             width: 100%;
             margin: 0 auto 5px auto;
             position: relative;
@@ -787,9 +789,11 @@
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
 
-            #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;} 
+            #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
+
+            #title-panel { min-height: 50px; padding: 6px; }
 
             #current-world-info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #current-world-info-group .info-label { font-size: 0.6em; }


### PR DESCRIPTION
## Summary
- ensure Snake Mobile title panel height matches progress panel on small screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685fc9785324833397711f6bd7eaae65