### PR TITLE
Actualiza panel de info del jugador

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1545,7 +1545,7 @@
                 </div>
                 <div class="control-group" id="player-name-control-group">
                     <div class="control-label-icon-row">
-                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                        <label class="control-label" for="playerNameSelector">Jugador:</label>
                         <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
@@ -1621,7 +1621,7 @@
                 <div class="panel-content">
                 <div class="control-group">
                     <div class="control-label-icon-row">
-                        <label class="control-label" for="playerNameSelector">Nombre del Jugador:</label>
+                        <label class="control-label" for="playerNameSelector">Jugador:</label>
                         <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
@@ -3779,8 +3779,8 @@ function setupSlider(slider, display) {
                 text: "<p>Selecciona el alimento que quieres que aparezca en el escenario. Esta elección solo afecta al aspecto visual y no modifica la jugabilidad.</p>"
             },
             playerName: {
-                title: "Nombre del Jugador",
-                text: "<p>Si deseas registrar a un nuevo jugador, puedes hacerlo desde el menú de configuración de la pantalla de inicio.</p>"
+                title: "Jugador",
+                text: "<p><strong>Modo Libre:</strong> Tu nombre se utiliza para guardar los ajustes personalizados de la partida.</p><p><strong>Modo Clasificación:</strong> Tu nombre se mostrará en el ranking para que puedas comparar tu puntuación con otros jugadores.</p><p><strong>Modo Aventura:</strong> Tu nombre permite guardar tus progresos y continuar tu partida donde la habías dejado.</p><p><strong>Modo Laberinto:</strong> Tu nombre permite guardar tus progresos y continuar tu partida donde la habías dejado.</p><p>Si deseas registrar a un nuevo jugador, puedes hacerlo desde el menú de configuración de la pantalla de inicio.</p>"
             },
             audioGeneral: {
                 title: "Audio General",


### PR DESCRIPTION
## Resumen
- ajusta el nombre del panel y el label de selección a "Jugador"
- conserva el texto ampliado sobre el uso del nombre en cada modo de juego

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6868ff94fb3c833384e201ba476423a1