### PR TITLE
Ajustes visuales del modo laberinto

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1480,6 +1480,7 @@
         .maze-level-button.disabled {
           pointer-events: none;
           opacity: 0.7;
+          filter: grayscale(100%);
         }
 
         #mazeLevelButtonsContainer.disabled {
@@ -1489,7 +1490,7 @@
 
         .maze-level-number {
           position: absolute;
-          top: 50%;
+          top: 45%;
           left: 50%;
           transform: translate(-50%, -50%);
           font-size: 1.4rem;


### PR DESCRIPTION
## Summary
- añadir filtro blanco y negro a los niveles bloqueados
- colocar el número del nivel ligeramente más arriba

## Testing
- `npm test` *(falla: falta `package.json`)*

------
https://chatgpt.com/codex/tasks/task_b_686bbd4992888333b3fe1848ab2c1ceb