### PR TITLE
Improve free mode settings with sliders

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -608,8 +608,8 @@
             -webkit-appearance: none;
             appearance: none;
             width: calc(100% - 50px);
-            height: 8px; 
-            background: #4B5563; 
+            height: 8px;
+            background: #4B5563;
             border-radius: 5px;
             outline: none;
             transition: opacity .2s;
@@ -621,17 +621,81 @@
             appearance: none;
             width: 20px;
             height: 20px;
-            background: #6ee7b7; 
+            background: #6ee7b7;
             cursor: pointer;
             border-radius: 50%;
         }
         #musicVolumeSlider::-moz-range-thumb {
             width: 20px;
             height: 20px;
-            background: #6ee7b7; 
+            background: #6ee7b7;
             cursor: pointer;
             border-radius: 50%;
-            border: none; 
+            border: none;
+        }
+        .settings-range {
+            -webkit-appearance: none;
+            appearance: none;
+            width: calc(100% - 50px);
+            height: 8px;
+            background: #4B5563;
+            border-radius: 5px;
+            outline: none;
+            transition: opacity .2s;
+            margin-top: 4px;
+            margin-bottom: 0;
+        }
+        .settings-range::-webkit-slider-thumb {
+            -webkit-appearance: none;
+            appearance: none;
+            width: 20px;
+            height: 20px;
+            background: #6ee7b7;
+            cursor: pointer;
+            border-radius: 50%;
+        }
+        .settings-range::-moz-range-thumb {
+            width: 20px;
+            height: 20px;
+            background: #6ee7b7;
+            cursor: pointer;
+            border-radius: 50%;
+            border: none;
+        }
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 40px;
+            height: 24px;
+        }
+        .switch input { opacity: 0; width: 0; height: 0; }
+        .slider.round {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #4B5563;
+            transition: .4s;
+            border-radius: 24px;
+        }
+        .slider.round:before {
+            position: absolute;
+            content: "";
+            height: 16px;
+            width: 16px;
+            left: 4px;
+            bottom: 4px;
+            background-color: white;
+            transition: .4s;
+            border-radius: 50%;
+        }
+        .switch input:checked + .slider.round {
+            background-color: #6ee7b7;
+        }
+        .switch input:checked + .slider.round:before {
+            transform: translateX(16px);
         }
 
         #action-buttons-row {
@@ -766,10 +830,14 @@
         #close-settings-button:hover, #close-info-button:hover, #close-specific-info-button:hover, #close-free-settings-button:hover {
             color: #6ee7b7;
         }
-        #settings-panel .control-group { 
-            background-color: #374151; 
-            min-width: unset; 
+        #settings-panel .control-group {
+            background-color: #374151;
+            min-width: unset;
             width:100%;
+        }
+        #free-settings-panel .control-group {
+            flex: none;
+            width: 100%;
         }
 
         /* Estilos para el contenido del panel de información */
@@ -1222,69 +1290,73 @@
                 </div>
                 <div class="control-group" id="apply-free-settings">Jugar</div>
                 <div class="control-group">
-                    <label class="control-label" for="free-speed-input">Velocidad (ms por paso)</label>
-                    <input type="number" id="free-speed-input" value="140">
+                    <label class="control-label" for="free-speed-input">Velocidad (ms por paso): <span id="free-speed-value">140</span></label>
+                    <input type="range" class="settings-range" id="free-speed-input" min="50" max="250" value="140">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-lifespan-input">Duración inicial comida (ms)</label>
-                    <input type="number" id="free-lifespan-input" value="7500">
-                </div>
-                <div class="control-group">
-                    <label class="control-label" for="free-length-input">Longitud inicial</label>
-                    <input type="number" id="free-length-input" value="10">
-                </div>
-                <div class="control-group">
-                    <label class="control-label" for="free-golden-chance-input">Probabilidad comida dorada</label>
-                    <input type="number" step="0.01" id="free-golden-chance-input" value="0.1">
-                </div>
-                <div class="control-group">
-                    <label class="control-label" for="free-golden-lifespan-input">Duración comida dorada (ms)</label>
-                    <input type="number" id="free-golden-lifespan-input" value="4000">
-                </div>
-                <div class="control-group range-group">
-                    <label class="control-label" for="free-lightning-range-min">Intervalo rayos (ms)</label>
-                    <div class="range-inputs">
-                        <input type="number" id="free-lightning-range-min" value="6000">
-                        <input type="number" id="free-lightning-range-max" value="10000">
+                    <div class="control-label-icon-row">
+                        <label class="control-label" for="free-lifespan-input">Duración inicial comida (ms): <span id="free-lifespan-value">7500</span></label>
+                        <label class="switch"><input type="checkbox" id="free-lifespan-toggle" checked><span class="slider round"></span></label>
                     </div>
