### PR TITLE
Update add-player button icon

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1378,9 +1378,7 @@
                         <div class="control-label-icon-row">
                             <label class="control-label" for="newPlayerNameInput">Añadir</label>
                             <button id="confirm-add-player-button" class="setting-info-button" aria-label="Confirmar nuevo nombre">
-                                <svg class="setting-info-icon" viewBox="0 0 20 20" fill="currentColor">
-                                    <path stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M10 5v10M5 10h10" />
-                                </svg>
+                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                             </button>
                         </div>
                         <input id="newPlayerNameInput" type="text">


### PR DESCRIPTION
## Summary
- swap the SVG plus icon for an image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6866497ddb708333a1d21917090a1da0