### PR TITLE
Add info button for player name input

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1543,6 +1543,15 @@
                     <select id="mazeLevelSelector" class="hidden">
                     </select>
                 </div>
+                <div class="control-group">
+                    <div class="control-label-icon-row">
+                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                        <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
+                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                        </button>
+                    </div>
+                    <select id="playerNameSelector"></select>
+                </div>
                 <div class="control-group" id="skin-control-group">
                     <div class="control-label-icon-row">
                         <label class="control-label" for="skinSelector">Disfraz:</label>
@@ -1611,7 +1620,12 @@
                 </div>
                 <div class="panel-content">
                 <div class="control-group">
-                    <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                    <div class="control-label-icon-row">
+                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                        <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
+                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                        </button>
+                    </div>
                     <select id="playerNameSelector"></select>
                 </div>
                 <div class="control-group">
@@ -3652,6 +3666,10 @@ function setupSlider(slider, display) {
             food: {
                 title: "Comestible",
                 text: "<p>Selecciona el alimento que quieres que aparezca en el escenario. Esta elección solo afecta al aspecto visual y no modifica la jugabilidad.</p>"
+            },
+            playerName: {
+                title: "Nombre del Jugador",
+                text: "<p>Si deseas registrar a un nuevo jugador, puedes hacerlo desde el menú de configuración de la pantalla de inicio.</p>"
             },
             audioGeneral: {
                 title: "Audio General",


### PR DESCRIPTION
## Summary
- show info icon beside player name selector in all mode panels
- explain in help text that new players are added from the main screen settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868c32f0c348333ab8dac5266f8252d