### PR TITLE
Fix settings panel disable bug in maze mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2589,6 +2589,8 @@
 
                 if (gameMode === 'levels') {
                     worldsSelector.disabled = false;
+                } else if (gameMode === 'maze') {
+                    mazeLevelSelector.disabled = false;
                 } else {
                     difficultySelector.disabled = false;
                 }


### PR DESCRIPTION
## Summary
- fix re-enabling controls after closing specific info when maze mode is active

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ff6365e38833383e10bd3178d10c3