### PR TITLE
Add selector info bar

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -165,12 +165,38 @@
             z-index: 10;
         }
 
+        #selector-info-bar {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 8px;
+            width: 100%;
+            margin: 0 auto 5px auto;
+            position: relative;
+            z-index: 10;
+        }
+
         #top-info-bar .info-group {
             display: flex;
             flex-direction: column;
             align-items: center;
             justify-content: center;
             background-color: #374151;
+            border-radius: 8px;
+            padding: 8px 10px;
+            min-width: 80px;
+            min-height: 55px;
+            box-sizing: border-box;
+            text-align: center;
+        }
+        #selector-info-bar .info-group {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: transparent;
+            background-size: contain;
+            background-repeat: no-repeat;
+            background-position: center;
             border-radius: 8px;
             padding: 8px 10px;
             min-width: 80px;
@@ -187,6 +213,21 @@
             word-break: break-word;
         }
         #top-info-bar .info-value {
+            font-size: 0.85em;
+            color: #f5f5f5;
+            font-family: 'Press Start 2P', sans-serif;
+            line-height: 1.3;
+        }
+        #selector-info-bar .info-label {
+            font-size: 0.65em;
+            color: #a0aec0;
+            margin-bottom: 4px;
+            display: block;
+            line-height: 1.1;
+            word-break: break-word;
+            display: none;
+        }
+        #selector-info-bar .info-value {
             font-size: 0.85em;
             color: #f5f5f5;
             font-family: 'Press Start 2P', sans-serif;
@@ -218,6 +259,16 @@
         #top-info-bar.selector-mode .info-label,
         #top-info-bar.selector-mode .coin-icon {
             display: none;
+        }
+
+        #selector-info-bar #selector-coins-info { background-image: url('https://i.imgur.com/lQ4ltzt.png'); position: relative; }
+        #selector-info-bar #selector-lives-info { background-image: url('https://i.imgur.com/vPzvx4U.png'); }
+        #selector-info-bar #selector-gems-info { background-image: url('https://i.imgur.com/P16YAd1.png'); }
+        #selector-info-bar #selector-coins-info .flex {
+            position: absolute;
+            top: 50%;
+            left: 60%;
+            transform: translate(-50%, -50%);
         }
 
         #title-panel {
@@ -655,14 +706,19 @@
         }
 
         #livesValue,
-        #lifeTimerValue {
+        #lifeTimerValue,
+        #selectorLivesValue,
+        #selectorLifeTimerValue {
             position: absolute;
             top: 50%;
             transform: translateY(-50%);
         }
 
-        #livesValue { right: 5px; }
-        #lifeTimerValue { left: -16px; text-align: right; }
+        #livesValue,
+        #selectorLivesValue { left: 5px; }
+
+        #lifeTimerValue,
+        #selectorLifeTimerValue { right: 10px; text-align: right; }
 
 
         #difficultySelector, #worldsSelector, #audioToggleSelector, #skinSelector, #foodSelector, #playerNameSelector, #free-difficulty-selector {
@@ -1318,6 +1374,9 @@
             #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
+            #selector-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
+            #selector-info-bar .info-label { font-size: 0.6em; }
+            #selector-info-bar .info-value { font-size: 0.8em; }
 
             #title-panel { min-height: 50px; padding: 6px; }
 
@@ -1408,6 +1467,9 @@
              #top-info-bar .info-label { font-size: 0.55em; }
              #top-info-bar .info-value { font-size: 0.7em; }
              #top-info-bar .info-group { min-width: 60px;}
+             #selector-info-bar .info-label { font-size: 0.55em; }
+             #selector-info-bar .info-value { font-size: 0.7em; }
+             #selector-info-bar .info-group { min-width: 60px;}
 
             #current-world-info-group .info-label { font-size: 0.55em; }
             #current-world-info-group .info-value { font-size: 0.7em; }
@@ -1715,6 +1777,31 @@
         </div>
         <div id="play-area">
 
