### PR TITLE
Implement player profiles

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2473,12 +2473,77 @@ function setupSlider(slider, display) {
             }
         };
         let currentSkin = 'snake';
+        let playerProfiles = {};
         let playerNames = ['Snake', 'GamiSnake'];
         let currentPlayerName = 'Snake';
+
+        function createDefaultProfile() {
+            return {
+                skin: 'snake',
+                food: 'apple',
+                difficulty: 'principiante',
+                audioGeneral: 'all',
+                musicVolume: 75,
+                gameMode: '',
+                currentWorld: 1,
+                currentLevelInWorld: 1,
+                maxUnlockedWorld: 1,
+                levelsProgress: Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false),
+                worldCurrentLevels: Array(TOTAL_WORLDS).fill(1),
+                currentMazeLevel: 1,
+                mazeLevelStars: Array(MAZE_LEVEL_COUNT).fill(0),
+                coins: 0
+            };
+        }
+
+        function loadPlayerProfiles() {
+            const stored = localStorage.getItem('snakePlayerProfiles');
+            if (stored) {
+                try {
+                    playerProfiles = JSON.parse(stored) || {};
+                } catch (e) {
+                    console.error('Error parsing player profiles', e);
+                    playerProfiles = {};
+                }
+            }
+            if (Object.keys(playerProfiles).length === 0) {
+                playerProfiles['Snake'] = createDefaultProfile();
+                playerProfiles['GamiSnake'] = createDefaultProfile();
+            }
+        }
+
+        function savePlayerProfiles() {
+            localStorage.setItem('snakePlayerProfiles', JSON.stringify(playerProfiles));
+        }
+
+        function applyProfile(profile) {
+            if (!profile) return;
+            difficultySelector.value = profile.difficulty || 'principiante';
+            classificationDifficultyIndex = CLASSIFICATION_DIFFICULTY_ORDER.indexOf(difficultySelector.value);
+            skinSelector.value = profile.skin || 'snake';
+            currentSkin = skinSelector.value;
+            applySkin(currentSkin);
+            foodSelector.value = profile.food || 'apple';
+            currentFood = foodSelector.value;
+            applyFood(currentFood);
+            audioToggleSelector.value = profile.audioGeneral || 'all';
+            musicVolumeSlider.value = profile.musicVolume || 75;
+            if (musicVolumeValue) musicVolumeValue.textContent = musicVolumeSlider.value;
+            gameModeSelector.value = profile.gameMode || '';
+            currentWorld = profile.currentWorld || 1;
+            currentLevelInWorld = profile.currentLevelInWorld || 1;
+            maxUnlockedWorld = profile.maxUnlockedWorld || 1;
+            levelsProgress = Array.isArray(profile.levelsProgress) ? profile.levelsProgress : Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+            worldCurrentLevels = Array.isArray(profile.worldCurrentLevels) ? profile.worldCurrentLevels : Array(TOTAL_WORLDS).fill(1);
+            currentMazeLevel = profile.currentMazeLevel || 1;
+            mazeLevelStars = Array.isArray(profile.mazeLevelStars) ? profile.mazeLevelStars : Array(MAZE_LEVEL_COUNT).fill(0);
+            totalCoins = profile.coins || 0;
+        }
         function getSelectedPlayerName() {
             return playerNameSelectors.length ? playerNameSelectors[0].value : '';
         }
         function updatePlayerNameSelectors(selectedName) {
+            playerNames = Object.keys(playerProfiles);
             playerNameSelectors.forEach(sel => {
                 sel.innerHTML = '';
                 playerNames.forEach(name => {
@@ -5031,7 +5096,10 @@ function setupSlider(slider, display) {
                 setTimeout(() => {
                     totalCoins += earnedCoins;
                     animateCoinGain(previousCoins, totalCoins);
-                    localStorage.setItem('snakeGameCoins', totalCoins.toString());
+                    if (playerProfiles[currentPlayerName]) {
+                        playerProfiles[currentPlayerName].coins = totalCoins;
+                        savePlayerProfiles();
+                    }
                     updateUIOnGameOver();
                     if (gameMode === 'levels' || gameMode === 'maze') {
                         saveGameSettings();
@@ -6893,16 +6961,22 @@ async function startGame(isRestart = false) {
         });
 
         playerNameSelectors.forEach(sel => sel.addEventListener('change', function() {
+            const previous = currentPlayerName;
+            saveGameSettings(); // Save previous profile
             currentPlayerName = this.value;
+            if (!playerProfiles[currentPlayerName]) {
+                playerProfiles[currentPlayerName] = createDefaultProfile();
+            }
             playerNameSelectors.forEach(s => { if (s !== this) s.value = this.value; });
+            applyProfile(playerProfiles[currentPlayerName]);
             saveGameSettings();
         }));
 
         function addNewPlayerFromInput() {
             const newName = newPlayerNameInput.value.trim();
             if (newName) {
-                if (!playerNames.includes(newName)) {
-                    playerNames.push(newName);
+                if (!playerProfiles[newName]) {
+                    playerProfiles[newName] = createDefaultProfile();
                 }
                 updatePlayerNameSelectors(newName);
                 currentPlayerName = newName;
@@ -6920,17 +6994,15 @@ async function startGame(isRestart = false) {
         }
         if (deletePlayerNameButton) {
             deletePlayerNameButton.addEventListener('click', function() {
-                if (playerNames.length <= 1) return;
+                if (Object.keys(playerProfiles).length <= 1) return;
                 const nameToDelete = getSelectedPlayerName();
                 if (nameToDelete === 'Snake') return;
-                const index = playerNames.indexOf(nameToDelete);
-                if (index > -1) {
-                    playerNames.splice(index, 1);
-                    const newSelection = playerNames[0];
-                    updatePlayerNameSelectors(newSelection);
-                    currentPlayerName = newSelection;
-                    saveGameSettings();
-                }
+                if (playerProfiles[nameToDelete]) delete playerProfiles[nameToDelete];
+                const remaining = Object.keys(playerProfiles);
+                const newSelection = remaining[0];
+                updatePlayerNameSelectors(newSelection);
+                currentPlayerName = newSelection;
+                saveGameSettings();
             });
         }
 
@@ -7480,161 +7552,46 @@ async function startGame(isRestart = false) {
         window.addEventListener('resize', resizeGameElements); 
         
         function saveGameSettings() {
-            localStorage.setItem('snakeGameDifficulty', difficultySelector.value);
-            localStorage.setItem('snakeGameSkin', skinSelector.value);
-            localStorage.setItem('snakeGameFood', foodSelector.value);
-            localStorage.setItem('snakeGamePlayerName', getSelectedPlayerName());
-            localStorage.setItem('snakePlayerNames', JSON.stringify(playerNames));
-            localStorage.setItem('snakeGameAudioGeneral', audioToggleSelector.value);
-            localStorage.setItem('snakeGameMusicVolume', musicVolumeSlider.value);
-            localStorage.setItem('snakeGameMode', gameModeSelector.value);
-            // Levels mode specific
-            localStorage.setItem('snakeCurrentWorld', currentWorld.toString());
-            localStorage.setItem('snakeCurrentLevelInWorld', currentLevelInWorld.toString());
-            localStorage.setItem('snakeMaxUnlockedWorld', maxUnlockedWorld.toString());
-            localStorage.setItem('snakeLevelsProgress', JSON.stringify(levelsProgress));
-            localStorage.setItem('snakeWorldCurrentLevels', JSON.stringify(worldCurrentLevels));
-            localStorage.setItem('snakeCurrentMazeLevel', currentMazeLevel.toString());
-            localStorage.setItem('snakeMazeLevelStars', JSON.stringify(mazeLevelStars));
+            const profile = playerProfiles[currentPlayerName] || createDefaultProfile();
+            profile.difficulty = difficultySelector.value;
+            profile.skin = skinSelector.value;
+            profile.food = foodSelector.value;
+            profile.audioGeneral = audioToggleSelector.value;
+            profile.musicVolume = musicVolumeSlider.value;
+            profile.gameMode = gameModeSelector.value;
+            profile.currentWorld = currentWorld;
+            profile.currentLevelInWorld = currentLevelInWorld;
+            profile.maxUnlockedWorld = maxUnlockedWorld;
+            profile.levelsProgress = levelsProgress;
+            profile.worldCurrentLevels = worldCurrentLevels;
+            profile.currentMazeLevel = currentMazeLevel;
+            profile.mazeLevelStars = mazeLevelStars;
+            profile.coins = totalCoins;
+            playerProfiles[currentPlayerName] = profile;
+            savePlayerProfiles();
+            localStorage.setItem('snakePlayerNames', JSON.stringify(Object.keys(playerProfiles)));
+            localStorage.setItem('snakeGamePlayerName', currentPlayerName);
             console.log("Configuraciones guardadas en localStorage.");
         }
 
         function loadGameSettings() {
-            const savedDifficulty = localStorage.getItem('snakeGameDifficulty');
-            if (savedDifficulty && DIFFICULTY_SETTINGS[savedDifficulty]) {
-                difficultySelector.value = savedDifficulty;
-            } else {
-                difficultySelector.value = 'principiante';
-            }
-            classificationDifficultyIndex = CLASSIFICATION_DIFFICULTY_ORDER.indexOf(difficultySelector.value);
-
-            const savedSkin = localStorage.getItem('snakeGameSkin');
-            if (savedSkin) skinSelector.value = savedSkin;
-
-            const savedPlayerNames = localStorage.getItem('snakePlayerNames');
-            if (savedPlayerNames) {
-                try {
-                    const parsed = JSON.parse(savedPlayerNames);
-                    if (Array.isArray(parsed) && parsed.length > 0) playerNames = parsed;
-                } catch (e) {
-                    console.error('Error parsing player names from localStorage', e);
-                    playerNames = ['Snake', 'GamiSnake'];
-                }
-            }
+            loadPlayerProfiles();
             updatePlayerNameSelectors();
             const savedPlayerName = localStorage.getItem('snakeGamePlayerName');
-            if (savedPlayerName && playerNames.includes(savedPlayerName)) {
-                updatePlayerNameSelectors(savedPlayerName);
+            if (savedPlayerName && playerProfiles[savedPlayerName]) {
                 currentPlayerName = savedPlayerName;
             } else {
-                currentPlayerName = getSelectedPlayerName();
+                currentPlayerName = Object.keys(playerProfiles)[0];
             }
+            updatePlayerNameSelectors(currentPlayerName);
+            applyProfile(playerProfiles[currentPlayerName]);
 
-            const savedFood = localStorage.getItem('snakeGameFood');
-            if (savedFood) foodSelector.value = savedFood;
-            
-            const savedAudioGeneral = localStorage.getItem('snakeGameAudioGeneral');
-            if (savedAudioGeneral) audioToggleSelector.value = savedAudioGeneral;
-
-            const savedMusicVolume = parseInt(localStorage.getItem('snakeGameMusicVolume'), 10);
-            if (Number.isFinite(savedMusicVolume) && savedMusicVolume >= 0 && savedMusicVolume <= 100) {
-                musicVolumeSlider.value = savedMusicVolume;
-            } else {
-                musicVolumeSlider.value = 75;
-            }
-            if (musicVolumeValue) musicVolumeValue.textContent = musicVolumeSlider.value;
-
-            const savedCoins = parseInt(localStorage.getItem('snakeGameCoins'), 10);
-            totalCoins = Number.isFinite(savedCoins) && savedCoins >= 0 ? savedCoins : 0;
-            
-            // Always start with no mode selected, regardless of any previously
-            // saved preference. Users must actively choose their mode each time
-            // they open the game.
+            // Always start with no mode selected
             gameModeSelector.value = '';
             gameMode = '';
-            
-            // Levels mode specific
-            const savedCurrentWorld = parseInt(localStorage.getItem('snakeCurrentWorld'), 10);
-            currentWorld = Number.isFinite(savedCurrentWorld) && savedCurrentWorld >= 1 ? savedCurrentWorld : 1;
 
-            const savedCurrentLevelInWorld = parseInt(localStorage.getItem('snakeCurrentLevelInWorld'), 10);
-            currentLevelInWorld = Number.isFinite(savedCurrentLevelInWorld) && savedCurrentLevelInWorld >= 1 ? savedCurrentLevelInWorld : 1;
-
-            const savedMaxUnlockedWorld = parseInt(localStorage.getItem('snakeMaxUnlockedWorld'), 10);
-            maxUnlockedWorld = Number.isFinite(savedMaxUnlockedWorld) && savedMaxUnlockedWorld >= 1 ? savedMaxUnlockedWorld : 1;
-
-            const savedLevelsProgress = localStorage.getItem('snakeLevelsProgress');
-            if (savedLevelsProgress) {
-                try {
-                    levelsProgress = JSON.parse(savedLevelsProgress);
-                    if (!Array.isArray(levelsProgress) || levelsProgress.length !== TOTAL_WORLDS * LEVELS_PER_WORLD) {
-                        console.warn("Invalid levels progress found in localStorage, resetting.");
-                        levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
-                    }
-                } catch (e) {
-                    console.error("Error parsing levels progress from localStorage, resetting.", e);
-                    levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
-                }
-            } else {
-                levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
-            }
-
-            const savedWorldCurrentLevels = localStorage.getItem('snakeWorldCurrentLevels');
-            if (savedWorldCurrentLevels) {
-                try {
-                    worldCurrentLevels = JSON.parse(savedWorldCurrentLevels);
-                    if (!Array.isArray(worldCurrentLevels) || worldCurrentLevels.length !== TOTAL_WORLDS) {
-                        console.warn('Invalid world current levels in localStorage, recomputing.');
-                        worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
-                    }
-                } catch (e) {
-                    console.error('Error parsing world current levels from localStorage, recomputing.', e);
-                    worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
-                }
-            } else {
-                worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
-                for (let w = 1; w <= TOTAL_WORLDS; w++) {
-                    const startIdx = (w - 1) * LEVELS_PER_WORLD;
-                    let level = 1;
-                    for (let l = 1; l <= LEVELS_PER_WORLD; l++) {
-                        if (!levelsProgress[startIdx + l - 1]) {
-                            level = l;
-                            break;
-                        }
-                    }
-                    worldCurrentLevels[w - 1] = level;
-                }
-            }
-            if (worldCurrentLevels[currentWorld - 1]) {
-                currentLevelInWorld = worldCurrentLevels[currentWorld - 1];
-            }
-            worldCurrentLevels[currentWorld - 1] = currentLevelInWorld;
-
-            const savedMazeLevel = parseInt(localStorage.getItem('snakeCurrentMazeLevel'), 10);
-            currentMazeLevel = Number.isFinite(savedMazeLevel) && savedMazeLevel >= 1 ? savedMazeLevel : 1;
-            displayMazeLevel = currentMazeLevel;
-            mazeLevelSelector.value = currentMazeLevel.toString();
-
-            const savedMazeLevelStars = localStorage.getItem('snakeMazeLevelStars');
-            if (savedMazeLevelStars) {
-                try {
-                    mazeLevelStars = JSON.parse(savedMazeLevelStars);
-                    if (!Array.isArray(mazeLevelStars) || mazeLevelStars.length !== MAZE_LEVEL_COUNT) {
-                        console.warn("Invalid maze level stars in localStorage, resetting.");
-                        mazeLevelStars = Array(MAZE_LEVEL_COUNT).fill(0);
-                    }
-                } catch (e) {
-                    console.error("Error parsing maze level stars from localStorage, resetting.", e);
-                    mazeLevelStars = Array(MAZE_LEVEL_COUNT).fill(0);
-                }
-            } else {
-                mazeLevelStars = Array(MAZE_LEVEL_COUNT).fill(0);
-            }
-
-            // Initialize display variables after loading game state
             displayWorld = currentWorld;
             displayLevelInWorld = currentLevelInWorld;
-            gameMode = gameModeSelector.value; // Ensure gameMode is set before calculating displayTargetScore
             modeSelectIndex = MODE_SELECT_ORDER.indexOf(gameMode);
 
             if (gameMode === 'levels') {


### PR DESCRIPTION
## Summary
- support multiple player profiles stored in localStorage
- update settings saving/loading to use per-player data
- persist coin count and progress within profiles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6868d8f6e47083338017cc8975a68b0e