+                    <input type="range" class="settings-range" id="free-lifespan-input" min="4000" max="8000" value="7500">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-lightning-lifespan">Duración del rayo (ms)</label>
-                    <input type="number" id="free-lightning-lifespan" value="5000">
+                    <label class="control-label" for="free-length-input">Longitud inicial: <span id="free-length-value">10</span></label>
+                    <input type="range" class="settings-range" id="free-length-input" min="3" max="50" value="10">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-yellow-chance">Probabilidad rayo amarillo</label>
-                    <input type="number" step="0.01" id="free-yellow-chance" value="0.75">
-                </div>
-                <div class="control-group">
-                    <label class="control-label" for="free-streak-reduction">Reducción de racha (ms)</label>
-                    <input type="number" id="free-streak-reduction" value="800">
-                </div>
-                <div class="control-group range-group">
-                    <label class="control-label" for="free-false-range-min">Intervalo comida falsa (ms)</label>
-                    <div class="range-inputs">
-                        <input type="number" id="free-false-range-min" value="6000">
-                        <input type="number" id="free-false-range-max" value="10000">
+                    <div class="control-label-icon-row">
+                        <label class="control-label">Comida dorada</label>
+                        <label class="switch"><input type="checkbox" id="free-golden-toggle" checked><span class="slider round"></span></label>
                     </div>
+                    <label class="control-label" for="free-golden-chance-input">Probabilidad: <span id="free-golden-chance-value">0.1</span></label>
+                    <input type="range" class="settings-range" id="free-golden-chance-input" min="0.1" max="1" step="0.05" value="0.1">
+                    <label class="control-label" for="free-golden-lifespan-input">Duración (ms): <span id="free-golden-lifespan-value">4000</span></label>
+                    <input type="range" class="settings-range" id="free-golden-lifespan-input" min="4000" max="8000" value="4000">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-false-lifespan">Duración comida falsa (ms)</label>
-                    <input type="number" id="free-false-lifespan" value="5000">
-                </div>
-                <div class="control-group range-group">
-                    <label class="control-label" for="free-mirror-range-min">Intervalo espejos (ms)</label>
-                    <div class="range-inputs">
-                        <input type="number" id="free-mirror-range-min" value="6000">
-                        <input type="number" id="free-mirror-range-max" value="10000">
+                    <div class="control-label-icon-row">
+                        <label class="control-label">Rayos</label>
+                        <label class="switch"><input type="checkbox" id="free-lightning-toggle" checked><span class="slider round"></span></label>
                     </div>
