### PR TITLE
Improve start button styling

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1014,9 +1014,8 @@
 
 
         #startButton, #restartMazeButton, #configButton, #backButton {
-            padding: 10px 15px;
+            padding: 0 15px;
             font-size: 0.85em;
-            color: #f5f5f5;
             border: none;
             border-radius: 8px;
             cursor: pointer;
@@ -1028,18 +1027,56 @@
             align-items: center;
             justify-content: center;
             box-sizing: border-box;
+            color: #f5f5f5;
         }
         #startButton {
-            background-color: #8f66af;
-            color: #F3F3F3;
-            border: 3px solid #2d1d3a;
-            box-shadow:
-                inset 0 10px 6px #D6BCE9,
-                4px 4px 6px #442F58;
-            text-shadow: -1px -1px 0 #2d1d3a,
-                         1px -1px 0 #2d1d3a,
-                        -1px 1px 0 #2d1d3a,
-                         1px 1px 0 #2d1d3a;
+            position: relative;
+            padding: 0 6px;
+            color: #4E3967;
+            border: 4px solid #2B1D3A;
+            border-radius: 20px;
+            box-shadow: 0 3px 0 #422E58;
+            text-shadow:
+                0px 0px 1px #2B1B39,
+               -1px -1px 0 #D0B5E2,
+                1px -1px 0 #D0B5E2,
+               -1px  1px 0 #D0B5E2,
+                1px  1px 0 #D0B5E2;
+            overflow: hidden;
+            background: none;
+            z-index: 0;
+        }
+        #startButton::before {
+            content: '';
+            position: absolute;
+            left: -2px;
+            top: -2px;
+            width: calc(100% + 4px);
+            height: calc(100% + 4px);
+            background: linear-gradient(
+                #D3BAE8 0%,
+                #D3BAE8 10%,
+                transparent 10%,
+                transparent 90%,
+                #583F7D 90%,
+                #583F7D 100%
+            );
+            border-radius: 20px;
+            pointer-events: none;
+            z-index: -2;
+        }
+        #startButton::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 0;
+            width: 100%;
+            height: 80%;
+            background-color: #8C64AF;
+            border-radius: 20px;
+            transform: translateY(-50%);
+            pointer-events: none;
+            z-index: -1;
         }
         #restartMazeButton {
             padding: 0;


### PR DESCRIPTION
## Summary
- refactor start button CSS to better mimic the provided design
- overlay central purple area using `::after`
- apply a single gradient stripe layer with `::before`
- ensure central color reveals the top and bottom stripes
- keep button text visible by stacking pseudo-elements behind

## Testing
- `git diff --stat HEAD~1`


------
https://chatgpt.com/codex/tasks/task_b_686f8210082083339bc3910046766d2d