### PR TITLE
Inline modular screen demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ For details on the upcoming Classification mode revamp, see [CLASIFICACION.md](C
 ## Local Storage & Dependencies
 
 Game settings, progress, high scores, and maze star achievements are saved using the browser's `localStorage` API. The HTML file loads external resources from CDNs, including Tailwind CSS for styles, Google Fonts for typography, and Tone.js for audio playback.
+
+## Simplified Screen System
+
+`index.html` includes a small demo that uses a `Screen` base class and a `ScreenManager` to change between sections (splash, mode select, and the different game modes). All of this logic is written directly in the HTML file so it runs anywhere without extra JavaScript files.
+
+Open `index.html` in a browser to see the example. The original game remains in `Snake Github.html`.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,3 @@
+.screen.hidden {
+    display: none;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>Snake Modular</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+    <div id="splash-screen" class="screen">
+        <button id="start-btn">Start</button>
+    </div>
+    <div id="mode-select-screen" class="screen hidden">
+        <p>Mode Select</p>
+    </div>
+    <div id="adventure-screen" class="screen hidden">
+        <p>Adventure Mode</p>
+    </div>
+    <div id="maze-screen" class="screen hidden">
+        <p>Maze Mode</p>
+    </div>
+    <div id="classification-screen" class="screen hidden">
+        <p>Classification Mode</p>
+    </div>
+    <div id="free-mode-screen" class="screen hidden">
+        <p>Free Mode</p>
+    </div>
+    <script>
+        class Screen {
+            constructor(rootSelector) {
+                this.root = document.querySelector(rootSelector);
+            }
+            show() {
+                this.root.classList.remove('hidden');
+            }
+            hide() {
+                this.root.classList.add('hidden');
+            }
+            update() {}
+        }
+
+        class ScreenManager {
+            constructor() {
+                this.screens = {};
+                this.currentScreen = null;
+            }
+            register(name, screen) {
+                this.screens[name] = screen;
+            }
+            switchTo(name) {
+                if (this.currentScreen) {
+                    this.currentScreen.hide();
+                }
+                this.currentScreen = this.screens[name];
+                if (this.currentScreen) {
+                    this.currentScreen.show();
+                }
+            }
+            getCurrentScreen() {
+                return this.currentScreen;
+            }
+        }
+
+        class SplashScreen extends Screen {
+            constructor() {
+                super('#splash-screen');
+                const btn = this.root.querySelector('#start-btn');
+                if (btn) {
+                    btn.addEventListener('click', () => {
+                        if (this.onStart) this.onStart();
+                    });
+                }
+            }
+        }
+
+        class ModeSelectScreen extends Screen {
+            constructor() {
+                super('#mode-select-screen');
+            }
+        }
+
+        class AdventureScreen extends Screen {
+            constructor() {
+                super('#adventure-screen');
+            }
+        }
+
+        class MazeScreen extends Screen {
+            constructor() {
+                super('#maze-screen');
+            }
+        }
+
+        class ClassificationScreen extends Screen {
+            constructor() {
+                super('#classification-screen');
+            }
+        }
+
+        class FreeModeScreen extends Screen {
+            constructor() {
+                super('#free-mode-screen');
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const manager = new ScreenManager();
+            const splash = new SplashScreen();
+            const select = new ModeSelectScreen();
+            const adventure = new AdventureScreen();
+            const maze = new MazeScreen();
+            const classification = new ClassificationScreen();
+            const freeMode = new FreeModeScreen();
+
+            splash.onStart = () => manager.switchTo('select');
+
+            manager.register('splash', splash);
+            manager.register('select', select);
+            manager.register('adventure', adventure);
+            manager.register('maze', maze);
+            manager.register('classification', classification);
+            manager.register('free', freeMode);
+
+            manager.switchTo('splash');
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- keep everything in one file by embedding the Screen classes and manager inside `index.html`
- remove old `js/` modules
- update README to explain the simplified setup

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_686eda713564833390df0ef905eac9c4