### PR TITLE
Show player name in all settings

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -623,6 +623,22 @@
             margin-top: 4px;
             margin-bottom: 0;
         }
+
+        #settings-panel #playerNameSelector {
+            width: calc(100% - 100px);
+        }
+
+        #player-select-control-group #open-name-manager-button {
+            right: 56px;
+        }
+
+        #player-select-control-group #delete-player-name-button {
+            right: 12px;
+        }
+
+        #free-player-name-group #open-name-manager-from-free {
+            right: 12px;
+        }
         
         #difficultySelector option, #worldsSelector option, #mazeLevelSelector option, #audioToggleSelector option, #skinSelector option, #foodSelector option, #gameModeSelector option, #playerNameSelector option {
             background-color: #374151;
@@ -1487,29 +1503,6 @@
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
                 </div>
                 <div class="panel-content">
-                <div class="control-row" id="player-row">
-                    <div id="player-select-control-group" class="control-group hidden">
-                        <div class="control-label-icon-row">
-                            <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
-                            <button id="delete-player-name-button" class="setting-info-button" aria-label="Eliminar jugador">
-                                <img class="setting-info-icon" src="https://i.imgur.com/w5E6xdU.png" alt="Eliminar" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
-                            </button>
-                        </div>
-                        <select id="playerNameSelector">
-                            <option value="Snake" selected>Snake</option>
-                            <option value="GamiSnake">GamiSnake</option>
-                        </select>
-                    </div>
-                    <div id="add-player-control-group" class="control-group hidden">
-                        <div class="control-label-icon-row">
-                            <label class="control-label" for="newPlayerNameInput">Añadir</label>
-                            <button id="confirm-add-player-button" class="setting-info-button" aria-label="Confirmar nuevo nombre">
-                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
-                            </button>
-                        </div>
-                        <input id="newPlayerNameInput" type="text">
-                    </div>
-                </div>
                 <div class="control-group" id="game-mode-control-group">
                     <div class="control-label-icon-row">
                         <label class="control-label" for="gameModeSelector">Tipo de Juego:</label>
@@ -1542,6 +1535,32 @@
                     </select>
                     <select id="mazeLevelSelector" class="hidden">
                     </select>
+                </div>
+                <div class="control-row" id="player-row">
+                    <div id="player-select-control-group" class="control-group">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                            <button id="open-name-manager-button" class="setting-info-button" aria-label="Añadir jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                            <button id="delete-player-name-button" class="setting-info-button hidden" aria-label="Eliminar jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/w5E6xdU.png" alt="Eliminar" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <select id="playerNameSelector">
+                            <option value="Snake" selected>Snake</option>
+                            <option value="GamiSnake">GamiSnake</option>
+                        </select>
+                    </div>
+                    <div id="add-player-control-group" class="control-group hidden">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="newPlayerNameInput">Añadir</label>
+                            <button id="confirm-add-player-button" class="setting-info-button" aria-label="Confirmar nuevo nombre">
+                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <input id="newPlayerNameInput" type="text">
+                    </div>
                 </div>
                 <div class="control-group" id="skin-control-group">
                     <div class="control-label-icon-row">
@@ -1610,8 +1629,13 @@
                     <button id="close-free-settings-button" aria-label="Cerrar ajustes">&times;</button>
                 </div>
                 <div class="panel-content">
-                <div class="control-group">
-                    <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                <div class="control-group" id="free-player-name-group">
+                    <div class="control-label-icon-row">
+                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                        <button id="open-name-manager-from-free" class="setting-info-button" aria-label="Añadir jugador">
+                            <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                        </button>
+                    </div>
                     <select id="playerNameSelector"></select>
                 </div>
                 <div class="control-group">
@@ -1843,6 +1867,8 @@
         const confirmAddPlayerButton = document.getElementById("confirm-add-player-button");
         const deletePlayerNameButton = document.getElementById("delete-player-name-button");
         const newPlayerNameInput = document.getElementById("newPlayerNameInput");
+        const openNameManagerButton = document.getElementById("open-name-manager-button");
+        const openNameManagerFromFreeButton = document.getElementById("open-name-manager-from-free");
         const playerSelectControlGroup = document.getElementById("player-select-control-group");
         const addPlayerControlGroup = document.getElementById("add-player-control-group");
         const difficultyControlGroup = document.getElementById("difficulty-control-group");
@@ -3296,14 +3322,18 @@ function setupSlider(slider, display) {
             else difficultyControlGroup.classList.remove('hidden');
             skinControlGroup.classList.remove('hidden');
             foodControlGroup.classList.remove('hidden');
-            playerSelectControlGroup.classList.add('hidden');
+            playerSelectControlGroup.classList.remove('hidden');
             addPlayerControlGroup.classList.add('hidden');
+            if (openNameManagerButton) openNameManagerButton.classList.remove('hidden');
+            if (deletePlayerNameButton) deletePlayerNameButton.classList.add('hidden');
             resetDataButton.classList.add('hidden');
             resetDataButton.classList.remove('interactive-mode');
 
             if (panelOpenedFromSplash) {
                 playerSelectControlGroup.classList.remove('hidden');
                 addPlayerControlGroup.classList.remove('hidden');
+                if (openNameManagerButton) openNameManagerButton.classList.add('hidden');
+                if (deletePlayerNameButton) deletePlayerNameButton.classList.remove('hidden');
                 gameModeControlGroup.classList.add('hidden');
                 difficultyControlGroup.classList.add('hidden');
                 skinControlGroup.classList.add('hidden');
@@ -6910,6 +6940,26 @@ async function startGame(isRestart = false) {
                     currentPlayerName = newSelection;
                     saveGameSettings();
                 }
+            });
+        }
+
+        if (openNameManagerButton) {
+            openNameManagerButton.addEventListener('click', function() {
+                closeSettingsPanel();
+                if (splashScreen) splashScreen.classList.remove('hidden');
+                if (gameContainer) gameContainer.classList.add('hidden');
+                panelOpenedFromSplash = true;
+                openSettingsPanel();
+            });
+        }
+
+        if (openNameManagerFromFreeButton) {
+            openNameManagerFromFreeButton.addEventListener('click', function() {
+                closeFreeSettingsPanel();
+                if (splashScreen) splashScreen.classList.remove('hidden');
+                if (gameContainer) gameContainer.classList.add('hidden');
+                panelOpenedFromSplash = true;
+                openSettingsPanel();
             });
         }
 


### PR DESCRIPTION
## Summary
- add player name selector to main settings panel above skin selection
- support same player name selector in free settings panel
- adjust styles for multiple icons and plus button
- open general settings from splash when '+' button pressed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868c0b78fac8333a222c7e585de2739