### PR TITLE
Update splash buttons to keep screen

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7129,14 +7129,10 @@ async function startGame(isRestart = false) {
             }
 
             attachSplashButtonEvents(splashInfoButtonEl, () => {
-                if (splashScreen) splashScreen.classList.add('hidden');
-                if (gameContainer) gameContainer.classList.remove('hidden');
                 openInfoPanel();
             });
 
             attachSplashButtonEvents(splashSettingsButtonEl, () => {
-                if (splashScreen) splashScreen.classList.add('hidden');
-                if (gameContainer) gameContainer.classList.remove('hidden');
                 openSettingsPanel();
             });
 


### PR DESCRIPTION
## Summary
- prevent info & settings buttons on splash from hiding the splash screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686370fc488c8333b5b38da6413ee4f3