+        <div id="selector-info-bar" class="hidden">
+            <div id="selector-coins-info" class="info-group">
+                <span class="info-label">Monedas:</span>
+                <div class="flex items-center justify-center relative">
+                    <svg class="coin-icon" viewBox="0 0 24 24" fill="none">
+                        <circle cx="12" cy="12" r="9" fill="#FCD34D" stroke="#D97706" stroke-width="2" />
+                    </svg>
+                    <span id="selectorCoinValue" class="info-value">0</span>
+                </div>
+            </div>
+            <div id="selector-lives-info" class="info-group relative">
+                <span class="info-label">Vidas:</span>
+                <div class="flex items-center justify-center relative">
+                    <span id="selectorLivesValue" class="info-value absolute">5</span>
+                    <span id="selectorLifeTimerValue" class="info-value absolute">Lleno</span>
+                </div>
+            </div>
+            <div id="selector-gems-info" class="info-group">
+                <span class="info-label">Gemas:</span>
+                <div class="flex items-center justify-center relative">
+                    <span id="selectorGemsValue" class="info-value">0</span>
+                </div>
+            </div>
+        </div>
+
         <div id="top-info-bar">
             <div id="coins-info-group" class="info-group">
                 <span class="info-label">Monedas:</span>
@@ -1729,11 +1816,11 @@
             <div id="points-info-group" class="info-group">
                 <span class="info-label">Puntos:</span>
                 <div class="flex items-center justify-center relative">
-        <span id="livesValue" class="info-value absolute hidden" style="left:5px;">5</span>
+        <span id="livesValue" class="info-value absolute hidden">5</span>
                     <span id="scoreValue" class="info-value">0</span>
                     <span id="target-score-divider" class="info-value mx-1 hidden">/</span>
                     <span id="targetScoreValue" class="info-value hidden">0</span>
-                    <span id="lifeTimerValue" class="info-value hidden absolute" style="right:10px;">Lleno</span>
+                    <span id="lifeTimerValue" class="info-value hidden absolute">Lleno</span>
                 </div>
             </div>
             <div id="time-info-group" class="info-group">
@@ -2137,10 +2224,14 @@
         let ctx; 
         const gameContainer = document.querySelector('.game-container'); 
         const coinValueDisplay = document.getElementById("coinValue");
+        const selectorCoinValueDisplay = document.getElementById("selectorCoinValue");
         const earnedCoinsMessage = document.getElementById("earnedCoinsMessage");
         const scoreValueDisplay = document.getElementById("scoreValue");
         const livesValueDisplay = document.getElementById("livesValue");
+        const selectorLivesValueDisplay = document.getElementById("selectorLivesValue");
         const lifeTimerValueDisplay = document.getElementById("lifeTimerValue");
+        const selectorLifeTimerValueDisplay = document.getElementById("selectorLifeTimerValue");
+        const selectorGemsValueDisplay = document.getElementById("selectorGemsValue");
         const targetScoreDivider = document.getElementById("target-score-divider");
         const targetScoreValueDisplay = document.getElementById("targetScoreValue");
         const timeLengthLabelEl = document.getElementById("timeLengthLabel");
@@ -2215,6 +2306,7 @@
         const infoPanelContent = document.getElementById("info-panel-content");
         const closeInfoButton = document.getElementById("close-info-button");
         const topInfoBar = document.getElementById('top-info-bar');
+        const selectorInfoBar = document.getElementById('selector-info-bar');
         const setupControls = document.getElementById('setup-controls');
         const actionButtonsRow = document.getElementById('action-buttons-row');
 
