### PR TITLE
Improve free mode speed slider UX

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1293,8 +1293,8 @@
                 </div>
                 <div class="control-group" id="apply-free-settings">Jugar</div>
                 <div class="control-group">
-                    <label class="control-label" for="free-speed-input">Velocidad (%): <span id="free-speed-value">100</span>%</label>
-                    <input type="range" class="settings-range" id="free-speed-input" min="50" max="200" step="5" value="100">
+                    <label class="control-label" for="free-speed-input">Velocidad: <span id="free-speed-value">67</span>%</label>
+                    <input type="range" class="settings-range" id="free-speed-input" min="0" max="100" step="5" value="67">
                 </div>
                 <div class="control-group">
                     <label class="control-label" for="free-length-input">Tamaño inicial: <span id="free-length-value">10</span></label>
@@ -2957,7 +2957,8 @@ function setupSlider(slider, display) {
         }
 
         function populateFreeSettingsInputs() {
-            freeSpeedInput.value = Math.round((freeModeSettings.speed / FREE_MODE_DEFAULTS.speed) * 100);
+            const speedFactor = freeModeSettings.speed / FREE_MODE_DEFAULTS.speed;
+            freeSpeedInput.value = Math.round(((2 - speedFactor) / 1.5) * 100);
             if (freeSpeedValue) freeSpeedValue.textContent = freeSpeedInput.value;
 
             freeLifespanToggle.checked = freeModeSettings.initialLifespan > 0;
@@ -3029,7 +3030,7 @@ function setupSlider(slider, display) {
 
         function applyFreeSettings() {
             freeModeSettings = {
-                speed: parseFloat(freeSpeedInput.value) / 100 * FREE_MODE_DEFAULTS.speed,
+                speed: (2 - (parseFloat(freeSpeedInput.value) / 100) * 1.5) * FREE_MODE_DEFAULTS.speed,
                 initialLifespan: freeLifespanToggle.checked ? parseFloat(freeLifespanInput.value) * 1000 : 0,
                 initialLength: parseInt(freeLengthInput.value, 10),
                 goldenFoodChance: freeGoldenToggle.checked ? parseFloat(freeGoldenChanceInput.value) / 100 : 0,


### PR DESCRIPTION
## Summary
- make the free mode speed slider run 0–100 with higher values meaning faster
- remove the redundant `(%)` text on the label

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68633b2d9cec8333bd0b35a5282e1402