### PR TITLE
Fix splash background placement

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -62,14 +62,18 @@
             height: 100%;
             display: flex;
             background-color: #02010a;
+            background-image: url(https://i.imgur.com/TyTwsMd.png);
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             z-index: 2000;
             display: flex;
             flex-direction: column;
             justify-content: space-between;
             align-items: center;
             padding: 20px 0;
-           border-radius: 12px;
-           box-sizing: border-box;
+            border-radius: 12px;
+            box-sizing: border-box;
         }
 
         #splash-top-image {
@@ -134,14 +138,14 @@
             padding-top: 10px;
             padding-left: 10px;
             padding-right: 10px;
-            padding-bottom: calc(10px + env(safe-area-inset-bottom)); 
-            border-radius: 12px; 
+            padding-bottom: calc(10px + env(safe-area-inset-bottom));
+            border-radius: 12px;
             box-shadow: 0 8px 16px rgba(0,0,0,0.3);
-            width: 100%; 
-            max-width: var(--game-max-width); 
-            box-sizing: border-box; 
-            height: 100%; 
-            display: flex; 
+            width: 100%;
+            max-width: var(--game-max-width);
+            box-sizing: border-box;
+            height: 100%;
+            display: flex;
             flex-direction: column;
         }
         #play-area { position: relative; }


### PR DESCRIPTION
## Summary
- apply the background image to the splash content so it appears behind splash images
- restore the original color on the game container

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6863ed750fa483339da98db004b027d5