### PR TITLE
Increase start button text size

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1032,6 +1032,7 @@
         #startButton {
             position: relative;
             padding: 0 6px;
+            font-size: 1.1em;
             color: #4E3967;
             border: 2px solid #2B1D3A;
             border-radius: 10px;
@@ -1441,9 +1442,12 @@
             .arrow-svg { width: 70%; height: 70%; }
             .arrow-icon { width: 100%; height: 100%; }
             
-             #startButton, #restartMazeButton, #configButton, #backButton {
-                 font-size: 0.75em;
-                 height: 55px;
+            #startButton, #restartMazeButton, #configButton, #backButton {
+                font-size: 0.75em;
+                height: 55px;
+            }
+            #startButton {
+                font-size: 1em;
             }
             #restartMazeButton, #configButton, #backButton {
                 min-width: 55px;
@@ -1531,9 +1535,12 @@
             .arrow-svg { width: 70%; height: 70%; }
             .arrow-icon { width: 100%; height: 100%; }
 
-             #startButton, #restartMazeButton, #configButton, #backButton {
-                 font-size: 0.7em;
-                 height: 50px;
+            #startButton, #restartMazeButton, #configButton, #backButton {
+                font-size: 0.7em;
+                height: 50px;
+            }
+            #startButton {
+                font-size: 0.9em;
             }
             #restartMazeButton, #configButton, #backButton {
                 min-width: 50px;


### PR DESCRIPTION
## Summary
- enlarge default start button text to 1.1em
- bump responsive layouts up 0.1em

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_b_686f987b1df883338f077a691d19959e