### PR TITLE
Introduce modular screen skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,13 @@ For details on the upcoming Classification mode revamp, see [CLASIFICACION.md](C
 ## Local Storage & Dependencies
 
 Game settings, progress, high scores, and maze star achievements are saved using the browser's `localStorage` API. The HTML file loads external resources from CDNs, including Tailwind CSS for styles, Google Fonts for typography, and Tone.js for audio playback.
+
+## Modular Screen System
+
+A simplified modular architecture has been added in the `index.html` page. Screens are organized using JavaScript classes in the `js/` directory:
+
+- `screenManager.js` defines a base `Screen` class and a `ScreenManager` to handle transitions.
+- Individual screens like `splash.js` or `modeSelect.js` extend `Screen` and manage their own DOM nodes.
+- Common information panels are encapsulated in small classes inside `js/panels/`.
+
+To try the modular demo, open `index.html` in a browser. The original game remains in `Snake Github.html`.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,3 @@
+.screen.hidden {
+    display: none;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Snake Modular</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div id="splash-screen" class="screen">
+        <button id="start-btn">Start</button>
+    </div>
+    <div id="mode-select-screen" class="screen hidden">
+        <p>Mode Select</p>
+    </div>
+    <div id="adventure-screen" class="screen hidden">
+        <p>Adventure Mode</p>
+    </div>
+    <div id="maze-screen" class="screen hidden">
+        <p>Maze Mode</p>
+    </div>
+    <div id="classification-screen" class="screen hidden">
+        <p>Classification Mode</p>
+    </div>
+    <div id="free-mode-screen" class="screen hidden">
+        <p>Free Mode</p>
+    </div>
+    <script type="module" src="js/main.js"></script>
+</body>
+</html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,30 @@
+import { ScreenManager } from './screenManager.js';
+import { SplashScreen } from './screens/splash.js';
+import { ModeSelectScreen } from './screens/modeSelect.js';
+import { AdventureScreen } from './screens/adventure.js';
+import { MazeScreen } from './screens/maze.js';
+import { ClassificationScreen } from './screens/classification.js';
+import { FreeModeScreen } from './screens/freeMode.js';
+
+const manager = new ScreenManager();
+const splash = new SplashScreen();
+const select = new ModeSelectScreen();
+const adventure = new AdventureScreen();
+const maze = new MazeScreen();
+const classification = new ClassificationScreen();
+const freeMode = new FreeModeScreen();
+
+splash.onStart = () => manager.switchTo('select');
+
+manager.register('splash', splash);
+manager.register('select', select);
+manager.register('adventure', adventure);
+manager.register('maze', maze);
+manager.register('classification', classification);
+manager.register('free', freeMode);
+
+window.addEventListener('DOMContentLoaded', () => {
+    manager.switchTo('splash');
+});
+
+export { manager };

--- a/js/panels/coinPanel.js
+++ b/js/panels/coinPanel.js
@@ -1,0 +1,10 @@
+export class CoinPanel {
+    constructor(selector) {
+        this.root = document.querySelector(selector);
+    }
+    setCoins(value) {
+        if (this.root) {
+            this.root.textContent = value;
+        }
+    }
+}

--- a/js/panels/gemPanel.js
+++ b/js/panels/gemPanel.js
@@ -1,0 +1,10 @@
+export class GemPanel {
+    constructor(selector) {
+        this.root = document.querySelector(selector);
+    }
+    setGems(value) {
+        if (this.root) {
+            this.root.textContent = value;
+        }
+    }
+}

--- a/js/panels/livesPanel.js
+++ b/js/panels/livesPanel.js
@@ -1,0 +1,10 @@
+export class LivesPanel {
+    constructor(selector) {
+        this.root = document.querySelector(selector);
+    }
+    setLives(value) {
+        if (this.root) {
+            this.root.textContent = value;
+        }
+    }
+}

--- a/js/screenManager.js
+++ b/js/screenManager.js
@@ -1,0 +1,34 @@
+export class Screen {
+    constructor(rootSelector) {
+        this.root = document.querySelector(rootSelector);
+    }
+    show() {
+        this.root.classList.remove('hidden');
+    }
+    hide() {
+        this.root.classList.add('hidden');
+    }
+    update() {}
+}
+
+export class ScreenManager {
+    constructor() {
+        this.screens = {};
+        this.currentScreen = null;
+    }
+    register(name, screen) {
+        this.screens[name] = screen;
+    }
+    switchTo(name) {
+        if (this.currentScreen) {
+            this.currentScreen.hide();
+        }
+        this.currentScreen = this.screens[name];
+        if (this.currentScreen) {
+            this.currentScreen.show();
+        }
+    }
+    getCurrentScreen() {
+        return this.currentScreen;
+    }
+}

--- a/js/screens/adventure.js
+++ b/js/screens/adventure.js
@@ -1,0 +1,7 @@
+import { Screen } from '../screenManager.js';
+
+export class AdventureScreen extends Screen {
+    constructor() {
+        super('#adventure-screen');
+    }
+}

--- a/js/screens/classification.js
+++ b/js/screens/classification.js
@@ -1,0 +1,7 @@
+import { Screen } from '../screenManager.js';
+
+export class ClassificationScreen extends Screen {
+    constructor() {
+        super('#classification-screen');
+    }
+}

--- a/js/screens/freeMode.js
+++ b/js/screens/freeMode.js
@@ -1,0 +1,7 @@
+import { Screen } from '../screenManager.js';
+
+export class FreeModeScreen extends Screen {
+    constructor() {
+        super('#free-mode-screen');
+    }
+}

--- a/js/screens/maze.js
+++ b/js/screens/maze.js
@@ -1,0 +1,7 @@
+import { Screen } from '../screenManager.js';
+
+export class MazeScreen extends Screen {
+    constructor() {
+        super('#maze-screen');
+    }
+}

--- a/js/screens/modeSelect.js
+++ b/js/screens/modeSelect.js
@@ -1,0 +1,7 @@
+import { Screen } from '../screenManager.js';
+
+export class ModeSelectScreen extends Screen {
+    constructor() {
+        super('#mode-select-screen');
+    }
+}

--- a/js/screens/splash.js
+++ b/js/screens/splash.js
@@ -1,0 +1,13 @@
+import { Screen } from '../screenManager.js';
+
+export class SplashScreen extends Screen {
+    constructor() {
+        super('#splash-screen');
+        const startBtn = this.root.querySelector('#start-btn');
+        if (startBtn) {
+            startBtn.addEventListener('click', () => {
+                if (this.onStart) this.onStart();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a basic modular architecture with `Screen` and `ScreenManager`
- add sample screen modules and panel classes
- add demo `index.html` that uses the new modules
- document the new modular setup in README

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686eda713564833390df0ef905eac9c4