### PR TITLE
Fix maze info button spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1004,8 +1004,9 @@
             right: auto;
             transform: none;
             background-color: transparent;
-            width: 44px;
-            height: 38px;
+            width: 32px;
+            height: 32px;
+            margin-left: 4px;
         }
         #maze-info-button .setting-info-icon {
             width: 100%;


### PR DESCRIPTION
## Summary
- tweak CSS for the maze info button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686bc161e71c83338f1ad1dd544a423a