### PR TITLE
Add transparent icons to select info buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -559,6 +559,12 @@
             filter: brightness(0.7);
         }
 
+        /* Semi-transparent icons for specific selectors */
+        .setting-info-button[data-setting="gameMode"] .setting-info-icon,
+        .setting-info-button[data-setting="difficulty"] .setting-info-icon {
+            opacity: 0.7;
+        }
+
         .coin-icon {
             width: 16px;
             height: 16px;


### PR DESCRIPTION
## Summary
- add opacity to info icons inside game mode and difficulty selectors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68675741d6988333b0017b5bb984b9b4