### PR TITLE
Apply start button style to free mode play button

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1294,22 +1294,35 @@
 #settings-panel #resetDataButton:hover { background-color: #b91c1c; }
 
         #free-settings-panel #apply-free-settings-bottom {
-            background-color: #4CAF50;
-            color: #f5f5f5;
+            background-color: #8f66af;
+            color: #F3F3F3;
+            border: 3px solid #2d1d3a;
+            box-shadow:
+                inset 0 10px 6px #D6BCE9,
+                4px 4px 6px #442F58;
+            text-shadow: -1px -1px 0 #2d1d3a,
+                         1px -1px 0 #2d1d3a,
+                        -1px 1px 0 #2d1d3a,
+                         1px 1px 0 #2d1d3a;
             border-radius: 8px;
             padding: 10px 15px;
             font-family: 'Press Start 2P', sans-serif;
             cursor: pointer;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.3s ease, transform 0.05s ease-out, filter 0.05s ease-out;
             width: 100%;
             text-align: center;
-            font-size: 0.75em;
+            font-size: 0.85em;
             display: flex;
             align-items: center;
             justify-content: center;
-            height: 40px;
+            height: 65px;
+            box-sizing: border-box;
         }
-        #free-settings-panel #apply-free-settings-bottom:hover { background-color: #45a049; }
+        #free-settings-panel #apply-free-settings-bottom:hover { filter: brightness(0.95); }
+        #free-settings-panel #apply-free-settings-bottom:disabled {
+            filter: brightness(0.6);
+            cursor: not-allowed;
+        }
 
         #reset-confirmation-panel { z-index: 2102; }
 
@@ -7205,6 +7218,7 @@ async function startGame(isRestart = false) {
         addIconPressEvents(modeLeftButton, modeLeftButtonIcon);
         addIconPressEvents(modeRightButton, modeRightButtonIcon);
         addIconPressEvents(startButton, startButton);
+        addIconPressEvents(applyFreeSettingsBottomButton, applyFreeSettingsBottomButton);
 
         // Original click listeners for D-Pad 
         upButton.addEventListener("click", () => changeDirection("up"));


### PR DESCRIPTION
## Summary
- make the free mode "Jugar" button match the start button style
- give the button press feedback like the start button

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_6867625b147c8333ae7036ff334f686e