### PR TITLE
Mejora visual del menú de personalización en móvil

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -951,8 +951,13 @@
                 width: calc(100% - 20px);
                 padding: 20px;
             }
-            .settings-header h2, .info-header h2, .specific-info-header h2 { 
+            .settings-header h2, .info-header h2, .specific-info-header h2 {
                 font-size: 1.1em;
+            }
+            #free-settings-panel .settings-header h2 {
+                font-size: 0.95em;
+                text-align: left;
+                white-space: nowrap;
             }
              #settings-panel .control-group {
                 min-height: 50px;


### PR DESCRIPTION
## Summary
- adjust mobile styles for the Free Mode settings header so the title fits on one line and aligns left

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6863537ddc8c83338159c952bfd88c19