### PR TITLE
Add expanded classification difficulties

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1028,9 +1028,11 @@
                         </button>
                     </div>
                     <select id="difficultySelector">
-                        <option value="easy" selected>Fácil</option> 
-                        <option value="normal">Normal</option> 
-                        <option value="difficult">Difícil</option>
+                        <option value="principiante" selected>Principiante</option>
+                        <option value="explorador">Explorador</option>
+                        <option value="desafiante">Desafiante</option>
+                        <option value="veterano">Veterano</option>
+                        <option value="maestro">Maestro</option>
                     </select>
                     <select id="worldsSelector" class="hidden">
                     </select>
@@ -1437,9 +1439,11 @@
         
         // Mapping for difficulty display names
         const DIFFICULTY_DISPLAY_NAMES = {
-            easy: "Fácil",
-            normal: "Normal",
-            difficult: "Difícil"
+            principiante: "Principiante",
+            explorador: "Explorador",
+            desafiante: "Desafiante",
+            veterano: "Veterano",
+            maestro: "Maestro"
         };
 
         // Mapping para nombres de jugadores en el ranking
@@ -1768,7 +1772,7 @@
             borderColor: '#E64A19', 
         };
 
-        let difficulty = 'easy'; 
+        let difficulty = 'principiante'; 
         let snakeSpeed = 150; 
         let foodTimeRemaining = 0; 
         let foodDisappearTimeoutId; 
@@ -1799,10 +1803,12 @@
         let modeTransitionFrom = 0;
 
         const DIFFICULTY_SETTINGS = {
-            easy: { speed: 200, initialLifespan: 11000 }, 
-            normal: { speed: 150, initialLifespan: 9000 }, 
-            difficult: { speed: 100, initialLifespan: 8000 } 
-        };
+            principiante: { speed: 200, initialLifespan: 11000 },
+            explorador: { speed: 180, initialLifespan: 9500 },
+            desafiante: { speed: 170, initialLifespan: 9000 },
+            veterano: { speed: 130, initialLifespan: 8000 },
+            maestro: { speed: 105, initialLifespan: 7000 }
+        }; 
         const MIN_FOOD_LIFESPAN = 4000; 
         const FOOD_WARNING_TIME = 3000; 
         const POINTS_PER_FOOD = 10;
