### PR TITLE
Add player name selector in splash settings

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -809,7 +809,7 @@
             padding: 25px;
             border-radius: 12px;
             box-shadow: 0 10px 30px rgba(0,0,0,0.6);
-            z-index: 1001;
+            z-index: 2100;
             width: 100%;
             max-width: var(--game-max-width);
             display: flex;
@@ -830,7 +830,7 @@
         }
 
          #specific-info-panel {
-            z-index: 1002; 
+            z-index: 2101;
         }
         .settings-header, .info-header, .specific-info-header, .reset-header {
             display: flex;
@@ -1135,7 +1135,7 @@
         }
         #free-settings-panel #apply-free-settings-bottom:hover { background-color: #45a049; }
 
-        #reset-confirmation-panel { z-index: 1003; }
+        #reset-confirmation-panel { z-index: 2102; }
 
         .reset-panel-hidden { display: none !important; }
 
@@ -1253,6 +1253,20 @@
                 <div class="settings-header">
                     <h2>Configuración</h2>
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
+                </div>
+                <div id="player-name-control-group" class="control-group hidden">
+                    <div class="control-label-icon-row">
+                        <label class="control-label" for="playerNameSelector">Jugador:</label>
+                        <button id="add-player-name-button" class="setting-info-button" aria-label="Añadir nuevo nombre">
+                            <svg class="setting-info-icon" viewBox="0 0 20 20" fill="currentColor">
+                                <path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M10 5v10M5 10h10" />
+                            </svg>
+                        </button>
+                    </div>
+                    <select id="playerNameSelector">
+                        <option value="Snake" selected>Snake</option>
+                        <option value="GamiSnake">GamiSnake</option>
+                    </select>
                 </div>
                 <div class="control-group" id="game-mode-control-group">
                     <div class="control-label-icon-row">
@@ -1581,6 +1595,9 @@
         const skinSelector = document.getElementById("skinSelector");
         const foodSelector = document.getElementById("foodSelector");
         const gameModeSelector = document.getElementById("gameModeSelector");
+        const playerNameSelector = document.getElementById("playerNameSelector");
+        const addPlayerNameButton = document.getElementById("add-player-name-button");
+        const playerNameControlGroup = document.getElementById("player-name-control-group");
         const difficultyControlGroup = document.getElementById("difficulty-control-group");
         const audioControlGroup = document.getElementById("audio-control-group");
         const skinControlGroup = document.getElementById("skin-control-group");
@@ -2185,6 +2202,8 @@ function setupSlider(slider, display) {
             }
         };
         let currentSkin = 'snake';
+        let playerNames = ['Snake', 'GamiSnake'];
+        let currentPlayerName = 'Snake';
         // --- Fin Configuración de Jugadores ---
 
         // --- Configuración de Comestibles ---
