### PR TITLE
Add transparency to game mode and difficulty info buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -542,6 +542,12 @@
             height: 38px;
             box-sizing: border-box;
         }
+
+        /* Make game mode and difficulty info buttons semi-transparent */
+        .setting-info-button[data-setting="gameMode"],
+        .setting-info-button[data-setting="difficulty"] {
+            background-color: rgba(56, 65, 82, 0.5);
+        }
         .setting-info-icon {
             width: 24px;
             height: 24px;


### PR DESCRIPTION
## Summary
- make game mode and difficulty info buttons semi-transparent so the background is visible

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686755605fd883339a02ecae4651d01f