### PR TITLE
Add configuration menu icon

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -225,6 +225,12 @@
             max-width: 90%;
         }
 
+#settings-title img {
+    max-height: 45px;
+    width: auto;
+    max-width: 90%;
+}
+
         #progress-panel {
             display: grid; 
             grid-template-columns: 1fr 1fr 1fr; 
@@ -1517,7 +1523,7 @@
         <div id="setup-controls"> 
         <div id="settings-panel" class="settings-panel-hidden">
                 <div class="settings-header">
-                    <h2>Configuración</h2>
+                    <h2 id="settings-title"><img src="https://i.imgur.com/IAfhEaH.png" alt="Configuración"></h2>
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
                 </div>
                 <div class="panel-content">


### PR DESCRIPTION
## Summary
- include image in settings menu header
- style new settings title image

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686b55f6d3408333bbf10d296c26e345