### PR TITLE
Add world progress retention

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1653,9 +1653,10 @@
             ]
         ];
         let currentWorld = 1;
-        let currentLevelInWorld = 1; 
+        let currentLevelInWorld = 1;
         let maxUnlockedWorld = 1;
         let levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+        let worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
 
         // --- Variables de visualización para UI ---
         let displayWorld = 1;
@@ -1819,6 +1820,10 @@
         let classificationTransitionStart = null;
         let classificationTransitionDir = 0;
         let classificationTransitionFrom = 0;
+        let worldTransitionStart = null;
+        let worldTransitionDir = 0;
+        let worldTransitionFrom = 1;
+
 
         const DIFFICULTY_SETTINGS = {
             principiante: {
@@ -2340,8 +2345,9 @@
                 const isMazeResultScreen = screenState.mazeResultType && !screenState.gameActuallyStarted;
                 const isModeSelectActive = showModeSelect;
                 const isModeSelectIntro = isModeSelectActive && MODE_SELECT_ORDER[modeSelectIndex] === 'intro';
+                const isSelectedWorldLocked = isWorldIntroCover && displayWorld > maxUnlockedWorld;
 
-                startButton.disabled = isModeSelectIntro;
+                startButton.disabled = isModeSelectIntro || isSelectedWorldLocked;
                 restartMazeButton.disabled = restartMazeButton.classList.contains('hidden');
                 configButton.disabled = false;
                 infoButton.disabled = false;
@@ -3580,6 +3586,7 @@
 
             if (levelWon) {
                 levelsProgress[absoluteLevelIndex] = true; // Se marca la estrella
+                worldCurrentLevels[currentWorld - 1] = currentLevelInWorld;
 
                 if (currentLevelInWorld === LEVELS_PER_WORLD) { // Mundo completado
                     screenState.showWorldCompleteCover = currentWorld;
@@ -3589,9 +3596,9 @@
                         // No hay más niveles a los que avanzar. currentWorld y currentLevelInWorld permanecen en el máximo.
                     } else { // Avanzar al siguiente mundo
                         startButton.textContent = "Nuevo Mundo";
-                        // Actualizamos inmediatamente el estado para el próximo inicio
+                        worldCurrentLevels[currentWorld - 1] = LEVELS_PER_WORLD;
                         currentWorld++;
-                        currentLevelInWorld = 1;
+                        currentLevelInWorld = worldCurrentLevels[currentWorld - 1] || 1;
                         if (currentWorld > maxUnlockedWorld) {
                             maxUnlockedWorld = currentWorld;
                         }
@@ -3613,6 +3620,7 @@
                 screenState.showWorldCompleteCover = 0;
                 screenState.showLevelCompleteCover = 0;
             }
+            worldCurrentLevels[currentWorld - 1] = currentLevelInWorld;
             drawStarProgress(); // Dibuja las estrellas con la nueva completada
             return levelWon;
         }
@@ -3850,14 +3858,18 @@
             }
         }
         
