### PR TITLE
Update world dropdown format

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4729,7 +4729,7 @@
                 const option = document.createElement('option');
                 option.value = i;
                 const name = WORLD_DISPLAY_NAMES[i - 1] || '';
-                option.textContent = `Mundo ${i}${name ? ': ' + name : ''}`;
+                option.textContent = name ? `${i}. ${name}` : `${i}`;
                 option.disabled = i > maxUnlockedWorld;
                 if (i === currentWorld) {
                     option.selected = true;


### PR DESCRIPTION
## Summary
- show worlds as `1. Name` instead of `Mundo 1: Name` when in adventure mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ff8c161fc8333b69d30bd07eb6ec1