### PR TITLE
Improve scrollbar padding behavior

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -888,10 +888,19 @@
             flex-direction: column;
             gap: 15px;
             border: 2px solid #2d1d3a;
-            overflow-y: auto;
             opacity: 0;
             transition: opacity 0.3s ease-out, transform 0.3s ease-out;
         }
+
+        .panel-content {
+            overflow-y: auto;
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            padding-right: 0;
+        }
+        .scroll-padding { padding-right: 10px; }
 
         #info-panel,
         #specific-info-panel {
@@ -974,9 +983,12 @@
         /* Estilos para el contenido del panel de información */
         #info-panel-content, #specific-info-content {
             line-height: 1.6;
-            overflow-y: auto; 
-            padding-right: 10px; 
-            color: #d1d5db; 
+            overflow-y: auto;
+            color: #d1d5db;
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+            padding-right: 0;
         }
         #info-panel-content h3#main-info-title,
         #info-panel-content h4, 
@@ -1009,30 +1021,30 @@
         /* Estilos de scroll unificados para todos los paneles */
         #info-panel-content::-webkit-scrollbar,
         #specific-info-content::-webkit-scrollbar,
-        #settings-panel::-webkit-scrollbar,
-        #info-panel::-webkit-scrollbar,
-        #specific-info-panel::-webkit-scrollbar,
-        #free-settings-panel::-webkit-scrollbar,
-        #reset-confirmation-panel::-webkit-scrollbar {
+        #settings-panel .panel-content::-webkit-scrollbar,
+        #info-panel .panel-content::-webkit-scrollbar,
+        #specific-info-panel .panel-content::-webkit-scrollbar,
+        #free-settings-panel .panel-content::-webkit-scrollbar,
+        #reset-confirmation-panel .panel-content::-webkit-scrollbar {
             width: 8px;
         }
         #info-panel-content::-webkit-scrollbar-track,
         #specific-info-content::-webkit-scrollbar-track,
-        #settings-panel::-webkit-scrollbar-track,
-        #info-panel::-webkit-scrollbar-track,
-        #specific-info-panel::-webkit-scrollbar-track,
-        #free-settings-panel::-webkit-scrollbar-track,
-        #reset-confirmation-panel::-webkit-scrollbar-track {
+        #settings-panel .panel-content::-webkit-scrollbar-track,
+        #info-panel .panel-content::-webkit-scrollbar-track,
+        #specific-info-panel .panel-content::-webkit-scrollbar-track,
+        #free-settings-panel .panel-content::-webkit-scrollbar-track,
+        #reset-confirmation-panel .panel-content::-webkit-scrollbar-track {
             background: #2d1d3a;
             border-radius: 4px;
         }
         #info-panel-content::-webkit-scrollbar-thumb,
         #specific-info-content::-webkit-scrollbar-thumb,
-        #settings-panel::-webkit-scrollbar-thumb,
-        #info-panel::-webkit-scrollbar-thumb,
-        #specific-info-panel::-webkit-scrollbar-thumb,
-        #free-settings-panel::-webkit-scrollbar-thumb,
-        #reset-confirmation-panel::-webkit-scrollbar-thumb {
+        #settings-panel .panel-content::-webkit-scrollbar-thumb,
+        #info-panel .panel-content::-webkit-scrollbar-thumb,
+        #specific-info-panel .panel-content::-webkit-scrollbar-thumb,
+        #free-settings-panel .panel-content::-webkit-scrollbar-thumb,
+        #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb {
             background: #442F58;
             border-radius: 4px;
         }
@@ -1040,16 +1052,16 @@
         #info-panel-content::-webkit-scrollbar-thumb:active,
         #specific-info-content::-webkit-scrollbar-thumb:hover,
         #specific-info-content::-webkit-scrollbar-thumb:active,
-        #settings-panel::-webkit-scrollbar-thumb:hover,
-        #settings-panel::-webkit-scrollbar-thumb:active,
-        #info-panel::-webkit-scrollbar-thumb:hover,
-        #info-panel::-webkit-scrollbar-thumb:active,
-        #specific-info-panel::-webkit-scrollbar-thumb:hover,
-        #specific-info-panel::-webkit-scrollbar-thumb:active,
-        #free-settings-panel::-webkit-scrollbar-thumb:hover,
-        #free-settings-panel::-webkit-scrollbar-thumb:active,
-        #reset-confirmation-panel::-webkit-scrollbar-thumb:hover,
-        #reset-confirmation-panel::-webkit-scrollbar-thumb:active {
+        #settings-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #settings-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #info-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #info-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #specific-info-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #specific-info-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #free-settings-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #free-settings-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb:active {
             background: #8f66af;
         }
 
@@ -1188,10 +1200,10 @@
                 height: 100%;
                 width: auto;
             }
-             #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel {
+            #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel {
                 padding: 15px;
             }
