### PR TITLE
Move lives count display to left

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -661,7 +661,7 @@
             transform: translateY(-50%);
         }
 
-        #livesValue { right: 5px; }
+        #livesValue { left: 5px; }
         #lifeTimerValue { left: -16px; text-align: right; }
 
 


### PR DESCRIPTION
## Summary
- tweak CSS for `#livesValue` so the life counter aligns to the left within its container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686e98de5ce08333be248cb5d3b4c68f