@@ -3571,8 +3663,8 @@ function setupSlider(slider, display) {
                 if (!titlePanel.classList.contains('hidden') && titlePanel.offsetParent) {
                     topReferenceElement = titlePanel;
                 } else {
-                    topReferenceElement = topInfoBar;
-                    if (topInfoBar.classList.contains('hidden') || !topInfoBar.offsetParent) {
+                    topReferenceElement = showModeSelect ? selectorInfoBar : topInfoBar;
+                    if (topReferenceElement.classList.contains('hidden') || !topReferenceElement.offsetParent) {
                         topReferenceElement = gameContainer;
                     }
                 }
@@ -6675,12 +6767,14 @@ function setupSlider(slider, display) {
 
         function updateCoinDisplay() {
             coinValueDisplay.textContent = totalCoins;
+            if (selectorCoinValueDisplay) selectorCoinValueDisplay.textContent = totalCoins;
         }
 
         function animateCoinGain(oldTotal, newTotal) {
             const diff = newTotal - oldTotal;
             if (diff <= 0) {
                 coinValueDisplay.textContent = newTotal;
+                if (selectorCoinValueDisplay) selectorCoinValueDisplay.textContent = newTotal;
                 return;
             }
             const duration = Math.min(2000, diff * 60);
@@ -6690,6 +6784,7 @@ function setupSlider(slider, display) {
                 const progress = Math.min(1, (now - start) / duration);
                 const value = Math.floor(oldTotal + diff * progress);
                 coinValueDisplay.textContent = value;
+                if (selectorCoinValueDisplay) selectorCoinValueDisplay.textContent = value;
                 if (progress < 1) requestAnimationFrame(step);
             }
             requestAnimationFrame(step);
@@ -6730,15 +6825,18 @@ function setupSlider(slider, display) {
 
         function updateLivesDisplay() {
             if (livesValueDisplay) livesValueDisplay.textContent = playerLives;
+            if (selectorLivesValueDisplay) selectorLivesValueDisplay.textContent = playerLives;
         }
 
         function updateLifeTimerDisplay() {
-            if (!lifeTimerValueDisplay) return;
+            if (!(lifeTimerValueDisplay || selectorLifeTimerValueDisplay)) return;
             if (playerLives >= MAX_LIVES || lifeRestoreQueue.length === 0) {
-                lifeTimerValueDisplay.textContent = 'Lleno';
+                if (lifeTimerValueDisplay) lifeTimerValueDisplay.textContent = 'Lleno';
+                if (selectorLifeTimerValueDisplay) selectorLifeTimerValueDisplay.textContent = 'Lleno';
             } else {
                 const remaining = Math.max(0, Math.ceil((lifeRestoreQueue[0] - Date.now()) / 1000));
-                lifeTimerValueDisplay.textContent = formatTime(remaining);
+                if (lifeTimerValueDisplay) lifeTimerValueDisplay.textContent = formatTime(remaining);
+                if (selectorLifeTimerValueDisplay) selectorLifeTimerValueDisplay.textContent = formatTime(remaining);
             }
         }
 
@@ -6813,17 +6911,17 @@ function setupSlider(slider, display) {
         
         function updateGameModeUI() {
 
-            topInfoBar.classList.toggle('selector-mode', showModeSelect);
+            if (selectorInfoBar) selectorInfoBar.classList.toggle('hidden', !showModeSelect);
+            topInfoBar.classList.toggle('hidden', showModeSelect);
 
             if (showModeSelect) {
-                if (livesValueDisplay) livesValueDisplay.classList.remove("hidden");
-                if (lifeTimerValueDisplay) lifeTimerValueDisplay.classList.remove('hidden');
                 if (scoreValueDisplay) scoreValueDisplay.classList.add('hidden');
                 if (targetScoreDivider) targetScoreDivider.classList.add('hidden');
                 if (targetScoreValueDisplay) targetScoreValueDisplay.classList.add('hidden');
+                updateCoinDisplay();
+                updateLivesDisplay();
+                updateLifeTimerDisplay();
             } else {
-                if (livesValueDisplay) livesValueDisplay.classList.add("hidden");
-                if (lifeTimerValueDisplay) lifeTimerValueDisplay.classList.add('hidden');
                 if (scoreValueDisplay) scoreValueDisplay.classList.remove('hidden');
                 if (targetScoreDivider && targetScoreValueDisplay) updateTargetScoreDisplay();
             }


### PR DESCRIPTION
## Summary
- create a new info bar for the game selector showing coins, lives, and gems
- update styles for the selector panel
- fix life overlay positions and remove inline styles
- sync DOM updates for selector panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686f54f029c083338981cfdce905b790