### PR TITLE
Add panel background and update panel styles

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -868,6 +868,10 @@
             left: 50%;
             transform: translateX(-50%) scale(0.95);
             background-color: #1F2937;
+            background-image: url('assets/panel-bg.svg');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
             padding: 25px;
             border-radius: 12px;
             box-shadow: 0 10px 30px rgba(0,0,0,0.6);

--- a/assets/panel-bg.svg
+++ b/assets/panel-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#334155"/>
+      <stop offset="100%" stop-color="#1F2937"/>
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad)"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `assets/panel-bg.svg`
- use the new image for settings/info/free panels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686658c54aa08333b3dbca76ed801675