### PR TITLE
Fix duplicate player name label in settings

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1490,7 +1490,7 @@
                 <div class="control-row" id="player-row">
                     <div id="player-select-control-group" class="control-group hidden">
                         <div class="control-label-icon-row">
-                            <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                            <label class="control-label" for="playerNameSelector">Jugador:</label>
                             <button id="delete-player-name-button" class="setting-info-button" aria-label="Eliminar jugador">
                                 <img class="setting-info-icon" src="https://i.imgur.com/w5E6xdU.png" alt="Eliminar" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                             </button>
@@ -1542,15 +1542,6 @@
                     </select>
                     <select id="mazeLevelSelector" class="hidden">
                     </select>
-                </div>
-                <div class="control-group">
-                    <div class="control-label-icon-row">
-                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
-                        <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
-                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
-                        </button>
-                    </div>
-                    <select id="playerNameSelector"></select>
                 </div>
                 <div class="control-group" id="skin-control-group">
                     <div class="control-label-icon-row">


### PR DESCRIPTION
## Summary
- update the first label for player name to "Jugador"
- remove duplicated player name selector container in the settings panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868cb7fd0588333b29b22b29f3f8e20