@@ -2248,6 +2267,7 @@ function setupSlider(slider, display) {
         let modeSelectIndex = 0;
         const MODE_SELECT_ORDER = ['intro', 'levels', 'freeMode', 'classification', 'maze'];
         let showModeSelect = false;
+        let panelOpenedFromSplash = false;
         let introOptionAvailable = true; // controls visibility of the intro slide
         const MODE_TRANSITION_DURATION = 300; // ms
         let modeTransitionStart = null;
@@ -2937,6 +2957,20 @@ function setupSlider(slider, display) {
 
         function openSettingsPanel() {
             togglePanel(settingsPanel, settingsPanel, true);
+            // Show or hide certain settings when accessed from the splash screen
+            gameModeControlGroup.classList.remove('hidden');
+            difficultyControlGroup.classList.remove('hidden');
+            skinControlGroup.classList.remove('hidden');
+            foodControlGroup.classList.remove('hidden');
+            playerNameControlGroup.classList.add('hidden');
+
+            if (panelOpenedFromSplash) {
+                playerNameControlGroup.classList.remove('hidden');
+                gameModeControlGroup.classList.add('hidden');
+                difficultyControlGroup.classList.add('hidden');
+                skinControlGroup.classList.add('hidden');
+                foodControlGroup.classList.add('hidden');
+            }
             if (gameOver && !gameIntervalId) { // Game is over and not running
                 if (ctx && canvasEl) {
                     ctx.fillStyle = "#374151";
@@ -3014,6 +3048,11 @@ function setupSlider(slider, display) {
             setTimeout(() => { // Ensure buttons are updated after panel animation
                 updateMainButtonStates();
             }, 0);
+
+            if (panelOpenedFromSplash && splashScreen && !splashScreen.classList.contains('hidden')) {
+                if (gameContainer) gameContainer.classList.add('hidden');
+                panelOpenedFromSplash = false;
+            }
         }
 
         function openFreeSettingsPanel() {
@@ -3193,6 +3232,11 @@ function setupSlider(slider, display) {
             setTimeout(() => {
                 updateMainButtonStates();
             }, 0);
+
+            if (panelOpenedFromSplash && splashScreen && !splashScreen.classList.contains('hidden')) {
+                if (gameContainer) gameContainer.classList.add('hidden');
+                panelOpenedFromSplash = false;
+            }
         }
         
         configButton.addEventListener('click', () => {
@@ -6336,6 +6380,27 @@ async function startGame(isRestart = false) {
             saveGameSettings();
         });
 
+        playerNameSelector.addEventListener('change', function() {
+            currentPlayerName = this.value;
+            saveGameSettings();
+        });
+
+        if (addPlayerNameButton) {
+            addPlayerNameButton.addEventListener('click', function() {
+                const newName = prompt('Introduce un nuevo nombre de jugador:');
+                if (newName) {
+                    playerNames.push(newName);
+                    const opt = document.createElement('option');
+                    opt.value = newName;
+                    opt.textContent = newName;
+                    playerNameSelector.appendChild(opt);
+                    playerNameSelector.value = newName;
+                    currentPlayerName = newName;
+                    saveGameSettings();
+                }
+            });
+        }
+
         difficultySelector.addEventListener('change', function() {
             const oldIndex = classificationDifficultyIndex;
             difficulty = this.value;
@@ -6821,6 +6886,8 @@ async function startGame(isRestart = false) {
             localStorage.setItem('snakeGameDifficulty', difficultySelector.value);
             localStorage.setItem('snakeGameSkin', skinSelector.value);
             localStorage.setItem('snakeGameFood', foodSelector.value);
+            localStorage.setItem('snakeGamePlayerName', playerNameSelector.value);
+            localStorage.setItem('snakePlayerNames', JSON.stringify(playerNames));
             localStorage.setItem('snakeGameAudioGeneral', audioToggleSelector.value);
             localStorage.setItem('snakeGameMusicVolume', musicVolumeSlider.value);
             localStorage.setItem('snakeGameMode', gameModeSelector.value);
@@ -6846,6 +6913,31 @@ async function startGame(isRestart = false) {
 
             const savedSkin = localStorage.getItem('snakeGameSkin');
             if (savedSkin) skinSelector.value = savedSkin;
+
+            const savedPlayerNames = localStorage.getItem('snakePlayerNames');
+            if (savedPlayerNames) {
+                try {
+                    const parsed = JSON.parse(savedPlayerNames);
+                    if (Array.isArray(parsed) && parsed.length > 0) playerNames = parsed;
+                } catch (e) {
+                    console.error('Error parsing player names from localStorage', e);
+                    playerNames = ['Snake', 'GamiSnake'];
+                }
+            }
+            playerNameSelector.innerHTML = '';
+            playerNames.forEach(name => {
+                const opt = document.createElement('option');
+                opt.value = name;
+                opt.textContent = name;
+                playerNameSelector.appendChild(opt);
+            });
+            const savedPlayerName = localStorage.getItem('snakeGamePlayerName');
+            if (savedPlayerName && playerNames.includes(savedPlayerName)) {
+                playerNameSelector.value = savedPlayerName;
+                currentPlayerName = savedPlayerName;
+            } else {
+                currentPlayerName = playerNameSelector.value;
+            }
 
             const savedFood = localStorage.getItem('snakeGameFood');
             if (savedFood) foodSelector.value = savedFood;
@@ -6980,6 +7072,7 @@ async function startGame(isRestart = false) {
             initialSnakeLength = cfg.initialLength;
             currentSkin = skinSelector.value;
             currentFood = foodSelector.value;
+            currentPlayerName = playerNameSelector.value;
             
             isMusicEnabled = (audioToggleSelector.value === 'all');
             areSfxEnabled = (audioToggleSelector.value === 'all' || audioToggleSelector.value === 'sfx_only');
@@ -7129,13 +7222,13 @@ async function startGame(isRestart = false) {
             }
 
             attachSplashButtonEvents(splashInfoButtonEl, () => {
-                if (splashScreen) splashScreen.classList.add('hidden');
+                panelOpenedFromSplash = true;
                 if (gameContainer) gameContainer.classList.remove('hidden');
                 openInfoPanel();
             });
 
             attachSplashButtonEvents(splashSettingsButtonEl, () => {
-                if (splashScreen) splashScreen.classList.add('hidden');
+                panelOpenedFromSplash = true;
                 if (gameContainer) gameContainer.classList.remove('hidden');
                 openSettingsPanel();
             });


### PR DESCRIPTION
## Summary
- add Player Name container to splash configuration menu
- store player names in localStorage and allow adding new ones
- hide or show containers based on splash access

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_686371391b9c833389a044627d9f0df7