### PR TITLE
Update splash background

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -130,18 +130,21 @@
 
         .game-container {
             text-align: center;
-            background-color: #1F2937;
+            background-image: url(https://i.imgur.com/TyTwsMd.png);
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             padding-top: 10px;
             padding-left: 10px;
             padding-right: 10px;
-            padding-bottom: calc(10px + env(safe-area-inset-bottom)); 
-            border-radius: 12px; 
+            padding-bottom: calc(10px + env(safe-area-inset-bottom));
+            border-radius: 12px;
             box-shadow: 0 8px 16px rgba(0,0,0,0.3);
-            width: 100%; 
-            max-width: var(--game-max-width); 
-            box-sizing: border-box; 
-            height: 100%; 
-            display: flex; 
+            width: 100%;
+            max-width: var(--game-max-width);
+            box-sizing: border-box;
+            height: 100%;
+            display: flex;
             flex-direction: column;
         }
         #play-area { position: relative; }


### PR DESCRIPTION
## Summary
- revert splash overlay background image
- use image background on game container

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6863ed750fa483339da98db004b027d5