### PR TITLE
Aumentar tamaño de botones de mundos

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1501,8 +1501,8 @@
 
         /* --- Estilo de botones para selección de mundos en modo aventura --- */
         .world-button {
-          width: 100px;
-          height: 100px;
+          width: 140px;
+          height: 140px;
           background-image: url('https://i.imgur.com/DYZjAz4.png');
           background-size: contain;
           background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- enlarge world selection buttons in adventure mode to give more visibility to the cover images

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686c2d53007c833394dda6fc30496a9b