### PR TITLE
Reorder game mode carousel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2710,7 +2710,7 @@ function setupSlider(slider, display) {
             gameActuallyStarted: false
         };
         let modeSelectIndex = 0;
-        const MODE_SELECT_ORDER = ['intro', 'levels', 'freeMode', 'classification', 'maze'];
+        const MODE_SELECT_ORDER = ['intro', 'levels', 'maze', 'classification', 'freeMode'];
         let showModeSelect = false;
         let panelOpenedFromSplash = false;
         let introOptionAvailable = true; // controls visibility of the intro slide


### PR DESCRIPTION
## Summary
- update game mode order so the selector now lists Adventure, Labyrinth, Classification and Free Mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686ad3420584833383ac53d60a64594f