### PR TITLE
Update coin panels with selector-only style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -156,41 +156,75 @@
         #play-area { position: relative; }
 
         #top-info-bar {
-            display: grid; 
-            grid-template-columns: 1fr 1fr 1fr; 
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
             gap: 8px;
             width: 100%;
-            margin: 0 auto 5px auto; 
-            position: relative; 
-            z-index: 10; 
+            margin: 0 auto 5px auto;
+            position: relative;
+            z-index: 10;
         }
 
         #top-info-bar .info-group {
             display: flex;
-            flex-direction: column; 
+            flex-direction: column;
             align-items: center;
-            justify-content: center; 
-            background-color: #374151; 
+            justify-content: center;
+            background-color: #374151;
             border-radius: 8px;
-            padding: 8px 10px; 
-            min-width: 80px; 
-            min-height: 55px; 
+            padding: 8px 10px;
+            min-width: 80px;
+            min-height: 55px;
             box-sizing: border-box;
             text-align: center;
         }
         #top-info-bar .info-label {
-            font-size: 0.65em; 
-            color: #a0aec0; 
-            margin-bottom: 4px; 
-            display: block; 
+            font-size: 0.65em;
+            color: #a0aec0;
+            margin-bottom: 4px;
+            display: block;
             line-height: 1.1;
-            word-break: break-word; 
+            word-break: break-word;
         }
         #top-info-bar .info-value {
-            font-size: 0.85em; 
+            font-size: 0.85em;
             color: #f5f5f5;
             font-family: 'Press Start 2P', sans-serif;
             line-height: 1.3;
+        }
+
+        #top-info-bar.selector-mode .info-group {
+            background-color: transparent;
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
+        }
+        #top-info-bar.selector-mode #coins-info-group {
+            background-image: url('https://i.imgur.com/lQ4ltzt.png');
+            position: relative;
+        }
+        #top-info-bar.selector-mode #points-info-group {
+            background-image: url('https://i.imgur.com/vPzvx4U.png');
+        }
+        #top-info-bar.selector-mode #time-info-group {
+            background-image: url('https://i.imgur.com/P16YAd1.png');
+        }
+        #top-info-bar.selector-mode #coins-info-group .flex {
+            position: absolute;
+            top: 50%;
+            left: 60%;
+            transform: translate(-50%, -50%);
+        }
+        #top-info-bar.selector-mode .info-label,
+        #top-info-bar.selector-mode .coin-icon {
+            display: none;
+        }
+
+        @media screen and (min-width: 600px) {
+            #top-info-bar.selector-mode {
+                grid-template-columns: auto auto auto;
+                justify-content: center;
+            }
         }
 
         #title-panel {
@@ -602,6 +636,7 @@
             height: 16px;
             margin-right: 4px;
         }
+
 
         #earnedCoinsMessage {
             position: absolute;
@@ -1368,8 +1403,8 @@
 
 
              #top-info-bar .info-label { font-size: 0.55em; }
-            #top-info-bar .info-value { font-size: 0.7em; }
-            #top-info-bar .info-group { min-width: 60px;} 
+             #top-info-bar .info-value { font-size: 0.7em; }
+             #top-info-bar .info-group { min-width: 60px;}
 
             #current-world-info-group .info-label { font-size: 0.55em; }
             #current-world-info-group .info-value { font-size: 0.7em; }
@@ -1678,7 +1713,7 @@
         <div id="play-area">
 
         <div id="top-info-bar">
-            <div class="info-group">
+            <div id="coins-info-group" class="info-group">
                 <span class="info-label">Monedas:</span>
                 <div class="flex items-center justify-center relative">
                     <svg class="coin-icon" viewBox="0 0 24 24" fill="none">
@@ -1688,7 +1723,7 @@
                     <span id="earnedCoinsMessage" class="earned-coins-msg hidden">+0</span>
                 </div>
             </div>
-            <div class="info-group">
+            <div id="points-info-group" class="info-group">
                 <span class="info-label">Puntos:</span>
                 <div class="flex items-center justify-center">
                     <span id="scoreValue" class="info-value">0</span>
@@ -1696,7 +1731,7 @@
                     <span id="targetScoreValue" class="info-value hidden">0</span>
                 </div>
             </div>
-            <div class="info-group">
+            <div id="time-info-group" class="info-group">
                 <span id="timeLengthLabel" class="info-label">Tiempo:</span>
                 <span id="timeLengthValue" class="info-value">60</span>
             </div>
@@ -6710,6 +6745,8 @@ function setupSlider(slider, display) {
         }
         
         function updateGameModeUI() {
+
+            topInfoBar.classList.toggle('selector-mode', showModeSelect);
 
             const isGameCurrentlyRunning = !!gameIntervalId;
             const isSettingsPanelCurrentlyOpen = !settingsPanel.classList.contains("settings-panel-hidden");


### PR DESCRIPTION
## Summary
- reintroduce original info bar layout with labels and coin icon
- add `.selector-mode` styling for new panel backgrounds
- toggle selector mode class when showing the mode selector
- constrain selector panel layout on larger screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_686e003798048333b6d19fb397292c11