### PR TITLE
Add classification difficulty sliding effect

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1382,6 +1382,12 @@
         };
         const freeModeCoverImg = new Image();
         const classificationModeCoverImg = new Image();
+        const classificationDifficultyImages = {
+            principiante: new Image(),
+            explorador: new Image(),
+            veterano: new Image(),
+            legendario: new Image()
+        };
         const modeSelectIntroImg = new Image();
         const modeSelectLevelsImg = new Image();
         const modeSelectFreeImg = new Image();
@@ -1402,7 +1408,7 @@
         };
 
         let worldImagesLoaded = 0;
-        const totalWorldImagesToLoad = Object.keys(worldImagesConfig).length * 4 + 10;
+        const totalWorldImagesToLoad = Object.keys(worldImagesConfig).length * 4 + 14;
         // --- FIN: Declaración de Objetos Image ---
 
         // --- Música de fondo y SFX ---
@@ -1808,6 +1814,12 @@
         let modeTransitionDir = 0;
         let modeTransitionFrom = 0;
 
+        const CLASSIFICATION_DIFFICULTY_ORDER = ['principiante', 'explorador', 'veterano', 'legendario'];
+        let classificationDifficultyIndex = 0;
+        let classificationTransitionStart = null;
+        let classificationTransitionDir = 0;
+        let classificationTransitionFrom = 0;
+
         const DIFFICULTY_SETTINGS = {
             principiante: {
                 speed: 180,
@@ -2027,6 +2039,10 @@
 
             freeModeCoverImg.src = 'https://i.imgur.com/6cMWnrC.png';
             classificationModeCoverImg.src = 'https://i.imgur.com/t5n37Mw.png';
+            classificationDifficultyImages.principiante.src = 'https://i.imgur.com/z4SlhGV.png';
+            classificationDifficultyImages.explorador.src = 'https://i.imgur.com/QCxdQQh.png';
+            classificationDifficultyImages.veterano.src = 'https://i.imgur.com/kEDCBEZ.png';
+            classificationDifficultyImages.legendario.src = 'https://i.imgur.com/Mohv1u4.png';
 
             mazeModeCoverImg.src = 'https://i.imgur.com/WY3lrHv.png';
             mazeFailImg.src = 'https://i.imgur.com/3snKeSJ.png';
@@ -2043,9 +2059,10 @@
                 ...Object.values(worldCompleteImages),
                 ...Object.values(levelCompleteImages),
                 ...Object.values(defeatImages),
-                freeModeCoverImg, classificationModeCoverImg, mazeModeCoverImg,
-                mazeFailImg, mazePartialImg, mazePerfectImg, mazeCompleteImg,
-                mazeFinalImg, mazeAllStarsImg, timeoutImg
+                freeModeCoverImg, classificationModeCoverImg,
+                ...Object.values(classificationDifficultyImages),
+                mazeModeCoverImg, mazeFailImg, mazePartialImg, mazePerfectImg,
+                mazeCompleteImg, mazeFinalImg, mazeAllStarsImg, timeoutImg
             ];
 
             allWorldImages.forEach(img => {
@@ -3969,18 +3986,39 @@
             ctx.fillStyle = "#374151";
             ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
 
-            const img = classificationModeCoverImg;
-            if (img && img.complete && img.naturalHeight !== 0) {
-                ctx.drawImage(img, 0, 0, canvasEl.width, canvasEl.height);
+            const now = performance.now();
+            let progress = 1;
+            if (classificationTransitionStart !== null) {
+                progress = Math.min((now - classificationTransitionStart) / MODE_TRANSITION_DURATION, 1);
+            }
+
+            const fromImg = classificationDifficultyImages[CLASSIFICATION_DIFFICULTY_ORDER[classificationTransitionStart !== null ? classificationTransitionFrom : classificationDifficultyIndex]];
+            const toImg = classificationDifficultyImages[CLASSIFICATION_DIFFICULTY_ORDER[classificationDifficultyIndex]];
+
+            if (classificationTransitionStart !== null && progress < 1) {
+                const offset = canvasEl.width * progress;
+                const dir = classificationTransitionDir;
+                if (fromImg && fromImg.complete && fromImg.naturalHeight !== 0) {
+                    ctx.drawImage(fromImg, -dir * offset, 0, canvasEl.width, canvasEl.height);
+                }
+                if (toImg && toImg.complete && toImg.naturalHeight !== 0) {
+                    ctx.drawImage(toImg, canvasEl.width * dir - dir * offset, 0, canvasEl.width, canvasEl.height);
+                }
+                requestAnimationFrame(draw);
             } else {
-                ctx.fillStyle = "white";
-                ctx.textAlign = "center";
-                ctx.font = `${Math.floor(canvasEl.width / 15)}px 'Press Start 2P'`;
-                ctx.fillText(`Modo Clasificación`, canvasEl.width / 2, canvasEl.height / 2);
-                if (!img.complete) {
-                    console.warn(`Imagen de portada de Modo Clasificación aún no cargada.`);
-                } else if (img.naturalHeight === 0) {
-                    console.warn(`Imagen de portada de Modo Clasificación parece estar corrupta o no es una imagen válida.`);
+                classificationTransitionStart = null;
+                if (toImg && toImg.complete && toImg.naturalHeight !== 0) {
+                    ctx.drawImage(toImg, 0, 0, canvasEl.width, canvasEl.height);
+                } else {
+                    ctx.fillStyle = "white";
+                    ctx.textAlign = "center";
+                    ctx.font = `${Math.floor(canvasEl.width / 15)}px 'Press Start 2P'`;
+                    ctx.fillText(DIFFICULTY_DISPLAY_NAMES[difficultySelector.value] || 'Clasificación', canvasEl.width / 2, canvasEl.height / 2);
+                    if (!toImg.complete) {
+                        console.warn(`Imagen de portada de dificultad aún no cargada.`);
+                    } else if (toImg.naturalHeight === 0) {
+                        console.warn(`Imagen de portada de dificultad parece estar corrupta o no es una imagen válida.`);
+                    }
                 }
             }
         }
@@ -4090,8 +4128,13 @@
                 updateMainButtonStates();
                 return;
             } else {
-                modeLeftButton.classList.add('hidden');
-                modeRightButton.classList.add('hidden');
+                if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
+                    modeLeftButton.classList.remove('hidden');
+                    modeRightButton.classList.remove('hidden');
+                } else {
+                    modeLeftButton.classList.add('hidden');
+                    modeRightButton.classList.add('hidden');
+                }
             }
 
             let speedBoostVisible = false;
@@ -5499,6 +5542,7 @@ async function startGame(isRestart = false) {
 
         difficultySelector.addEventListener('change', function() {
             difficulty = this.value;
+            classificationDifficultyIndex = CLASSIFICATION_DIFFICULTY_ORDER.indexOf(this.value);
             if (!gameIntervalId) {
                 const cfg = DIFFICULTY_SETTINGS[difficulty];
                 snakeSpeed = cfg.speed;
@@ -5745,6 +5789,10 @@ async function startGame(isRestart = false) {
                     screenState.showFreeModeCover = true;
                 } else if (selectedMode === 'classification') {
                     screenState.showClassificationCover = true;
+                    classificationDifficultyIndex = 0;
+                    const initDiff = CLASSIFICATION_DIFFICULTY_ORDER[classificationDifficultyIndex];
+                    difficultySelector.value = initDiff;
+                    difficultySelector.dispatchEvent(new Event('change'));
                 } else {
                     screenState.showMazeCover = true;
                 }
@@ -5842,12 +5890,36 @@ async function startGame(isRestart = false) {
             draw();
         }
 
+        function startClassificationTransition(dir) {
+            if (classificationTransitionStart !== null) return;
+            classificationTransitionDir = dir;
+            classificationTransitionFrom = classificationDifficultyIndex;
+            classificationDifficultyIndex = (classificationDifficultyIndex + dir + CLASSIFICATION_DIFFICULTY_ORDER.length) % CLASSIFICATION_DIFFICULTY_ORDER.length;
+            const newDiff = CLASSIFICATION_DIFFICULTY_ORDER[classificationDifficultyIndex];
+            difficultySelector.value = newDiff;
+            difficultySelector.dispatchEvent(new Event('change'));
+            updateGameModeUI();
+            saveGameSettings();
+            classificationTransitionStart = performance.now();
+            if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
+                requestAnimationFrame(draw);
+            }
+        }
+
         modeLeftButton.addEventListener("click", () => {
-            startModeTransition(-1);
+            if (showModeSelect) {
+                startModeTransition(-1);
+            } else if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
+                startClassificationTransition(-1);
+            }
             if (areSfxEnabled) playSound('modeSwitch');
         });
         modeRightButton.addEventListener("click", () => {
-            startModeTransition(1);
+            if (showModeSelect) {
+                startModeTransition(1);
+            } else if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
+                startClassificationTransition(1);
+            }
             if (areSfxEnabled) playSound('modeSwitch');
         });
 
@@ -5880,6 +5952,7 @@ async function startGame(isRestart = false) {
             } else {
                 difficultySelector.value = 'principiante';
             }
+            classificationDifficultyIndex = CLASSIFICATION_DIFFICULTY_ORDER.indexOf(difficultySelector.value);
 
             const savedSkin = localStorage.getItem('snakeGameSkin');
             if (savedSkin) skinSelector.value = savedSkin;


### PR DESCRIPTION
## Summary
- animate difficulty covers using a slide transition similar to mode selection
- update left/right buttons to trigger the new transition

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68610bc3df308333a70d7baa92667d97