### PR TITLE
Adjust free mode label style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -843,6 +843,13 @@
             width: 100%;
         }
 
+        /* Primer título/texto en cada contenedor del modo libre */
+        #free-settings-panel .control-group > label.control-label:first-child,
+        #free-settings-panel .control-group > .control-label-icon-row:first-child > label.control-label {
+            font-size: 0.85em;
+            color: #F3F3F3;
+        }
+
         /* Estilos para el contenido del panel de información */
         #info-panel-content, #specific-info-content {
             line-height: 1.6;


### PR DESCRIPTION
## Summary
- tweak free mode controls style so the first label in each group is larger and white

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6863496fc210833382778b3afc1ebb2c