-        function drawWorldCoverImage(worldNumber) {
+        function drawSingleWorldCover(worldNumber) {
             if (!ctx || !canvasEl) return;
-            ctx.fillStyle = "#374151"; 
+            ctx.fillStyle = "#374151";
             ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
 
             const img = worldCoverImages[worldNumber];
             if (img && img.complete && img.naturalHeight !== 0) {
+                if (worldNumber > maxUnlockedWorld) {
+                    ctx.filter = 'grayscale(100%)';
+                }
                 ctx.drawImage(img, 0, 0, canvasEl.width, canvasEl.height);
+                ctx.filter = 'none';
             } else {
                 ctx.fillStyle = "white";
                 ctx.textAlign = "center";
@@ -4023,6 +4035,35 @@
             }
         }
 
+        function drawWorldCover() {
+            if (!ctx || !canvasEl) return;
+            const now = performance.now();
+            let progress = 1;
+            if (worldTransitionStart !== null) {
+                progress = Math.min((now - worldTransitionStart) / MODE_TRANSITION_DURATION, 1);
+            }
+
+            const fromWorld = worldTransitionStart !== null ? worldTransitionFrom : displayWorld;
+            const toWorld = displayWorld;
+
+            if (worldTransitionStart !== null && progress < 1) {
+                const offset = canvasEl.width * progress;
+                const dir = worldTransitionDir;
+                ctx.save();
+                ctx.translate(-dir * offset, 0);
+                drawSingleWorldCover(fromWorld);
+                ctx.restore();
+                ctx.save();
+                ctx.translate(canvasEl.width * dir - dir * offset, 0);
+                drawSingleWorldCover(toWorld);
+                ctx.restore();
+                requestAnimationFrame(draw);
+            } else {
+                worldTransitionStart = null;
+                drawSingleWorldCover(toWorld);
+            }
+        }
+
         function drawMazeCover() {
             if (!ctx || !canvasEl) return;
             ctx.fillStyle = "#374151";
@@ -4128,7 +4169,7 @@
                 updateMainButtonStates();
                 return;
             } else {
-                if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
+                if ((screenState.showClassificationCover || (screenState.showCoverForWorld > 0 && gameMode === 'levels')) && !screenState.gameActuallyStarted) {
                     modeLeftButton.classList.remove('hidden');
                     modeRightButton.classList.remove('hidden');
                 } else {
@@ -4205,9 +4246,11 @@
                 return;
             }
             if (screenState.showCoverForWorld > 0 && gameMode === 'levels' && !screenState.gameActuallyStarted) {
-                drawWorldCoverImage(screenState.showCoverForWorld);
-                updateMainButtonStates(); 
-                return; 
+                modeLeftButton.classList.remove('hidden');
+                modeRightButton.classList.remove('hidden');
+                drawWorldCover();
+                updateMainButtonStates();
+                return;
             }
 
 
@@ -4988,7 +5031,9 @@
         function drawStarProgress() {
             starProgressContainer.innerHTML = '';
             if (gameMode === 'levels') {
-                const worldToDisplayStarsFor = gameOver ? displayWorld : currentWorld;
+                const worldToDisplayStarsFor = (screenState.showCoverForWorld > 0 && !screenState.gameActuallyStarted)
+                    ? displayWorld
+                    : (gameOver ? displayWorld : currentWorld);
                 const worldLevelStartIndex = (worldToDisplayStarsFor - 1) * LEVELS_PER_WORLD;
                 for (let i = 0; i < LEVELS_PER_WORLD; i++) {
                     const levelIndexInTotal = worldLevelStartIndex + i;
@@ -5130,7 +5175,7 @@ async function startGame(isRestart = false) {
 
                     // Update display variables for the new world's cover screen
                     displayWorld = currentWorld;
-                    displayLevelInWorld = 1; // New world starts at level 1
+                    displayLevelInWorld = currentLevelInWorld;
                     const absoluteDisplayLevelIndex = (displayWorld - 1) * LEVELS_PER_WORLD + (displayLevelInWorld - 1);
                     if (absoluteDisplayLevelIndex >= 0 && absoluteDisplayLevelIndex < TARGET_SCORES_LEVELS.length) {
                         displayTargetScore = TARGET_SCORES_LEVELS[absoluteDisplayLevelIndex];
@@ -5585,7 +5630,7 @@ async function startGame(isRestart = false) {
                 }
 
                 currentWorld = newSelectedWorld;
-                currentLevelInWorld = 1; 
+                currentLevelInWorld = worldCurrentLevels[newSelectedWorld - 1] || 1;
 
                 // Update display variables to reflect the new selection
                 displayWorld = currentWorld;
@@ -5844,9 +5889,14 @@ async function startGame(isRestart = false) {
             const isSpecificInfoOpen = specificInfoPanel && !specificInfoPanel.classList.contains("specific-info-panel-hidden");
 
             if (!isSettingsOpen && !isInfoOpen && !isSpecificInfoOpen) {
+                const key = e.key.toLowerCase();
+                if (screenState.showCoverForWorld && gameMode === 'levels' && !screenState.gameActuallyStarted) {
+                    if (key === 'arrowleft' || key === 'a') { startWorldTransition(-1); e.preventDefault(); return; }
+                    if (key === 'arrowright' || key === 'd') { startWorldTransition(1); e.preventDefault(); return; }
+                    if (key === 'enter') { if (displayWorld <= maxUnlockedWorld) startGame(false); e.preventDefault(); return; }
+                }
                 if (gameOver && e.key !== "Enter" && gameIntervalId === null) return;
                 let newDirectionCmd = null; // Use newDirectionCmd to align with function parameter
-                const key = e.key.toLowerCase();
                 switch (key) {
                     case "arrowup": case "w": newDirectionCmd = "up"; break;
                     case "arrowdown": case "s": newDirectionCmd = "down"; break;
@@ -5854,7 +5904,7 @@ async function startGame(isRestart = false) {
                     case "arrowright": case "d": newDirectionCmd = "right"; break;
                     case "enter": if (gameOver || !gameIntervalId) { startGame(false); } break;
                 }
-                if (newDirectionCmd) { changeDirection(newDirectionCmd); } // Call with newDirectionCmd
+                if (newDirectionCmd) { changeDirection(newDirectionCmd); }
                 if (["arrowup", "arrowdown", "arrowleft", "arrowright", "w", "a", "s", "d"].includes(key)) { e.preventDefault(); }
             } else if (isSpecificInfoOpen) {
                  if (e.key === "Escape") { closeSpecificInfoPanel(); }
@@ -5918,12 +5968,45 @@ async function startGame(isRestart = false) {
                 requestAnimationFrame(draw);
             }
         }
+        function startWorldTransition(dir) {
+            if (worldTransitionStart !== null) return;
+            worldTransitionDir = dir;
+            worldTransitionFrom = displayWorld;
+            displayWorld = ((displayWorld - 1 + dir + TOTAL_WORLDS) % TOTAL_WORLDS) + 1;
+            if (displayWorld <= maxUnlockedWorld) {
+                currentWorld = displayWorld;
+                currentLevelInWorld = worldCurrentLevels[currentWorld - 1] || 1;
+                const absoluteIndex = (currentWorld - 1) * LEVELS_PER_WORLD + (currentLevelInWorld - 1);
+                displayLevelInWorld = currentLevelInWorld;
+                displayTargetScore = TARGET_SCORES_LEVELS[absoluteIndex] || 0;
+                if (!gameIntervalId) {
+                    const cfg = LEVEL_SETTINGS[currentWorld - 1][currentLevelInWorld - 1];
+                    snakeSpeed = cfg.speed;
+                    initialSnakeLength = cfg.initialLength;
+                }
+                saveGameSettings();
+            }
+            screenState.showCoverForWorld = displayWorld;
+            screenState.showWorldCompleteCover = 0;
+            screenState.showLevelCompleteCover = 0;
+            screenState.showDefeatCoverForWorld = 0;
+            screenState.showTimeoutCover = false;
+            screenState.showFreeModeCover = false;
+            updateGameModeUI();
+            worldTransitionStart = performance.now();
+            if (!screenState.gameActuallyStarted) {
+                requestAnimationFrame(draw);
+            }
+        }
+
 
         modeLeftButton.addEventListener("click", () => {
             if (showModeSelect) {
                 startModeTransition(-1);
             } else if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
                 startClassificationTransition(-1);
+            } else if (screenState.showCoverForWorld && gameMode === 'levels' && !screenState.gameActuallyStarted) {
+                startWorldTransition(-1);
             }
             if (areSfxEnabled) playSound('modeSwitch');
         });
@@ -5932,6 +6015,8 @@ async function startGame(isRestart = false) {
                 startModeTransition(1);
             } else if (screenState.showClassificationCover && !screenState.gameActuallyStarted) {
                 startClassificationTransition(1);
+            } else if (screenState.showCoverForWorld && gameMode === 'levels' && !screenState.gameActuallyStarted) {
+                startWorldTransition(1);
             }
             if (areSfxEnabled) playSound('modeSwitch');
         });
@@ -5953,6 +6038,7 @@ async function startGame(isRestart = false) {
             localStorage.setItem('snakeCurrentLevelInWorld', currentLevelInWorld.toString());
             localStorage.setItem('snakeMaxUnlockedWorld', maxUnlockedWorld.toString());
             localStorage.setItem('snakeLevelsProgress', JSON.stringify(levelsProgress));
+            localStorage.setItem('snakeWorldCurrentLevels', JSON.stringify(worldCurrentLevels));
             localStorage.setItem('snakeCurrentMazeLevel', currentMazeLevel.toString());
             localStorage.setItem('snakeMazeLevelStars', JSON.stringify(mazeLevelStars));
             console.log("Configuraciones guardadas en localStorage.");
@@ -6016,8 +6102,39 @@ async function startGame(isRestart = false) {
                     levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
                 }
             } else {
-                 levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+                levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
             }
+
+            const savedWorldCurrentLevels = localStorage.getItem('snakeWorldCurrentLevels');
+            if (savedWorldCurrentLevels) {
+                try {
+                    worldCurrentLevels = JSON.parse(savedWorldCurrentLevels);
+                    if (!Array.isArray(worldCurrentLevels) || worldCurrentLevels.length !== TOTAL_WORLDS) {
+                        console.warn('Invalid world current levels in localStorage, recomputing.');
+                        worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
+                    }
+                } catch (e) {
+                    console.error('Error parsing world current levels from localStorage, recomputing.', e);
+                    worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
+                }
+            } else {
+                worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
+                for (let w = 1; w <= TOTAL_WORLDS; w++) {
+                    const startIdx = (w - 1) * LEVELS_PER_WORLD;
+                    let level = 1;
+                    for (let l = 1; l <= LEVELS_PER_WORLD; l++) {
+                        if (!levelsProgress[startIdx + l - 1]) {
+                            level = l;
+                            break;
+                        }
+                    }
+                    worldCurrentLevels[w - 1] = level;
+                }
+            }
+            if (worldCurrentLevels[currentWorld - 1]) {
+                currentLevelInWorld = worldCurrentLevels[currentWorld - 1];
+            }
+            worldCurrentLevels[currentWorld - 1] = currentLevelInWorld;
 
             const savedMazeLevel = parseInt(localStorage.getItem('snakeCurrentMazeLevel'), 10);
             currentMazeLevel = Number.isFinite(savedMazeLevel) && savedMazeLevel >= 1 ? savedMazeLevel : 1;


### PR DESCRIPTION
## Summary
- keep track of the last level reached for every world
- restore level progress when switching worlds
- store per-world progress in localStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6861158b1db48333be4dd2795bea558e