### PR TITLE
Increase mobile arrow size

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -400,7 +400,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 5px;
+            padding: 2px;
             user-select: none;
             -webkit-user-select: none;
             -ms-user-select: none;
@@ -439,8 +439,8 @@
         .control-button:hover { filter: brightness(0.95); }
         
         .arrow-svg {
-            width: 60%;
-            height: 60%;
+            width: 100%;
+            height: 100%;
             fill: currentColor;
         }
         .control-button .arrow-svg path {
@@ -1158,7 +1158,7 @@
                 min-height: 110px; 
                 gap: 6px;
             }
-            .arrow-svg { width: 55%; height: 55%; }
+            .arrow-svg { width: 95%; height: 95%; }
             .arrow-icon { width: 100%; height: 100%; }
             
              #startButton, #restartMazeButton, #configButton, #backButton {
@@ -1247,7 +1247,7 @@
                 min-height: 100px; 
                 gap: 5px;
             }
-            .arrow-svg { width: 50%; height: 50%; }
+            .arrow-svg { width: 90%; height: 90%; }
             .arrow-icon { width: 100%; height: 100%; }
 
              #startButton, #restartMazeButton, #configButton, #backButton {


### PR DESCRIPTION
## Summary
- enlarge arrow SVGs to fill control buttons
- reduce padding on control buttons so arrows appear larger

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68676d63168c8333964542816e67884b