### PR TITLE
Change progress label to Mundo in adventure mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4936,7 +4936,7 @@
                 progressPanel.classList.remove('hidden');
                 starProgressContainer.classList.remove('hidden');
                 highScoreDisplay.classList.add('hidden');
-                progressPanelLeftLabel.textContent = "Nivel:";
+                progressPanelLeftLabel.textContent = "Mundo:";
                 progressPanelLeftValue.textContent = `${displayWorld}.${displayLevelInWorld}`;
                 
                 difficultyLabel.textContent = "Mundo Actual:";


### PR DESCRIPTION
## Summary
- use `Mundo` label for the progress panel when in adventure mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686157f3e1b88333b1a93b222853e423