### PR TITLE
Remove coin icon from selector and adjust coin value position

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -266,7 +266,7 @@
         #selector-info-bar #selector-gems-info { background-image: url('https://i.imgur.com/P16YAd1.png'); }
         #selector-info-bar #selector-coins-info .flex {
             position: absolute;
-            top: 50%;
+            top: 60%;
             left: 60%;
             transform: translate(-50%, -50%);
         }
@@ -1785,9 +1785,6 @@
             <div id="selector-coins-info" class="info-group">
                 <span class="info-label">Monedas:</span>
                 <div class="flex items-center justify-center relative">
-                    <svg class="coin-icon" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="9" fill="#FCD34D" stroke="#D97706" stroke-width="2" />
-                    </svg>
                     <span id="selectorCoinValue" class="info-value">0</span>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- remove coin icon on the game selector screen
- lower the coin value display slightly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686f722284c0833395c9b67e61ba1aef