### PR TITLE
Fix difficulty update in classification mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5459,7 +5459,7 @@ async function startGame(isRestart = false) {
         });
 
         difficultySelector.addEventListener('change', function() {
-            difficulty = this.value; 
+            difficulty = this.value;
             if (!gameIntervalId) {
                 const cfg = DIFFICULTY_SETTINGS[difficulty];
                 snakeSpeed = cfg.speed;
@@ -5470,8 +5470,10 @@ async function startGame(isRestart = false) {
                 displayHighScoreInPanel();
             } else if (gameMode === 'classification') {
                 displayClassificationHighScoreInPanel();
-                // Ya no actualizamos progressPanelLeftValue aquí, #high-score-display es independiente
-                // progressPanelLeftValue.textContent = DIFFICULTY_DISPLAY_NAMES[difficulty] || difficulty;
+                // También actualizamos la dificultad mostrada en pantalla
+                if (progressPanelLeftValue) {
+                    progressPanelLeftValue.textContent = DIFFICULTY_DISPLAY_NAMES[difficulty] || difficulty;
+                }
             }
             saveGameSettings();
         });


### PR DESCRIPTION
## Summary
- update `progressPanelLeftValue` when difficulty changes in classification mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6860e31ab56c833388aae7108ac54410