### PR TITLE
Fix free-mode panel scroll padding

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -973,6 +973,10 @@
             width: 100%;
         }
 
+        #free-settings-panel .panel-content {
+            padding-right: 10px;
+        }
+
         /* Primer título/texto en cada contenedor del modo libre */
         #free-settings-panel .control-group > label.control-label:first-child,
         #free-settings-panel .control-group > .control-label-icon-row:first-child > label.control-label {


### PR DESCRIPTION
## Summary
- add padding-right to the free-mode settings panel content so the scrollbar spacing matches the splash info panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6866b49eba10833393117f5befa1930d