+                    <label class="control-label" for="free-lightning-range-min">Intervalo mínimo (ms): <span id="free-lightning-range-min-value">4000</span></label>
+                    <input type="range" class="settings-range" id="free-lightning-range-min" min="0" max="4000" value="4000">
+                    <label class="control-label" for="free-lightning-range-max">Intervalo máximo (ms): <span id="free-lightning-range-max-value">16000</span></label>
+                    <input type="range" class="settings-range" id="free-lightning-range-max" min="16000" max="20000" value="16000">
+                    <label class="control-label" for="free-lightning-lifespan">Duración del rayo (ms): <span id="free-lightning-lifespan-value">5000</span></label>
+                    <input type="range" class="settings-range" id="free-lightning-lifespan" min="4000" max="10000" value="5000">
+                    <label class="control-label" for="free-yellow-chance">Probabilidad rayo amarillo: <span id="free-yellow-chance-value">0.75</span></label>
+                    <input type="range" class="settings-range" id="free-yellow-chance" min="0" max="1" step="0.05" value="0.75">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-mirror-lifespan">Duración del espejo (ms)</label>
-                    <input type="number" id="free-mirror-lifespan" value="5000">
+                    <label class="control-label">Racha</label>
+                    <label class="switch"><input type="checkbox" id="free-streak-toggle" checked><span class="slider round"></span></label>
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-mirror-effect">Duración efecto espejo (ms)</label>
-                    <input type="number" id="free-mirror-effect" value="3000">
+                    <div class="control-label-icon-row">
+                        <label class="control-label">Comida falsa</label>
+                        <label class="switch"><input type="checkbox" id="free-false-toggle" checked><span class="slider round"></span></label>
+                    </div>
+                    <label class="control-label" for="free-false-range-min">Intervalo mínimo (ms): <span id="free-false-range-min-value">4000</span></label>
+                    <input type="range" class="settings-range" id="free-false-range-min" min="0" max="4000" value="4000">
+                    <label class="control-label" for="free-false-range-max">Intervalo máximo (ms): <span id="free-false-range-max-value">16000</span></label>
+                    <input type="range" class="settings-range" id="free-false-range-max" min="16000" max="20000" value="16000">
+                    <label class="control-label" for="free-false-lifespan">Duración comida falsa (ms): <span id="free-false-lifespan-value">5000</span></label>
+                    <input type="range" class="settings-range" id="free-false-lifespan" min="4000" max="10000" value="5000">
+                </div>
+                <div class="control-group">
+                    <div class="control-label-icon-row">
+                        <label class="control-label">Espejos</label>
+                        <label class="switch"><input type="checkbox" id="free-mirror-toggle" checked><span class="slider round"></span></label>
+                    </div>
+                    <label class="control-label" for="free-mirror-range-min">Intervalo mínimo (ms): <span id="free-mirror-range-min-value">4000</span></label>
+                    <input type="range" class="settings-range" id="free-mirror-range-min" min="0" max="4000" value="4000">
+                    <label class="control-label" for="free-mirror-range-max">Intervalo máximo (ms): <span id="free-mirror-range-max-value">16000</span></label>
+                    <input type="range" class="settings-range" id="free-mirror-range-max" min="16000" max="20000" value="16000">
+                    <label class="control-label" for="free-mirror-lifespan">Duración del espejo (ms): <span id="free-mirror-lifespan-value">5000</span></label>
+                    <input type="range" class="settings-range" id="free-mirror-lifespan" min="4000" max="10000" value="5000">
+                    <label class="control-label" for="free-mirror-effect">Duración efecto espejo (ms): <span id="free-mirror-effect-value">3000</span></label>
+                    <input type="range" class="settings-range" id="free-mirror-effect" min="3000" max="10000" value="3000">
                 </div>
                 <div class="control-group">
                     <label class="control-label" for="free-obstacle-count">Número de obstáculos</label>
@@ -1502,23 +1574,83 @@
         const closeSpecificInfoButton = document.getElementById("close-specific-info-button");
 
         const freeSpeedInput = document.getElementById("free-speed-input");
+        const freeSpeedValue = document.getElementById("free-speed-value");
         const freeLifespanInput = document.getElementById("free-lifespan-input");
+        const freeLifespanValue = document.getElementById("free-lifespan-value");
+        const freeLifespanToggle = document.getElementById("free-lifespan-toggle");
         const freeLengthInput = document.getElementById("free-length-input");
+        const freeLengthValue = document.getElementById("free-length-value");
         const freeGoldenChanceInput = document.getElementById("free-golden-chance-input");
+        const freeGoldenChanceValue = document.getElementById("free-golden-chance-value");
         const freeGoldenLifespanInput = document.getElementById("free-golden-lifespan-input");
+        const freeGoldenLifespanValue = document.getElementById("free-golden-lifespan-value");
+        const freeGoldenToggle = document.getElementById("free-golden-toggle");
         const freeLightningRangeMin = document.getElementById("free-lightning-range-min");
+        const freeLightningRangeMinValue = document.getElementById("free-lightning-range-min-value");
         const freeLightningRangeMax = document.getElementById("free-lightning-range-max");
