### PR TITLE
Refine free mode start button

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -751,7 +751,10 @@
             font-size: 1.4em;
             margin: 0;
         }
-        #close-settings-button, #close-info-button, #close-specific-info-button { 
+        #free-settings-panel .settings-header h2 {
+            font-size: 1.1em;
+        }
+        #close-settings-button, #close-info-button, #close-specific-info-button, #close-free-settings-button {
             background: none;
             border: none;
             color: #f5f5f5;
@@ -760,7 +763,7 @@
             padding: 0;
             line-height: 1;
         }
-        #close-settings-button:hover, #close-info-button:hover, #close-specific-info-button:hover { 
+        #close-settings-button:hover, #close-info-button:hover, #close-specific-info-button:hover, #close-free-settings-button:hover {
             color: #6ee7b7;
         }
         #settings-panel .control-group { 
@@ -987,7 +990,28 @@
             height: 40px;
         }
 
-        #settings-panel #resetDataButton:hover { background-color: #b91c1c; }
+#settings-panel #resetDataButton:hover { background-color: #b91c1c; }
+
+        #free-settings-panel .button-group {
+            justify-content: center;
+        }
+        #free-settings-panel #apply-free-settings {
+            background-color: #4CAF50;
+            color: #f5f5f5;
+            border: none;
+            border-radius: 8px;
+            padding: 10px 15px;
+            font-family: 'Press Start 2P', sans-serif;
+            cursor: pointer;
+            transition: background-color 0.3s ease;
+            width: 100%;
+            font-size: 0.75em;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 40px;
+        }
+        #free-settings-panel #apply-free-settings:hover { background-color: #45a049; }
 
         #reset-confirmation-panel { z-index: 1003; }
 
@@ -1196,8 +1220,11 @@
 
             <div id="free-settings-panel" class="free-settings-panel-hidden">
                 <div class="settings-header">
-                    <h2>Ajustes Modo Libre</h2>
+                    <h2>Personaliza tu juego</h2>
                     <button id="close-free-settings-button" aria-label="Cerrar ajustes">&times;</button>
+                </div>
+                <div class="control-group button-group">
+                    <button id="apply-free-settings">Jugar</button>
                 </div>
                 <div class="control-group">
                     <label class="control-label" for="free-speed-input">Velocidad (ms por paso)</label>
@@ -1267,9 +1294,6 @@
                 <div class="control-group">
                     <label class="control-label" for="free-obstacle-count">Número de obstáculos</label>
                     <input type="number" id="free-obstacle-count" value="5">
-                </div>
-                <div class="control-group">
-                    <button id="apply-free-settings">Guardar</button>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- move free mode "Jugar" button to the top of the panel
- style the "Jugar" button for centered text

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_6862ac1e4bc48333a681175c0538fb8f