### PR TITLE
Fix locked world level indicator

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5985,6 +5985,12 @@ async function startGame(isRestart = false) {
                     initialSnakeLength = cfg.initialLength;
                 }
                 saveGameSettings();
+            } else {
+                // Al mostrar la portada de un mundo bloqueado, aseguramos que el
+                // nivel visualizado sea siempre 1 y se muestre su puntuación objetivo
+                displayLevelInWorld = 1;
+                const absoluteIndex = (displayWorld - 1) * LEVELS_PER_WORLD;
+                displayTargetScore = TARGET_SCORES_LEVELS[absoluteIndex] || 0;
             }
             screenState.showCoverForWorld = displayWorld;
             screenState.showWorldCompleteCover = 0;


### PR DESCRIPTION
## Summary
- ensure locked world covers always show level `1`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686122a5d9cc8333aafce241de9d1bb9