### PR TITLE
Adjust coin and gem position on mobile

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1458,6 +1458,12 @@
             #selector-info-bar .info-label { font-size: 0.6em; }
             #selector-info-bar .info-value { font-size: 0.8em; }
 
+            /* Move coins and gems slightly right on mobile */
+            #selector-info-bar #selector-coins-info .flex,
+            #selector-info-bar #selector-gems-info .flex {
+                left: 65%;
+            }
+
           /* Slightly shift lives and recovery timer to the right on mobile */
             #livesValue,
             #selectorLivesValue { left: -42px; }
@@ -1558,6 +1564,11 @@
              #top-info-bar .info-group { min-width: 60px;}
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
+             /* Move coins and gems slightly right on mobile */
+             #selector-info-bar #selector-coins-info .flex,
+             #selector-info-bar #selector-gems-info .flex {
+                 left: 65%;
+             }
              #selector-info-bar .info-group { min-width: 60px;}
 
             #current-world-info-group .info-label { font-size: 0.55em; }


### PR DESCRIPTION
## Summary
- shift coins and gems slightly right on mobile screens so they line up better

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686fb8a2b33083339222b52cd0e14a61