### PR TITLE
Apply start button style to reset data buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -902,7 +902,10 @@
             transform: scale(0.90) translateY(2px);
             filter: brightness(0.7);
         }
-        #startButton.icon-button-pressed {
+        #startButton.icon-button-pressed,
+        #resetDataButton.icon-button-pressed,
+        #confirmResetYes.icon-button-pressed,
+        #confirmResetNo.icon-button-pressed {
             filter: brightness(0.5);
         }
         .config-svg,
@@ -1286,23 +1289,31 @@
 
         #settings-panel #resetDataButton {
             background-color: #dc2626;
-            color: #f5f5f5;
+            color: #F3F3F3;
+            border: 3px solid #7f1d1d;
+            box-shadow:
+                inset 0 10px 6px #f87171,
+                4px 4px 6px #7f1d1d;
+            text-shadow: -1px -1px 0 #7f1d1d,
+                         1px -1px 0 #7f1d1d,
+                        -1px 1px 0 #7f1d1d,
+                         1px 1px 0 #7f1d1d;
             border-radius: 8px;
             padding: 10px 15px;
-            font-family: 'Press Start 2P', sans-serif;
+            font-family: "Press Start 2P", sans-serif;
             cursor: pointer;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.3s ease, transform 0.05s ease-out, filter 0.05s ease-out;
             width: 100%;
             text-align: center;
-            font-size: 0.65em;
+            font-size: 0.85em;
             display: flex;
             align-items: center;
             justify-content: center;
-            flex-direction: row;
-            height: 40px;
+            height: 65px;
+            box-sizing: border-box;
         }
 
-#settings-panel #resetDataButton:hover { background-color: #b91c1c; }
+#settings-panel #resetDataButton:hover { filter: brightness(0.95); }
 
         #free-settings-panel #apply-free-settings-bottom {
             background-color: #8f66af;
@@ -1347,26 +1358,39 @@
         #reset-confirmation-panel .reset-buttons button {
             flex: 1;
             padding: 10px 15px;
-            font-size: 0.65em;
-            color: #f5f5f5;
-            border: none;
+            font-size: 0.85em;
+            color: #F3F3F3;
             border-radius: 8px;
-            font-family: 'Press Start 2P', sans-serif;
+            font-family: "Press Start 2P", sans-serif;
             cursor: pointer;
-            transition: background-color 0.3s ease;
+            transition: background-color 0.3s ease, transform 0.05s ease-out, filter 0.05s ease-out;
+            height: 65px;
+            box-sizing: border-box;
         }
         #confirmResetYes {
             background-color: #b91c1c;
+            border: 3px solid #7f1d1d;
+            box-shadow:
+                inset 0 10px 6px #f87171,
+                4px 4px 6px #7f1d1d;
+            text-shadow: -1px -1px 0 #7f1d1d,
+                         1px -1px 0 #7f1d1d,
+                        -1px 1px 0 #7f1d1d,
+                         1px 1px 0 #7f1d1d;
         }
-        #confirmResetYes:hover {
-            background-color: #dc2626;
-        }
+        #confirmResetYes:hover { filter: brightness(0.95); }
         #confirmResetNo {
             background-color: #4CAF50;
+            border: 3px solid #1b5e20;
+            box-shadow:
+                inset 0 10px 6px #81c784,
+                4px 4px 6px #1b5e20;
+            text-shadow: -1px -1px 0 #1b5e20,
+                         1px -1px 0 #1b5e20,
+                        -1px 1px 0 #1b5e20,
+                         1px 1px 0 #1b5e20;
         }
-        #confirmResetNo:hover {
-            background-color: #45a049;
-        }
+        #confirmResetNo:hover { filter: brightness(0.95); }
 
         @media screen and (min-width: 800px) {
             #splash-content { padding: 0px 0; }
@@ -7233,6 +7257,9 @@ async function startGame(isRestart = false) {
         addIconPressEvents(modeRightButton, modeRightButtonIcon);
         addIconPressEvents(startButton, startButton);
         addIconPressEvents(applyFreeSettingsBottomButton, applyFreeSettingsBottomButton);
+        addIconPressEvents(resetDataButton, resetDataButton);
+        addIconPressEvents(confirmResetYesButton, confirmResetYesButton);
+        addIconPressEvents(confirmResetNoButton, confirmResetNoButton);
 
         // Original click listeners for D-Pad 
         upButton.addEventListener("click", () => changeDirection("up"));


### PR DESCRIPTION
## Summary
- apply start button style to Reset Data button
- style confirmation buttons with red/green scheme
- add press feedback for reset data and confirmation buttons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6867853a70c48333872b50de32e97431