### PR TITLE
Fix settings panel alignment

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -823,9 +823,19 @@
 
         .centered-panel {
             top: 50%;
+        }
+        #settings-panel.centered-panel,
+        #info-panel.centered-panel,
+        #specific-info-panel.centered-panel,
+        #free-settings-panel.centered-panel,
+        #reset-confirmation-panel.centered-panel {
             transform: translate(-50%, -50%) scale(0.95);
         }
-        .centered-panel.panel-visible {
+        #settings-panel.centered-panel.panel-visible,
+        #info-panel.centered-panel.panel-visible,
+        #specific-info-panel.centered-panel.panel-visible,
+        #free-settings-panel.centered-panel.panel-visible,
+        #reset-confirmation-panel.centered-panel.panel-visible {
             transform: translate(-50%, -50%) scale(1);
         }
         #settings-panel.panel-visible,


### PR DESCRIPTION
## Summary
- ensure the settings panel (and other panels) correctly center when opened from the splash screen by overriding transform on elements with the `centered-panel` class

## Testing
- `grep -R "test" -n | head`

------
https://chatgpt.com/codex/tasks/task_b_68637ae21e3483338433342e03e9592b