### PR TITLE
Change difficulty label in free mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1614,7 +1614,7 @@
                 <div class="panel-content">
                 <div class="control-group" id="free-difficulty-control-group">
                     <div class="control-label-icon-row">
-                        <label class="control-label" for="free-difficulty-selector">Dificultad:</label>
+                        <label class="control-label" for="free-difficulty-selector">Configuración:</label>
                         <button id="free-difficulty-info-button" class="setting-info-button" data-setting="freeDifficulty" aria-label="Información sobre dificultad libre">
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>


### PR DESCRIPTION
## Summary
- adjust the free mode personalization label from "Dificultad" to "Configuración"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686a5c36b5c08333ac84b498f49ff303