### PR TITLE
Fix reset data button and adjust selector font

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -513,7 +513,7 @@
         #difficultySelector, #worldsSelector, #mazeLevelSelector, #audioToggleSelector, #skinSelector, #foodSelector, #gameModeSelector {
             padding: 4px 6px;
             width: calc(100% - 50px);
-            font-size: 0.8em;
+            font-size: 0.75em;
             border: none;
             border-radius: 4px;
             background-color: transparent;
@@ -849,7 +849,7 @@
              #settings-panel #foodSelector,
              #settings-panel #gameModeSelector,
              #settings-panel #musicVolumeSlider {
-                font-size: 0.7em;
+                font-size: 0.65em;
                 margin-top: 2px;
                 margin-bottom: 0;
              }
@@ -936,7 +936,7 @@
         }
 
         #resetDataButton {
-            background-color: #b91c1c;
+            background-color: #dc2626;
             color: #f5f5f5;
             border-radius: 8px;
             padding: 10px 15px;
@@ -949,9 +949,11 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            flex-direction: row;
+            height: 40px;
         }
 
-        #resetDataButton:hover { background-color: #dc2626; }
+        #resetDataButton:hover { background-color: #b91c1c; }
 
         #reset-confirmation-panel { z-index: 1003; }
 


### PR DESCRIPTION
## Summary
- ensure reset data button is red and vertically centered
- decrease font size on setting selectors so they're smaller on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6862587555f083338a4be4b813f8e923