+        const freeLightningRangeMaxValue = document.getElementById("free-lightning-range-max-value");
         const freeLightningLifespan = document.getElementById("free-lightning-lifespan");
+        const freeLightningLifespanValue = document.getElementById("free-lightning-lifespan-value");
         const freeYellowChance = document.getElementById("free-yellow-chance");
-        const freeStreakReduction = document.getElementById("free-streak-reduction");
+        const freeYellowChanceValue = document.getElementById("free-yellow-chance-value");
+        const freeLightningToggle = document.getElementById("free-lightning-toggle");
+        const freeStreakToggle = document.getElementById("free-streak-toggle");
         const freeFalseRangeMin = document.getElementById("free-false-range-min");
+        const freeFalseRangeMinValue = document.getElementById("free-false-range-min-value");
         const freeFalseRangeMax = document.getElementById("free-false-range-max");
+        const freeFalseRangeMaxValue = document.getElementById("free-false-range-max-value");
         const freeFalseLifespan = document.getElementById("free-false-lifespan");
+        const freeFalseLifespanValue = document.getElementById("free-false-lifespan-value");
+        const freeFalseToggle = document.getElementById("free-false-toggle");
         const freeMirrorRangeMin = document.getElementById("free-mirror-range-min");
+        const freeMirrorRangeMinValue = document.getElementById("free-mirror-range-min-value");
         const freeMirrorRangeMax = document.getElementById("free-mirror-range-max");
+        const freeMirrorRangeMaxValue = document.getElementById("free-mirror-range-max-value");
         const freeMirrorLifespan = document.getElementById("free-mirror-lifespan");
+        const freeMirrorLifespanValue = document.getElementById("free-mirror-lifespan-value");
         const freeMirrorEffect = document.getElementById("free-mirror-effect");
+        const freeMirrorEffectValue = document.getElementById("free-mirror-effect-value");
+        const freeMirrorToggle = document.getElementById("free-mirror-toggle");
         const freeObstacleCount = document.getElementById("free-obstacle-count");
+
+        function setupSlider(slider, display) {
+            if (slider && display) {
+                slider.addEventListener('input', () => { display.textContent = slider.value; });
+                display.textContent = slider.value;
+            }
+        }
+
+        function setupToggle(toggle, inputs) {
+            if (!toggle) return;
+            const arr = Array.isArray(inputs) ? inputs : [inputs];
+            toggle.addEventListener('change', () => {
+                arr.forEach(inp => { if (inp) inp.disabled = !toggle.checked; });
+            });
+            arr.forEach(inp => { if (inp) inp.disabled = !toggle.checked; });
+        }
+
+        setupSlider(freeSpeedInput, freeSpeedValue);
+        setupSlider(freeLifespanInput, freeLifespanValue);
+        setupSlider(freeLengthInput, freeLengthValue);
+        setupSlider(freeGoldenChanceInput, freeGoldenChanceValue);
+        setupSlider(freeGoldenLifespanInput, freeGoldenLifespanValue);
+        setupSlider(freeLightningRangeMin, freeLightningRangeMinValue);
+        setupSlider(freeLightningRangeMax, freeLightningRangeMaxValue);
+        setupSlider(freeLightningLifespan, freeLightningLifespanValue);
+        setupSlider(freeYellowChance, freeYellowChanceValue);
+        setupSlider(freeFalseRangeMin, freeFalseRangeMinValue);
+        setupSlider(freeFalseRangeMax, freeFalseRangeMaxValue);
+        setupSlider(freeFalseLifespan, freeFalseLifespanValue);
+        setupSlider(freeMirrorRangeMin, freeMirrorRangeMinValue);
+        setupSlider(freeMirrorRangeMax, freeMirrorRangeMaxValue);
+        setupSlider(freeMirrorLifespan, freeMirrorLifespanValue);
+        setupSlider(freeMirrorEffect, freeMirrorEffectValue);
+
+        setupToggle(freeLifespanToggle, freeLifespanInput);
+        setupToggle(freeGoldenToggle, [freeGoldenChanceInput, freeGoldenLifespanInput]);
+        setupToggle(freeLightningToggle, [freeLightningRangeMin, freeLightningRangeMax, freeLightningLifespan, freeYellowChance]);
+        setupToggle(freeFalseToggle, [freeFalseRangeMin, freeFalseRangeMax, freeFalseLifespan]);
+        setupToggle(freeMirrorToggle, [freeMirrorRangeMin, freeMirrorRangeMax, freeMirrorLifespan, freeMirrorEffect]);
 
 
         // --- INICIO: Declaración de Objetos Image ---
