### PR TITLE
Align maze level buttons with start button effects

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1466,11 +1466,15 @@
           background-position: center;
           position: relative;
           cursor: pointer;
-          transition: transform 0.2s ease;
+          transition: transform 0.05s ease-out, filter 0.05s ease-out;
         }
 
         .maze-level-button:hover {
-          transform: scale(1.05);
+          filter: brightness(0.95);
+        }
+
+        .maze-level-button.icon-button-pressed {
+          filter: brightness(0.5);
         }
 
         .maze-level-button.disabled {
@@ -1488,8 +1492,8 @@
           top: 50%;
           left: 50%;
           transform: translate(-50%, -50%);
-          font-size: 0.85rem;
-          color: white;
+          font-size: 1.4rem;
+          color: #C084FC;
           text-shadow: 1px 1px 2px black;
           font-family: 'Press Start 2P', sans-serif;
         }
@@ -6812,6 +6816,9 @@ function populateMazeLevelButtons() {
 
                     requestAnimationFrame(draw);
                 });
+
+                // Press feedback similar to start button
+                addIconPressEvents(button, button);
 
                 mazeLevelButtonsContainer.appendChild(button);
             }


### PR DESCRIPTION
## Summary
- match maze level button hover and press behavior with the start button
- enlarge and color maze level numbers in violet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686bb84a7f58833387cb3f96c8958b57