### PR TITLE
Modify D-pad side overlay

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -565,10 +565,15 @@
             grid-column: 3; 
             grid-row: 1 / span 2; 
         } 
-        #down-button  { 
-            grid-column: 2; 
-            grid-row: 2; 
-        } 
+        #down-button  {
+            grid-column: 2;
+            grid-row: 2;
+        }
+
+        #left-button::after,
+        #right-button::after {
+            height: 95%;
+        }
 
         .control-button:hover { filter: brightness(0.95); }
         


### PR DESCRIPTION
## Summary
- tweak side D-pad buttons so the overlay covers 95% height

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_686fb34bb12c8333ad27723228245576