### PR TITLE
Update info buttons for maze and adventure modes

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1614,7 +1614,7 @@
                     <div class="header-title-group">
                         <h2 id="settings-title"><img id="settings-title-img" src="https://i.imgur.com/IAfhEaH.png" alt="Configuración"></h2>
                         <button id="maze-info-button" class="setting-info-button hidden" data-setting="mazeLevel" aria-label="Información del modo laberinto">
-                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            <img class="setting-info-icon" src="https://i.imgur.com/IW3a5DA.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
                     </div>
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
@@ -1651,7 +1651,7 @@
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
                         <button id="world-info-button" class="setting-info-button hidden" data-setting="world" aria-label="Información sobre mundos">
-                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            <img class="setting-info-icon" src="https://i.imgur.com/IW3a5DA.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
                     </div>
                     <select id="difficultySelector">


### PR DESCRIPTION
## Summary
- update the info button icons for Maze and Adventure mode panels

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686bc6efa67883338bc171f65ffe5f61