### PR TITLE
Fix mode select intro reset

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -6982,8 +6982,8 @@ async function startGame(isRestart = false) {
                 // Return to mode selection
                 showModeSelect = true;
                 modeTransitionStart = null;
-                introOptionAvailable = false;
-                modeSelectIndex = MODE_SELECT_ORDER.indexOf(gameMode) >= 0 ? MODE_SELECT_ORDER.indexOf(gameMode) : 0;
+                introOptionAvailable = true;
+                modeSelectIndex = 0;
                 gameMode = '';
                 gameModeSelector.value = '';
                 screenState.showCoverForWorld = 0;


### PR DESCRIPTION
## Summary
- show "¿A qué te apetece jugar hoy?" intro slide again when returning to mode selection

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6863ea27b0c883339c0f557390560d79