### PR TITLE
award coins by time in free mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4766,7 +4766,13 @@ function setupSlider(slider, display) {
             draw();
             managePostGameOverMusicAndAnimation();
 
-            const earnedCoins = Math.floor(score / POINTS_PER_COIN);
+            let earnedCoins;
+            if (gameMode === 'freeMode') {
+                // In free mode coins are earned based on time played
+                earnedCoins = Math.floor(gameTimeElapsed / 1000);
+            } else {
+                earnedCoins = Math.floor(score / POINTS_PER_COIN);
+            }
             const previousCoins = totalCoins;
 
             const soundDelay = levelEffectivelyWon ? WIN_SOUND_DURATION : GAME_OVER_SOUND_DURATION;


### PR DESCRIPTION
## Summary
- calculate earned coins by play time in free mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6863e1ac42988333b296899e7bf4af08