### PR TITLE
Improve start button styling

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1014,9 +1014,8 @@
 
 
         #startButton, #restartMazeButton, #configButton, #backButton {
-            padding: 10px 15px;
+            padding: 0 15px;
             font-size: 0.85em;
-            color: #f5f5f5;
             border: none;
             border-radius: 8px;
             cursor: pointer;
@@ -1028,18 +1027,46 @@
             align-items: center;
             justify-content: center;
             box-sizing: border-box;
+            color: #f5f5f5;
         }
         #startButton {
-            background-color: #8f66af;
-            color: #F3F3F3;
-            border: 3px solid #2d1d3a;
-            box-shadow:
-                inset 0 10px 6px #D6BCE9,
-                4px 4px 6px #442F58;
-            text-shadow: -1px -1px 0 #2d1d3a,
-                         1px -1px 0 #2d1d3a,
-                        -1px 1px 0 #2d1d3a,
-                         1px 1px 0 #2d1d3a;
+            position: relative;
+            padding: 0 6px;
+            color: #4E3967;
+            background-color: #8C64AF;
+            border: 4px solid #2B1D3A;
+            border-radius: 20px;
+            box-shadow: 0 3px 0 #422E58;
+            text-shadow:
+                0px 0px 1px #2B1B39,
+               -1px -1px 0 #D0B5E2,
+                1px -1px 0 #D0B5E2,
+               -1px  1px 0 #D0B5E2,
+                1px  1px 0 #D0B5E2;
+            overflow: hidden;
+            background-clip: padding-box;
+        }
+        #startButton::before,
+        #startButton::after {
+            content: '';
+            position: absolute;
+            left: -2px;
+            width: calc(100% + 4px);
+            height: 10%;
+            z-index: 0;
+            pointer-events: none;
+        }
+        #startButton::before {
+            top: -2px;
+            background-color: #D3BAE8;
+            border-top-left-radius: 20px;
+            border-top-right-radius: 20px;
+        }
+        #startButton::after {
+            bottom: -2px;
+            background-color: #583F7D;
+            border-bottom-left-radius: 20px;
+            border-bottom-right-radius: 20px;
         }
         #restartMazeButton {
             padding: 0;


### PR DESCRIPTION
## Summary
- style start/select main action button using a retro design
- limit shading pseudo-elements to thin stripes
- clip background to reveal curved center

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_686f8210082083339bc3910046766d2d