### PR TITLE
Adjust info screens

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -25,18 +25,23 @@
             overflow: hidden; 
         }
         body {
-            height: 100%; 
+            height: 100%;
             font-family: 'Press Start 2P', sans-serif;
             margin: 0;
             display: flex;
-            justify-content: center; 
+            justify-content: center;
             align-items: center;   
             background-color: #111827; 
             color: #f5f5f5; 
             -webkit-font-smoothing: antialiased;
             -moz-osx-font-smoothing: grayscale;
             overflow: hidden; 
-            touch-action: none; 
+            touch-action: none;
+        }
+
+        /* Color violeta para textos en negrita */
+        strong {
+            color: #8f66af;
         }
 
         .hidden {
@@ -1060,20 +1065,20 @@
         #info-panel-content h3#main-info-title,
         #info-panel-content h4,
         #specific-info-content h4 {
-            font-size: 1.1em;
+            font-size: 1em;
             color: #8f66af;
             margin-top: 6px;
             margin-bottom: 3px;
             text-align: left;
         }
          #specific-info-content h3 {
-            font-size: 0.85em;
+            font-size: 0.8em;
             color: #f5f5f5;
             margin-bottom: 6px;
             text-align: center;
         }
         #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul {
-            font-size: 0.85em;
+            font-size: 0.8em;
             margin-bottom: 6px;
             text-align: justify;
         }
@@ -1221,9 +1226,9 @@
              }
 
 
-             #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 1em; } 
-             #info-panel-content h4, #specific-info-content h4 { font-size: 1em; } 
-             #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul { font-size: 0.8em; } 
+            #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 0.95em; }
+            #info-panel-content h4, #specific-info-content h4 { font-size: 0.95em; }
+            #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul { font-size: 0.75em; }
         }
          @media screen and (max-width: 400px) { 
             /* --- INICIO DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
@@ -1272,9 +1277,9 @@
             #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel {
                 padding: 15px;
             }
-            #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 0.9em; }
-            #info-panel-content h4, #specific-info-content h4 { font-size: 0.9em; }
-            #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul { font-size: 0.75em; }
+            #info-panel-content h3#main-info-title, #specific-info-content h3 { font-size: 0.85em; }
+            #info-panel-content h4, #specific-info-content h4 { font-size: 0.85em; }
+            #info-panel-content p, #info-panel-content ul, #specific-info-content p, #specific-info-content ul { font-size: 0.7em; }
         }
 
         @media screen and (min-width: 600px) {


### PR DESCRIPTION
## Summary
- shrink fonts on info panels for a cleaner look
- color `<strong>` text violet to match headings

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6869372721308333ba6f3e2a8c84ea7f