-            #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 0.9em; } 
+            #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 0.9em; }
             #info-panel-content h4, #specific-info-content h4 { font-size: 0.9em; }
             #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul { font-size: 0.75em; }
         }
@@ -1368,6 +1380,7 @@
                     <h2>Configuración</h2>
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
                 </div>
+                <div class="panel-content">
                 <div class="control-row" id="player-row">
                     <div id="player-select-control-group" class="control-group hidden">
                         <div class="control-label-icon-row">
@@ -1482,6 +1495,7 @@
                     <input type="range" id="musicVolumeSlider" min="0" max="100" value="50">
                 </div>
                 <div class="control-group" id="resetDataButton">Reiniciar datos del juego</div>
+                </div>
             </div>
 
             <div id="free-settings-panel" class="free-settings-panel-hidden">
@@ -1489,6 +1503,7 @@
                     <h2>Personaliza tu juego</h2>
                     <button id="close-free-settings-button" aria-label="Cerrar ajustes">&times;</button>
                 </div>
+                <div class="panel-content">
                 <div class="control-group">
                     <label class="control-label" for="free-speed-input">Velocidad: <span id="free-speed-value">67</span>%</label>
                     <input type="range" class="settings-range" id="free-speed-input" min="0" max="100" step="5" value="67">
@@ -1560,6 +1575,7 @@
                     <input type="range" class="settings-range" id="free-obstacle-count" min="0" max="50" value="5">
                 </div>
                 <div class="control-group" id="apply-free-settings-bottom">Jugar</div>
+                </div>
             </div>
 
             <div id="info-panel" class="info-panel-hidden">
@@ -1598,11 +1614,13 @@
                 <div class="reset-header">
                     <h2>Reiniciar</h2>
                 </div>
-                <p>Esta decisión eliminará todos tus progresos y puntuaciones</p>
-                <p>¿Estás seguro de que deseas eliminar todos los datos del juego?</p>
-                <div class="reset-buttons">
-                    <button id="confirmResetYes">Sí</button>
-                    <button id="confirmResetNo">No</button>
+                <div class="panel-content">
+                    <p>Esta decisión eliminará todos tus progresos y puntuaciones</p>
+                    <p>¿Estás seguro de que deseas eliminar todos los datos del juego?</p>
+                    <div class="reset-buttons">
+                        <button id="confirmResetYes">Sí</button>
+                        <button id="confirmResetNo">No</button>
+                    </div>
                 </div>
             </div>
 
@@ -1763,6 +1781,10 @@
         const resetConfirmPanel = document.getElementById("reset-confirmation-panel");
         const confirmResetYesButton = document.getElementById("confirmResetYes");
         const confirmResetNoButton = document.getElementById("confirmResetNo");
+
+        const settingsPanelContent = settingsPanel.querySelector('.panel-content');
+        const freeSettingsPanelContent = freeSettingsPanel.querySelector('.panel-content');
+        const resetConfirmPanelContent = resetConfirmPanel.querySelector('.panel-content');
 
         const modeLeftButton = document.getElementById("mode-left-button");
         const modeRightButton = document.getElementById("mode-right-button");
@@ -2859,12 +2881,23 @@ function setupSlider(slider, display) {
             // If a panel is open, re-calculate its position after resize
             if (!settingsPanel.classList.contains("settings-panel-hidden")) {
                 positionPanel(settingsPanel);
+                applyScrollbarPadding(settingsPanelContent);
             }
             if (!infoPanel.classList.contains("info-panel-hidden")) {
                 positionPanel(infoPanel);
+                applyScrollbarPadding(infoPanelContent);
             }
             if (specificInfoPanel && !specificInfoPanel.classList.contains("specific-info-panel-hidden")) {
                 positionPanel(specificInfoPanel);
+                applyScrollbarPadding(specificInfoContent);
+            }
+            if (freeSettingsPanel && !freeSettingsPanel.classList.contains("free-settings-panel-hidden")) {
+                positionPanel(freeSettingsPanel);
+                applyScrollbarPadding(freeSettingsPanelContent);
+            }
+            if (resetConfirmPanel && !resetConfirmPanel.classList.contains("reset-panel-hidden")) {
+                positionPanel(resetConfirmPanel);
+                applyScrollbarPadding(resetConfirmPanelContent);
             }
 
 
@@ -3025,6 +3058,13 @@ function setupSlider(slider, display) {
             }
         }
 
