### PR TITLE
Update control buttons style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -392,22 +392,27 @@
         }
 
         .control-button {
-            background-color: #384152; 
-            border: 1px solid #2D3748; 
-            border-radius: 12px; 
-            color: #fff3e1; 
+            background-color: #8f66af;
+            border: 3px solid #2d1d3a;
+            border-radius: 8px;
+            color: #F3F3F3;
             cursor: pointer;
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 5px; 
-            user-select: none; 
-            -webkit-user-select: none; 
-            -ms-user-select: none; 
-            transition: background-color 0.2s ease, transform 0.05s ease-out, filter 0.05s ease-out;
-            width: 100%; 
-            height: 100%; 
+            padding: 5px;
+            user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            transition: background-color 0.3s ease, transform 0.05s ease-out, filter 0.05s ease-out;
+            width: 100%;
+            height: 100%;
             box-sizing: border-box;
+            box-shadow: inset 0 10px 6px #D6BCE9;
+            text-shadow: -1px -1px 0 #2d1d3a,
+                         1px -1px 0 #2d1d3a,
+                        -1px 1px 0 #2d1d3a,
+                         1px 1px 0 #2d1d3a;
         }
         .d-pad-button-pressed { 
             transform: scale(0.95) translateY(1px);
@@ -431,12 +436,18 @@
             grid-row: 2; 
         } 
 
-        .control-button:hover { background-color: #4a5568; }
+        .control-button:hover { filter: brightness(0.95); }
         
         .arrow-svg {
             width: 60%;
             height: 60%;
             fill: currentColor;
+        }
+        .control-button .arrow-svg path {
+            fill: #47315F;
+            stroke: #C1A4D4;
+            stroke-width: 1.5;
+            stroke-linejoin: round;
         }
         .arrow-icon {
             width: 100%;


### PR DESCRIPTION
## Summary
- apply start button style to control buttons while removing outer drop shadow
- color control button arrows using #47315F with #C1A4D4 outline

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686765211dc8833384aeb076c74b95f6