### PR TITLE
Improve world buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1562,6 +1562,11 @@
           background-size: cover;
         }
 
+        .world-button .maze-stars .star {
+          width: 20px;
+          height: 20px;
+        }
+
         .maze-stars .star.full {
           background-image: url('https://i.imgur.com/mJU2iIm.png');
         }
@@ -6839,9 +6844,9 @@ function populateWorldButtons() {
                 button.className = 'world-button';
                 const worldImg = worldImagesConfig[i]?.cover || '';
                 button.style.backgroundImage = `url('https://i.imgur.com/DYZjAz4.png'), url('${worldImg}')`;
-                button.style.backgroundSize = 'contain, cover';
+                button.style.backgroundSize = 'contain, 65%';
                 button.style.backgroundRepeat = 'no-repeat';
-                button.style.backgroundPosition = 'center';
+                button.style.backgroundPosition = 'center, center 45%';
 
                 const starsContainer = document.createElement('div');
                 starsContainer.className = 'maze-stars';


### PR DESCRIPTION
## Summary
- reduce world cover image to 65% of button and shift up slightly
- keep maze mode stars at 14px but show 20px stars in world selector

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_686c34018ccc8333a7a4b3e20a2fd849