### PR TITLE
Improve start button press feedback

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -829,13 +829,13 @@
             font-size: 0.85em;
             color: #f5f5f5;
             border: none;
-            border-radius: 8px; 
+            border-radius: 8px;
             cursor: pointer;
-            transition: background-color 0.3s ease; 
-            width: 100%; 
-            height: 65px; 
-            font-family: 'Press Start 2P', sans-serif; 
-            display: flex; 
+            transition: background-color 0.3s ease, transform 0.05s ease-out, filter 0.05s ease-out;
+            width: 100%;
+            height: 65px;
+            font-family: 'Press Start 2P', sans-serif;
+            display: flex;
             align-items: center;
             justify-content: center;
             box-sizing: border-box;
@@ -7201,6 +7201,7 @@ async function startGame(isRestart = false) {
         addIconPressEvents(restartMazeButton, restartMazeButtonIcon);
         addIconPressEvents(modeLeftButton, modeLeftButtonIcon);
         addIconPressEvents(modeRightButton, modeRightButtonIcon);
+        addIconPressEvents(startButton, startButton);
 
         // Original click listeners for D-Pad 
         upButton.addEventListener("click", () => changeDirection("up"));


### PR DESCRIPTION
## Summary
- add transform transition to start button style
- trigger press animation on start button using existing helper

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68675e95daa483339b0947a336b09c14