+        function applyScrollbarPadding(el) {
+            if (!el) return;
+            const needsPadding = el.scrollHeight > el.clientHeight + 1;
+            if (needsPadding) el.classList.add('scroll-padding');
+            else el.classList.remove('scroll-padding');
+        }
+
         // --- Panel Management Refactor ---
         function togglePanel(panelElement, contentContainer, show) {
             if (!panelElement) {
@@ -3050,13 +3090,13 @@ function setupSlider(slider, display) {
                     togglePanel(infoPanel, infoPanelContent, false);
                 }
                 if (panelElement === settingsPanel && freeSettingsPanel && !freeSettingsPanel.classList.contains("free-settings-panel-hidden")) {
-                    togglePanel(freeSettingsPanel, freeSettingsPanel, false);
+                    togglePanel(freeSettingsPanel, freeSettingsPanelContent, false);
                 }
                 if (panelElement === infoPanel && !settingsPanel.classList.contains("settings-panel-hidden")) {
-                    togglePanel(settingsPanel, settingsPanel, false);
+                    togglePanel(settingsPanel, settingsPanelContent, false);
                 }
                 if (panelElement === freeSettingsPanel && !settingsPanel.classList.contains("settings-panel-hidden")) {
-                    togglePanel(settingsPanel, settingsPanel, false);
+                    togglePanel(settingsPanel, settingsPanelContent, false);
                 }
                 if (panelElement !== specificInfoPanel && specificInfoPanel && !specificInfoPanel.classList.contains("specific-info-panel-hidden")) {
                     togglePanel(specificInfoPanel, specificInfoContent, false);
@@ -3065,10 +3105,13 @@ function setupSlider(slider, display) {
                 panelElement.classList.remove(hiddenClassName);
                 positionPanel(panelElement);
                 
-                requestAnimationFrame(() => { 
+                requestAnimationFrame(() => {
                     panelElement.classList.add(visibleClassName);
                     const targetScrollElement = contentContainer || panelElement;
-                     if(targetScrollElement) targetScrollElement.scrollTop = 0;
+                    if (targetScrollElement) {
+                        targetScrollElement.scrollTop = 0;
+                        applyScrollbarPadding(targetScrollElement);
+                    }
                 });
                 
                 startButton.disabled = true;
@@ -3109,7 +3152,7 @@ function setupSlider(slider, display) {
         function openSettingsPanel() {
             if (panelOpenedFromSplash) settingsPanel.classList.add('centered-panel');
             else settingsPanel.classList.remove('centered-panel');
-            togglePanel(settingsPanel, settingsPanel, true);
+            togglePanel(settingsPanel, settingsPanelContent, true);
             // Show or hide certain settings when accessed from the splash screen
             gameModeControlGroup.classList.remove('hidden');
             difficultyControlGroup.classList.remove('hidden');
@@ -3166,7 +3209,7 @@ function setupSlider(slider, display) {
         function closeSettingsPanel() {
             const wasSpecificInfoOpen = specificInfoPanel && !specificInfoPanel.classList.contains("specific-info-panel-hidden");
             
-            togglePanel(settingsPanel, settingsPanel, false); // Hides panel
+            togglePanel(settingsPanel, settingsPanelContent, false); // Hides panel
 
             if (wasSpecificInfoOpen) {
                 togglePanel(specificInfoPanel, specificInfoContent, false); // Hides specific info
@@ -3215,12 +3258,12 @@ function setupSlider(slider, display) {
         }
 
         function openFreeSettingsPanel() {
-            togglePanel(freeSettingsPanel, freeSettingsPanel, true);
+            togglePanel(freeSettingsPanel, freeSettingsPanelContent, true);
             populateFreeSettingsInputs();
         }
 
         function closeFreeSettingsPanel() {
-            togglePanel(freeSettingsPanel, freeSettingsPanel, false);
+            togglePanel(freeSettingsPanel, freeSettingsPanelContent, false);
             setTimeout(updateMainButtonStates, 0);
         }
 
@@ -3418,12 +3461,12 @@ function setupSlider(slider, display) {
         function openResetConfirmPanel() {
             if (panelOpenedFromSplash) resetConfirmPanel.classList.add('centered-panel');
             else resetConfirmPanel.classList.remove('centered-panel');
-            togglePanel(settingsPanel, settingsPanel, false);
-            togglePanel(resetConfirmPanel, resetConfirmPanel, true);
+            togglePanel(settingsPanel, settingsPanelContent, false);
+            togglePanel(resetConfirmPanel, resetConfirmPanelContent, true);
         }
 
         function closeResetConfirmPanel() {
-            togglePanel(resetConfirmPanel, resetConfirmPanel, false);
+            togglePanel(resetConfirmPanel, resetConfirmPanelContent, false);
             resetConfirmPanel.classList.remove('centered-panel');
         }
 
@@ -3433,7 +3476,7 @@ function setupSlider(slider, display) {
         if (confirmResetNoButton) {
             confirmResetNoButton.addEventListener('click', () => {
                 closeResetConfirmPanel();
-                togglePanel(settingsPanel, settingsPanel, true);
+                togglePanel(settingsPanel, settingsPanelContent, true);
             });
         }
         if (confirmResetYesButton) {


### PR DESCRIPTION
## Summary
- add helper `applyScrollbarPadding` and call it when opening panels or on resize
- show scroll padding only when overflow is present
- restore vertical gaps by making `.panel-content` flex with spacing

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_68669f9988b4833380c6390f48beea3f