### PR TITLE
Fix width for menu button containers

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -761,17 +761,17 @@
             display: flex;
         }
         #back-button-wrapper {
-            flex-grow: 1;
+            flex: 0 0 auto;
         }
         #start-button-wrapper {
-            flex-grow: 3;
+            flex: 1 1 auto;
             display: flex;
             gap: 4px;
         }
         #start-button-wrapper.split #startButton { flex-grow: 2; }
         #start-button-wrapper.split #restartMazeButton { flex-grow: 1; }
         #config-button-wrapper {
-            flex-grow: 1;
+            flex: 0 0 auto;
         }
 
 


### PR DESCRIPTION
## Summary
- adjust flex values on `back` and `config` button wrappers
- let the `start` button fill remaining row width

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_68639dc9103c8333bc660ac74ac74ef8