@@ -2068,13 +2200,13 @@
             initialLength: 10,
             goldenFoodChance: 0.1,
             goldenFoodLifespan: 4000,
-            lightningSpawnRange: [6000, 10000],
+            lightningSpawnRange: [4000, 16000],
             lightningLifespan: 5000,
             yellowLightningChance: 0.75,
             streakReduction: 800,
-            falseFoodSpawnRange: [6000, 10000],
+            falseFoodSpawnRange: [4000, 16000],
             falseFoodLifespan: 5000,
-            mirrorSpawnRange: [6000, 10000],
+            mirrorSpawnRange: [4000, 16000],
             mirrorLifespan: 5000,
             mirrorEffectDuration: 3000,
             obstacleCount: 5
@@ -2823,39 +2955,92 @@
 
         function populateFreeSettingsInputs() {
             freeSpeedInput.value = freeModeSettings.speed;
-            freeLifespanInput.value = freeModeSettings.initialLifespan;
+            if (freeSpeedValue) freeSpeedValue.textContent = freeSpeedInput.value;
+
+            freeLifespanToggle.checked = freeModeSettings.initialLifespan > 0;
+            freeLifespanInput.value = freeModeSettings.initialLifespan > 0 ? freeModeSettings.initialLifespan : 4000;
+            if (freeLifespanValue) freeLifespanValue.textContent = freeLifespanInput.value;
+            freeLifespanInput.disabled = !freeLifespanToggle.checked;
+
             freeLengthInput.value = freeModeSettings.initialLength;
-            freeGoldenChanceInput.value = freeModeSettings.goldenFoodChance;
+            if (freeLengthValue) freeLengthValue.textContent = freeLengthInput.value;
+
+            freeGoldenToggle.checked = freeModeSettings.goldenFoodChance > 0;
+            freeGoldenChanceInput.value = freeModeSettings.goldenFoodChance > 0 ? freeModeSettings.goldenFoodChance : 0.1;
+            if (freeGoldenChanceValue) freeGoldenChanceValue.textContent = freeGoldenChanceInput.value;
             freeGoldenLifespanInput.value = freeModeSettings.goldenFoodLifespan;
-            freeLightningRangeMin.value = freeModeSettings.lightningSpawnRange[0];
-            freeLightningRangeMax.value = freeModeSettings.lightningSpawnRange[1];
+            if (freeGoldenLifespanValue) freeGoldenLifespanValue.textContent = freeGoldenLifespanInput.value;
+            freeGoldenChanceInput.disabled = freeGoldenLifespanInput.disabled = !freeGoldenToggle.checked;
+
+            freeLightningToggle.checked = !!freeModeSettings.lightningSpawnRange;
+            if (freeModeSettings.lightningSpawnRange) {
+                freeLightningRangeMin.value = freeModeSettings.lightningSpawnRange[0];
+                freeLightningRangeMax.value = freeModeSettings.lightningSpawnRange[1];
+            } else {
+                freeLightningRangeMin.value = 0;
+                freeLightningRangeMax.value = 16000;
+            }
+            if (freeLightningRangeMinValue) freeLightningRangeMinValue.textContent = freeLightningRangeMin.value;
+            if (freeLightningRangeMaxValue) freeLightningRangeMaxValue.textContent = freeLightningRangeMax.value;
+            freeLightningRangeMin.disabled = freeLightningRangeMax.disabled = !freeLightningToggle.checked;
             freeLightningLifespan.value = freeModeSettings.lightningLifespan;
+            if (freeLightningLifespanValue) freeLightningLifespanValue.textContent = freeLightningLifespan.value;
+            freeLightningLifespan.disabled = !freeLightningToggle.checked;
             freeYellowChance.value = freeModeSettings.yellowLightningChance;
-            freeStreakReduction.value = freeModeSettings.streakReduction;
-            freeFalseRangeMin.value = freeModeSettings.falseFoodSpawnRange[0];
-            freeFalseRangeMax.value = freeModeSettings.falseFoodSpawnRange[1];
+            if (freeYellowChanceValue) freeYellowChanceValue.textContent = freeYellowChance.value;
+            freeYellowChance.disabled = !freeLightningToggle.checked;
+
+            freeStreakToggle.checked = freeModeSettings.streakReduction > 0;
+
+            freeFalseToggle.checked = !!freeModeSettings.falseFoodSpawnRange;
+            if (freeModeSettings.falseFoodSpawnRange) {
+                freeFalseRangeMin.value = freeModeSettings.falseFoodSpawnRange[0];
+                freeFalseRangeMax.value = freeModeSettings.falseFoodSpawnRange[1];
+            } else {
+                freeFalseRangeMin.value = 0;
+                freeFalseRangeMax.value = 16000;
+            }
+            if (freeFalseRangeMinValue) freeFalseRangeMinValue.textContent = freeFalseRangeMin.value;
+            if (freeFalseRangeMaxValue) freeFalseRangeMaxValue.textContent = freeFalseRangeMax.value;
+            freeFalseRangeMin.disabled = freeFalseRangeMax.disabled = !freeFalseToggle.checked;
             freeFalseLifespan.value = freeModeSettings.falseFoodLifespan;
-            freeMirrorRangeMin.value = freeModeSettings.mirrorSpawnRange[0];
-            freeMirrorRangeMax.value = freeModeSettings.mirrorSpawnRange[1];
+            if (freeFalseLifespanValue) freeFalseLifespanValue.textContent = freeFalseLifespan.value;
+            freeFalseLifespan.disabled = !freeFalseToggle.checked;
+
+            freeMirrorToggle.checked = !!freeModeSettings.mirrorSpawnRange;
+            if (freeModeSettings.mirrorSpawnRange) {
+                freeMirrorRangeMin.value = freeModeSettings.mirrorSpawnRange[0];
+                freeMirrorRangeMax.value = freeModeSettings.mirrorSpawnRange[1];
+            } else {
+                freeMirrorRangeMin.value = 0;
+                freeMirrorRangeMax.value = 16000;
+            }
+            if (freeMirrorRangeMinValue) freeMirrorRangeMinValue.textContent = freeMirrorRangeMin.value;
+            if (freeMirrorRangeMaxValue) freeMirrorRangeMaxValue.textContent = freeMirrorRangeMax.value;
+            freeMirrorRangeMin.disabled = freeMirrorRangeMax.disabled = !freeMirrorToggle.checked;
             freeMirrorLifespan.value = freeModeSettings.mirrorLifespan;
+            if (freeMirrorLifespanValue) freeMirrorLifespanValue.textContent = freeMirrorLifespan.value;
             freeMirrorEffect.value = freeModeSettings.mirrorEffectDuration;
+            if (freeMirrorEffectValue) freeMirrorEffectValue.textContent = freeMirrorEffect.value;
+            freeMirrorLifespan.disabled = freeMirrorEffect.disabled = !freeMirrorToggle.checked;
+
             freeObstacleCount.value = freeModeSettings.obstacleCount;
         }
 
         function applyFreeSettings() {
             freeModeSettings = {
                 speed: parseInt(freeSpeedInput.value, 10),
-                initialLifespan: parseInt(freeLifespanInput.value, 10),
+                initialLifespan: freeLifespanToggle.checked ? parseInt(freeLifespanInput.value, 10) : 0,
                 initialLength: parseInt(freeLengthInput.value, 10),
-                goldenFoodChance: parseFloat(freeGoldenChanceInput.value),
+                goldenFoodChance: freeGoldenToggle.checked ? parseFloat(freeGoldenChanceInput.value) : 0,
                 goldenFoodLifespan: parseInt(freeGoldenLifespanInput.value, 10),
-                lightningSpawnRange: [parseInt(freeLightningRangeMin.value, 10), parseInt(freeLightningRangeMax.value, 10)],
+                lightningSpawnRange: freeLightningToggle.checked ? [parseInt(freeLightningRangeMin.value, 10), parseInt(freeLightningRangeMax.value, 10)] : null,
                 lightningLifespan: parseInt(freeLightningLifespan.value, 10),
                 yellowLightningChance: parseFloat(freeYellowChance.value),
-                streakReduction: parseInt(freeStreakReduction.value, 10),
-                falseFoodSpawnRange: [parseInt(freeFalseRangeMin.value, 10), parseInt(freeFalseRangeMax.value, 10)],
+                streakReduction: freeStreakToggle.checked ? 800 : 0,
+                falseFoodSpawnRange: freeFalseToggle.checked ? [parseInt(freeFalseRangeMin.value, 10), parseInt(freeFalseRangeMax.value, 10)] : null,
                 falseFoodLifespan: parseInt(freeFalseLifespan.value, 10),
-                mirrorSpawnRange: [parseInt(freeMirrorRangeMin.value, 10), parseInt(freeMirrorRangeMax.value, 10)],
+                mirrorSpawnRange: freeMirrorToggle.checked ? [parseInt(freeMirrorRangeMin.value, 10), parseInt(freeMirrorRangeMax.value, 10)] : null,
                 mirrorLifespan: parseInt(freeMirrorLifespan.value, 10),
                 mirrorEffectDuration: parseInt(freeMirrorEffect.value, 10),
                 obstacleCount: parseInt(freeObstacleCount.value, 10)
@@ -3464,7 +3649,8 @@
             let range;
             if (gameMode === 'classification' || gameMode === 'freeMode') {
                 const cfg = (gameMode === 'classification') ? (DIFFICULTY_SETTINGS[difficultySelector.value] || {}) : freeModeSettings;
-                range = cfg.falseFoodSpawnRange || [5000, 7000];
+                if (!cfg.falseFoodSpawnRange) return;
+                range = cfg.falseFoodSpawnRange;
             } else if (gameMode === "levels" && (currentWorld === 7 || currentWorld === 8 || currentWorld === 10)) {
                 if (currentWorld === 7) {
                     range = FALSE_FOOD_SPAWN_RANGES_WORLD4[currentLevelInWorld - 1] || [5000,8000];
@@ -3625,7 +3811,8 @@
             let range;
             if (gameMode === "classification" || gameMode === 'freeMode') {
                 const cfg = (gameMode === 'classification') ? (DIFFICULTY_SETTINGS[difficultySelector.value] || {}) : freeModeSettings;
-                range = cfg.lightningSpawnRange || [5000, 7000];
+                if (!cfg.lightningSpawnRange) return;
+                range = cfg.lightningSpawnRange;
             } else if (gameMode === "levels" && (currentWorld === 3 || currentWorld === 4 || currentWorld === 9 || currentWorld === 10)) {
                 if (currentWorld === 3) {
                     range = LIGHTNING_SPAWN_RANGES_WORLD6[currentLevelInWorld - 1] || [5000, 7000];
@@ -3755,7 +3942,8 @@
             let range;
             if (gameMode === 'classification' || gameMode === 'freeMode') {
                 const cfg = (gameMode === 'classification') ? (DIFFICULTY_SETTINGS[difficultySelector.value] || {}) : freeModeSettings;
-                range = cfg.mirrorSpawnRange || [5000, 7000];
+                if (!cfg.mirrorSpawnRange) return;
+                range = cfg.mirrorSpawnRange;
             } else if (gameMode === "levels" && (currentWorld === 9 || currentWorld === 10)) {
                 range = currentWorld === 9 ?
                     (MIRROR_SPAWN_RANGES_WORLD7[currentLevelInWorld - 1] || [5000, 7000]) :


### PR DESCRIPTION
## Summary
- add reusable slider/toggle styles
- allow free mode parameters to be configured with sliders and toggle switches
- update default ranges
- disable spawns when toggles off
- fix free settings container to auto-resize

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6862b9ddb2c8833385abf04941d80f62