### PR TITLE
Add navigation arrows to maze selector

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4243,7 +4243,10 @@
                 updateMainButtonStates();
                 return;
             } else {
-                if ((screenState.showClassificationCover || (screenState.showCoverForWorld > 0 && gameMode === 'levels')) && !screenState.gameActuallyStarted) {
+                if ((screenState.showClassificationCover ||
+                     (screenState.showCoverForWorld > 0 && gameMode === 'levels') ||
+                     (screenState.showMazeCover && gameMode === 'maze')) &&
+                    !screenState.gameActuallyStarted) {
                     modeLeftButton.classList.remove('hidden');
                     modeRightButton.classList.remove('hidden');
                 } else {
@@ -4290,6 +4293,8 @@
                 return;
             }
             if (screenState.showMazeCover && !screenState.gameActuallyStarted) {
+                modeLeftButton.classList.remove('hidden');
+                modeRightButton.classList.remove('hidden');
                 drawMazeCover();
                 updateMainButtonStates();
                 return;


### PR DESCRIPTION
## Summary
- reveal navigation arrows while browsing maze levels
- keep arrows visible when the maze cover is shown so players can change levels

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686135b5d3fc83339fb7601bc488db66