### PR TITLE
Implement vertical centering of info buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -443,9 +443,10 @@
         }
         
         .control-group {
+            position: relative;
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            justify-content: space-between;
             background-color: #374151;
             border-radius: 8px;
             padding: 8px 12px;
@@ -464,30 +465,33 @@
             margin-bottom: 6px; 
         }
 
-        .control-label { 
-            font-size: 0.7em; 
-            color: #a0aec0; 
-            display: block; 
+        .control-label {
+            font-size: 0.7em;
+            color: #a0aec0;
+            display: block;
             line-height: 1.1;
-            text-align: left; 
-            flex-grow: 1; 
-            margin-right: 8px; 
+            text-align: left;
+            flex-grow: 1;
+            margin-right: 0;
         }
         
         .setting-info-button {
-            background-color: #384152; 
+            position: absolute;
+            top: 50%;
+            right: 12px;
+            transform: translateY(-50%);
+            background-color: #384152;
             border: none;
             border-radius: 8px;
-            padding: 0; 
+            padding: 0;
             cursor: pointer;
             transition: background-color 0.3s ease;
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 44px;  
-            height: 38px; 
+            width: 44px;
+            height: 38px;
             box-sizing: border-box;
-            flex-shrink: 0; 
         }
         .setting-info-button:hover {
             background-color: #4a5568; 
@@ -506,22 +510,22 @@
 
 
         #difficultySelector, #worldsSelector, #mazeLevelSelector, #audioToggleSelector, #skinSelector, #foodSelector, #gameModeSelector {
-            padding: 4px 6px; 
-            font-size: 0.8em; 
-            border: none; 
-            border-radius: 4px; 
-            background-color: transparent; 
-            color: #f5f5f5; 
+            padding: 4px 6px;
+            width: calc(100% - 50px);
+            font-size: 0.8em;
+            border: none;
+            border-radius: 4px;
+            background-color: transparent;
+            color: #f5f5f5;
             font-family: 'Press Start 2P', sans-serif;
-            text-align: left; 
-            width: 100%; 
-            height: 38px; 
+            text-align: left;
+            height: 38px;
             box-sizing: border-box;
-            -moz-appearance: none; 
-            -webkit-appearance: none; 
-            appearance: none; 
+            -moz-appearance: none;
+            -webkit-appearance: none;
+            appearance: none;
             margin-top: 4px;
-            margin-bottom: 4px;
+            margin-bottom: 0;
         }
         
         #difficultySelector option, #worldsSelector option, #mazeLevelSelector option, #audioToggleSelector option, #skinSelector option, #foodSelector option, #gameModeSelector option {
@@ -569,14 +573,14 @@
         #musicVolumeSlider {
             -webkit-appearance: none;
             appearance: none;
-            width: 100%;
+            width: calc(100% - 50px);
             height: 8px; 
             background: #4B5563; 
             border-radius: 5px;
             outline: none;
             transition: opacity .2s;
-             margin-top: 4px;
-            margin-bottom: 4px;
+            margin-top: 4px;
+            margin-bottom: 0;
         }
         #musicVolumeSlider::-webkit-slider-thumb {
             -webkit-appearance: none;
@@ -832,7 +836,7 @@
             }
              #settings-panel .control-group {
                 min-height: 50px;
-                justify-content: center;
+                justify-content: space-between;
                 padding-top: 6px;
                 padding-bottom: 6px;
             }
@@ -846,7 +850,7 @@
              #settings-panel #musicVolumeSlider {
                 font-size: 0.7em;
                 margin-top: 2px;
-                margin-bottom: 2px;
+                margin-bottom: 0;
              }
              #settings-panel .control-label-icon-row { margin-bottom: 0px; }
              .setting-info-button {
@@ -923,7 +927,7 @@
         #settings-panel #gameModeSelector {
             height: 30px;
             margin-top: 2px;
-            margin-bottom: 2px;
+            margin-bottom: 0;
         }
         }
 


### PR DESCRIPTION
## Summary
- ensure settings info button is vertically centered inside each settings block
- make room for the absolute-positioned button by padding the selectors
- anchor selectors to the bottom of their container and size them to avoid overlapping the info button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68624a8c581083338de06418254df742