### PR TITLE
Update maze and adventure menu icons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3441,7 +3441,7 @@ function setupSlider(slider, display) {
                 configButton.disabled = true;
                 backButton.disabled = true;
                 backButtonIcon.src = showModeSelect ? 'https://i.imgur.com/1WrBpTQ.png' : 'https://i.imgur.com/Wvl87cV.png';
-                configButtonIcon.src = showModeSelect ? 'https://i.imgur.com/9HHOgFe.png' : 'https://i.imgur.com/jekDmyV.png';
+                configButtonIcon.src = showModeSelect ? 'https://i.imgur.com/9HHOgFe.png' : ((gameMode === 'levels' || gameMode === 'maze') ? 'https://i.imgur.com/IW3a5DA.png' : 'https://i.imgur.com/jekDmyV.png');
                 return;
             }
 
@@ -3451,7 +3451,7 @@ function setupSlider(slider, display) {
                 configButton.disabled = true;
                 backButton.disabled = true;
                 backButtonIcon.src = showModeSelect ? 'https://i.imgur.com/1WrBpTQ.png' : 'https://i.imgur.com/Wvl87cV.png';
-                configButtonIcon.src = showModeSelect ? 'https://i.imgur.com/9HHOgFe.png' : 'https://i.imgur.com/jekDmyV.png';
+                configButtonIcon.src = showModeSelect ? 'https://i.imgur.com/9HHOgFe.png' : ((gameMode === 'levels' || gameMode === 'maze') ? 'https://i.imgur.com/IW3a5DA.png' : 'https://i.imgur.com/jekDmyV.png');
             } else {
                 const isWorldIntroCover = screenState.showCoverForWorld > 0 && !screenState.gameActuallyStarted;
                 const isWorldCompleteScreen = screenState.showWorldCompleteCover > 0;
@@ -3478,7 +3478,7 @@ function setupSlider(slider, display) {
                     configButtonIcon.src = 'https://i.imgur.com/9HHOgFe.png';
                 } else {
                     backButtonIcon.src = 'https://i.imgur.com/Wvl87cV.png';
-                    configButtonIcon.src = 'https://i.imgur.com/jekDmyV.png';
+                    configButtonIcon.src = (gameMode === 'levels' || gameMode === 'maze') ? 'https://i.imgur.com/IW3a5DA.png' : 'https://i.imgur.com/jekDmyV.png';
                 }
 
                 if (isModeSelectActive) {


### PR DESCRIPTION
## Summary
- restore original info button icons
- update config button to show new icon in Maze and Adventure modes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686bc6efa67883338bc171f65ffe5f61