### PR TITLE
Fix name selector after closing info panel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3448,6 +3448,9 @@ function setupSlider(slider, display) {
                     if (!musicVolumeSlider.disabled) musicVolumeControlGroup.classList.add("interactive-mode");
                     else musicVolumeControlGroup.classList.remove("interactive-mode");
                 }
+                playerNameSelector.disabled = false;
+                if (playerSelectControlGroup) playerSelectControlGroup.classList.add("interactive-mode");
+                if (addPlayerControlGroup) addPlayerControlGroup.classList.add("interactive-mode");
                 settingsPanel.querySelectorAll('.setting-info-button').forEach(btn => btn.disabled = false);
                 
                 // Ensure main action buttons reflect that settings panel is still the context


### PR DESCRIPTION
## Summary
- reenable player name selector when closing specific info panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686387d552708333aee2ca1426b96c1b