### PR TITLE
Fix classification help panel title

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3900,13 +3900,13 @@ function setupSlider(slider, display) {
                 console.error(`No help text found for setting: ${settingKey}`);
                 return;
             }
-            
-            specificInfoTitle.textContent = helpData.title;
 
             if (settingKey === 'difficulty') {
-                specificInfoTitle.textContent = 'Dificultad';
+                // In classification mode show the dedicated title
+                specificInfoTitle.textContent = helpData.title;
                 specificInfoContent.innerHTML = helpData.text_classification;
             } else {
+                specificInfoTitle.textContent = helpData.title;
                 specificInfoContent.innerHTML = helpData.text;
             }
             


### PR DESCRIPTION
## Summary
- fix "Modo Clasificación" title not being applied in help panel

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686a507dcb708333a40513fff6e53423