### PR TITLE
Improve obstacle customization slider

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1370,8 +1370,8 @@
                     <input type="range" class="settings-range" id="free-mirror-effect" min="3" max="10" step="0.5" value="3">
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="free-obstacle-count">Número de obstáculos</label>
-                    <input type="number" id="free-obstacle-count" value="5">
+                    <label class="control-label" for="free-obstacle-count">Número de obstáculos: <span id="free-obstacle-count-value">5</span></label>
+                    <input type="range" class="settings-range" id="free-obstacle-count" min="0" max="50" value="5">
                 </div>
             </div>
 
@@ -1617,6 +1617,7 @@
         const freeMirrorEffectValue = document.getElementById("free-mirror-effect-value");
         const freeMirrorToggle = document.getElementById("free-mirror-toggle");
         const freeObstacleCount = document.getElementById("free-obstacle-count");
+        const freeObstacleCountValue = document.getElementById("free-obstacle-count-value");
 
 function setupSlider(slider, display) {
     if (slider && display) {
@@ -1663,6 +1664,7 @@ function setupSlider(slider, display) {
         setupRangeSlider(freeMirrorRange, freeMirrorRangeDisplay);
         setupSlider(freeMirrorLifespan, freeMirrorLifespanValue);
         setupSlider(freeMirrorEffect, freeMirrorEffectValue);
+        setupSlider(freeObstacleCount, freeObstacleCountValue);
 
         setupToggle(freeLifespanToggle, freeLifespanInput);
         setupToggle(freeGoldenToggle, [freeGoldenChanceInput, freeGoldenLifespanInput]);
@@ -3042,6 +3044,7 @@ function setupSlider(slider, display) {
             freeMirrorLifespan.disabled = freeMirrorEffect.disabled = !freeMirrorToggle.checked;
 
             freeObstacleCount.value = freeModeSettings.obstacleCount;
+            if (freeObstacleCountValue) freeObstacleCountValue.textContent = freeObstacleCount.value;
 
             [
                 freeLifespanToggle,


### PR DESCRIPTION
## Summary
- replace number input for obstacle count with range slider
- display selected value using `free-obstacle-count-value`
- handle slider in JavaScript when opening settings and applying values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68634cf4cfac8333bdadb2d0087d9692