### PR TITLE
Reduce spacing between titles and content

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -992,7 +992,7 @@
             justify-content: space-between;
             align-items: center;
             color: #8f66af;
-            margin-bottom: 10px;
+            margin-bottom: 5px;
         }
         .settings-header h2, .info-header h2, .specific-info-header h2, .reset-header h2 {
             font-size: 1.4em;
@@ -1054,24 +1054,24 @@
             padding-right: 0;
         }
         #info-panel-content h3#main-info-title,
-        #info-panel-content h4, 
-        #specific-info-content h4 { 
-            font-size: 1.1em; 
-            color: #8f66af; 
-            margin-top: 20px; 
-            margin-bottom: 10px; 
-            text-align: left; 
+        #info-panel-content h4,
+        #specific-info-content h4 {
+            font-size: 1.1em;
+            color: #8f66af;
+            margin-top: 10px;
+            margin-bottom: 5px;
+            text-align: left;
         }
-         #specific-info-content h3 { 
-            font-size: 0.85em; 
-            color: #f5f5f5; 
-            margin-bottom: 12px;
-            text-align: center; 
+         #specific-info-content h3 {
+            font-size: 0.85em;
+            color: #f5f5f5;
+            margin-bottom: 8px;
+            text-align: center;
         }
         #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul {
-            font-size: 0.85em; 
-            margin-bottom: 12px;
-            text-align: justify; 
+            font-size: 0.85em;
+            margin-bottom: 8px;
+            text-align: justify;
         }
         #info-panel-content ul, #specific-info-content ul {
             list-style-type: disc; 
@@ -1700,7 +1700,7 @@
 
                     <h4>Más información</h4>
                     <p>Para más detalles sobre cada tipo de juego u opciones de configuración o personalización, accede al menú de ajustes y pulsa sobre el icono de información del elemento sobre el que te interese obtener más información.</p>
-                    <p style="text-align: center; margin-top: 20px;"><strong>¡Diviértete y que crezca la serpiente!</strong></p>
+                    <p style="text-align: center; margin-top: 10px;"><strong>¡Diviértete y que crezca la serpiente!</strong></p>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- decrease margins below panel headers
- tighten spacing for info panel headings and paragraphs
- adjust inline style for info panel closing message

## Testing
- `git diff --color --stat`


------
https://chatgpt.com/codex/tasks/task_b_68678f47ffec83338dc2948e59d46432