@@ -2515,13 +2521,13 @@
         const specificHelpTexts = {
             gameMode: {
                 title: "Tipo de Juego",
-                text: "<p>Define la estructura principal de tus partidas, eligiendo entre:</p><h4>Modo Aventura</h4><p>Embárcate en un viaje progresivo a través de diversos mundos. En este modo:</p><ul><li>Cada mundo presenta un diseño de escenario único y puede introducir nuevos obstáculos o mecánicas.</li><li>Deberás alcanzar una <strong>puntuación objetivo</strong> en cada nivel para superarlo.</li><li>Desbloquea <strong>nuevos mundos</strong> superando todos los niveles del mundo en el que te encuentras.</li><li>La dificultad de los niveles y mundos aumenta gradualmente, ¿Serás capaz de superarlos todos?</li></ul><h4>Modo Libre</h4><p>Disfruta de la experiencia clásica de Snake sin la presión de superar niveles específicos. En este modo:</p><ul><li>El objetivo principal es conseguir la <strong>máxima puntuación</strong> y la <strong>serpiente más larga</strong> posible en una única partida.</li><li>La dificultad que selecciones (Fácil, Normal, Difícil) afectará directamente la velocidad inicial de la serpiente y a la clasificación en la que se registran las puntuaciones.</li></ul><h4>Modo Clasificación</h4><p>Un modo similar al Modo Libre donde también competirás por lograr la mejor puntuación posible. Las puntuaciones se almacenan de forma independiente para este modo.</p>"
+                text: "<p>Define la estructura principal de tus partidas, eligiendo entre:</p><h4>Modo Aventura</h4><p>Embárcate en un viaje progresivo a través de diversos mundos. En este modo:</p><ul><li>Cada mundo presenta un diseño de escenario único y puede introducir nuevos obstáculos o mecánicas.</li><li>Deberás alcanzar una <strong>puntuación objetivo</strong> en cada nivel para superarlo.</li><li>Desbloquea <strong>nuevos mundos</strong> superando todos los niveles del mundo en el que te encuentras.</li><li>La dificultad de los niveles y mundos aumenta gradualmente, ¿Serás capaz de superarlos todos?</li></ul><h4>Modo Libre</h4><p>Disfruta de la experiencia clásica de Snake sin la presión de superar niveles específicos. En este modo:</p><ul><li>El objetivo principal es conseguir la <strong>máxima puntuación</strong> y la <strong>serpiente más larga</strong> posible en una única partida.</li><li>La dificultad que selecciones (Principiante, Explorador, Desafiante, Veterano, Maestro) afectará directamente la velocidad inicial de la serpiente y a la clasificación en la que se registran las puntuaciones.</li></ul><h4>Modo Clasificación</h4><p>Un modo similar al Modo Libre donde también competirás por lograr la mejor puntuación posible. Las puntuaciones se almacenan de forma independiente para este modo.</p>"
             },
             difficulty: { 
                 title: "Dificultad / Mundo", 
                 text_adventure: "<h4> (Solo en Modo Aventura)</h4><p>Cuando juegas en <strong>Modo Aventura</strong>, tendrás disponibles un total de 8 mundos. Cada uno de ellos dispone de 5 niveles de creciente dificultad. Tendrás que superarlos todos para poder avanzar al siguiente mundo. Complétalos todos para finalizar este modo de juego.</p><p>El selector de <strong>Mundos</strong> (que aparece al seleccionar \"Modo Aventura\") te permite elegir en qué mundo específico deseas comenzar tu aventura, siempre y cuando ya lo hayas desbloqueado previamente jugando y superando los anteriores en la dificultad seleccionada. ¡Supera los mundos para acceder a nuevos escenarios y desafíos más emocionantes o volver a jugar a los que ya hayas superado!</p><p>No olvides estar atento a las novedades del juego, ¡Puede que haya nuevos niveles muy pronto!</p>",
-                text_free: "<h4> (Solo en Modo Libre)</h4><p>Ajusta el nivel de desafío para que se adapte a tu habilidad y preferencias. La dificultad influye principalmente en la velocidad de la serpiente y el tiempo de desaparición de los comestibles.</p><h4>Fácil</h4><p>La opción perfecta si estás empezando o si prefieres una experiencia de juego más relajada. La serpiente se mueve a una velocidad considerablemente reducida y los comestibles tardan más tiempo en desaparecer, dándote más tiempo para reaccionar y planificar tus movimientos.</p><h4>Normal</h4><p>Un reto equilibrado, recomendado para la mayoría de los jugadores que ya conocen la mecánica básica de Snake. La velocidad de la serpiente es moderada al igual que el tiempo de desaparición de los comestibles, exigiendo buena anticipación y reflejos para conseguir puntuaciones altas.</p><h4>Difícil</h4><p>¡Prepárate para un desafío intenso! En esta dificultad, la serpiente se mueve muy rápido desde el inicio y los comestibles desaparecen mucho más rápido, poniendo a prueba tu concentración y destreza al máximo.</p>",
-                text_classification: "<h4> (Solo en Modo Clasificación)</h4><p>Compite por la mejor puntuación al igual que en el Modo Libre, pero con una tabla de récords independiente.</p>"
+                text_free: "<h4> (Solo en Modo Libre)</h4><p>Ajusta el nivel de desafío para que se adapte a tu habilidad y preferencias. Cada dificultad modifica la velocidad y activa distintas mecánicas.</p><h4>Principiante</h4><p>Experiencia clásica sin mecánicas adicionales.</p><h4>Explorador</h4><p>La comida desaparece tras un tiempo moderado.</p><h4>Desafiante</h4><p>Se añaden obstáculos al escenario.</p><h4>Veterano</h4><p>Obstáculos y rayos que invierten controles temporalmente.</p><h4>Maestro</h4><p>Incluye todas las mecánicas anteriores y alimentos falsos.</p>",
+                text_classification: "<h4> (Solo en Modo Clasificación)</h4><p>Compite por la mejor puntuación y elige entre cinco dificultades que activan las mecánicas del Modo Aventura.</p>"
             },
             skin: {
                 title: "Jugador",
@@ -5012,7 +5018,7 @@ async function startGame(isRestart = false) {
                 snakeSpeed = DIFFICULTY_SETTINGS[difficultySelector.value].speed;
                 initialSnakeLength = DEFAULT_INITIAL_SNAKE_LENGTH;
             } else { // maze
-                snakeSpeed = DIFFICULTY_SETTINGS.easy.speed;
+                snakeSpeed = DIFFICULTY_SETTINGS.principiante.speed;
                 initialSnakeLength = DEFAULT_INITIAL_SNAKE_LENGTH;
             }
 
@@ -5071,27 +5077,58 @@ async function startGame(isRestart = false) {
                 updateTimeLengthDisplay();
                 clearInterval(gameTimerIntervalId);
             }
-            if (gameMode === "levels" && (currentWorld === 7 || currentWorld === 8 || currentWorld === 10)) {
-                startWorld4FalseFoodMechanics();
-            } else {
+            
+            if (gameMode === "levels") {
+                if (currentWorld === 7 || currentWorld === 8 || currentWorld === 10) {
+                    startWorld4FalseFoodMechanics();
+                } else {
+                    stopWorld4FalseFoodMechanics();
+                }
+
+                if (currentWorld === 8) {
+                    startWorld5Obstacles();
+                } else if (currentWorld === 3) {
+                    stopWorld6Obstacles();
+                    startWorld6LightningMechanics();
+                } else if (currentWorld === 4) {
+                    stopWorld6Obstacles();
+                    startWorld6LightningMechanics();
+                } else if (currentWorld === 9) {
+                    startWorld6Obstacles();
+                    startWorld6LightningMechanics();
+                    startWorld7MirrorMechanics();
+                } else if (currentWorld === 10) {
+                    startWorld8Obstacles();
+                    startWorld6LightningMechanics();
+                    startWorld7MirrorMechanics();
+                } else {
+                    stopWorld5Obstacles();
+                    stopWorld6Obstacles();
+                    stopWorld6LightningMechanics();
+                    stopWorld7MirrorMechanics();
+                    stopWorld8Obstacles();
+                }
+            } else if (gameMode === 'classification') {
                 stopWorld4FalseFoodMechanics();
-            }
-            if (gameMode === "levels" && currentWorld === 8) {
-                startWorld5Obstacles();
-            } else if (gameMode === "levels" && currentWorld === 3) {
+                stopWorld5Obstacles();
                 stopWorld6Obstacles();
-                startWorld6LightningMechanics();
-            } else if (gameMode === "levels" && currentWorld === 4) {
-                stopWorld6Obstacles();
-                startWorld6LightningMechanics();
-            } else if (gameMode === "levels" && currentWorld === 9) {
-                startWorld6Obstacles();
-                startWorld6LightningMechanics();
-                startWorld7MirrorMechanics();
-            } else if (gameMode === "levels" && currentWorld === 10) {
-                startWorld8Obstacles();
-                startWorld6LightningMechanics();
-                startWorld7MirrorMechanics();
+                stopWorld6LightningMechanics();
+                stopWorld7MirrorMechanics();
+                stopWorld8Obstacles();
+
+                const diff = difficultySelector.value;
+                if (diff === 'desafiante') {
+                    startWorld5Obstacles();
+                } else if (diff === 'veterano') {
+                    startWorld6Obstacles();
+                    startWorld6LightningMechanics();
+                    startWorld7MirrorMechanics();
+                } else if (diff === 'maestro') {
+                    startWorld4FalseFoodMechanics();
+                    startWorld8Obstacles();
+                    startWorld6LightningMechanics();
+                    startWorld7MirrorMechanics();
+                }
             } else if (gameMode === 'maze') {
                 stopWorld5Obstacles();
                 stopWorld6Obstacles();
@@ -5099,14 +5136,13 @@ async function startGame(isRestart = false) {
                 stopWorld7MirrorMechanics();
                 stopWorld8Obstacles();
                 startMazeLevel();
-            } else {
+            } else { // freeMode
                 stopWorld5Obstacles();
                 stopWorld6Obstacles();
                 stopWorld6LightningMechanics();
                 stopWorld7MirrorMechanics();
                 stopWorld8Obstacles();
             }
-            
             generateFood(); 
             updateScoreDisplay();
             clearInterval(gameIntervalId); 


### PR DESCRIPTION
## Summary
- introduce five difficulty tiers
- show Spanish names for new difficulties
- update selector options and help text
- enable world mechanics in classification mode based on difficulty

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685ffc9d05f48333ab1400ada2dbbafe