### PR TITLE
Add store menu to unlock foods

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1225,10 +1225,10 @@
             display: block;
         }
 
-        .settings-panel-hidden, .info-panel-hidden, .specific-info-panel-hidden, .free-settings-panel-hidden, .reset-panel-hidden, .config-menu-panel-hidden, .generic-menu-panel-hidden {
+        .settings-panel-hidden, .info-panel-hidden, .specific-info-panel-hidden, .free-settings-panel-hidden, .reset-panel-hidden, .config-menu-panel-hidden, .generic-menu-panel-hidden, .store-panel-hidden, .purchase-confirmation-panel-hidden {
             display: none !important;
         }
-        #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel {
+        #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel, #store-panel, #purchase-confirmation-panel {
             position: fixed;
             left: 50%;
             transform: translateX(-50%) scale(0.95);
@@ -1329,7 +1329,9 @@
         #free-settings-panel.centered-panel,
         #reset-confirmation-panel.centered-panel,
         #config-menu-panel.centered-panel,
-        #generic-menu-panel.centered-panel {
+        #generic-menu-panel.centered-panel,
+        #store-panel.centered-panel,
+        #purchase-confirmation-panel.centered-panel {
             transform: translate(-50%, -50%) scale(0.95);
         }
         #settings-panel.centered-panel.panel-visible,
@@ -1338,7 +1340,9 @@
         #free-settings-panel.centered-panel.panel-visible,
         #reset-confirmation-panel.centered-panel.panel-visible,
         #config-menu-panel.centered-panel.panel-visible,
-        #generic-menu-panel.centered-panel.panel-visible {
+        #generic-menu-panel.centered-panel.panel-visible,
+        #store-panel.centered-panel.panel-visible,
+        #purchase-confirmation-panel.centered-panel.panel-visible {
             transform: translate(-50%, -50%) scale(1);
         }
         #settings-panel.panel-visible,
@@ -1347,7 +1351,9 @@
         #free-settings-panel.panel-visible,
         #reset-confirmation-panel.panel-visible,
         #config-menu-panel.panel-visible,
-        #generic-menu-panel.panel-visible {
+        #generic-menu-panel.panel-visible,
+        #store-panel.panel-visible,
+        #purchase-confirmation-panel.panel-visible {
             opacity: 1;
             transform: translateX(-50%) scale(1);
         }
@@ -1751,6 +1757,8 @@
         }
 
         #reset-confirmation-panel { z-index: 2102; }
+        #store-panel { z-index: 2100; }
+        #purchase-confirmation-panel { z-index: 2103; }
 
         .reset-panel-hidden { display: none !important; }
 
@@ -1839,6 +1847,37 @@
           pointer-events: none;
           opacity: 0.7;
           filter: grayscale(100%);
+        }
+
+        /* --- Estilo de celdas de la tienda --- */
+        .store-item {
+          width: 120px;
+          height: 120px;
+          background-image: url('https://i.imgur.com/NNbtyMH.png');
+          background-size: contain;
+          background-repeat: no-repeat;
+          background-position: center;
+          position: relative;
+          cursor: pointer;
+          transition: transform 0.05s ease-out, filter 0.05s ease-out;
+        }
+        .store-item:hover { filter: brightness(0.95); }
+        .store-item.icon-button-pressed { filter: brightness(0.5); }
+        .store-item.disabled {
+          pointer-events: none;
+          opacity: 0.7;
+          filter: grayscale(100%);
+        }
+        .store-item-status {
+          position: absolute;
+          bottom: 8px;
+          left: 0;
+          right: 0;
+          text-align: center;
+          font-size: 0.7rem;
+          color: #C084FC;
+          text-shadow: 1px 1px 2px black;
+          font-family: 'Press Start 2P', sans-serif;
         }
 
         #mazeLevelButtonsContainer.disabled {
@@ -2327,6 +2366,27 @@
                     <p>Contenido no disponible todavía</p>
                 </div>
             </div>
+            <div id="store-panel" class="store-panel-hidden">
+                <div class="settings-header">
+                    <h2>Tienda</h2>
+                    <button id="close-store-panel" aria-label="Cerrar">&times;</button>
+                </div>
+                <div class="panel-content">
+                    <div id="store-items-container" class="flex flex-wrap justify-center gap-4"></div>
+                </div>
+            </div>
+            <div id="purchase-confirmation-panel" class="purchase-confirmation-panel-hidden">
+                <div class="reset-header">
+                    <h2>Confirmar Compra</h2>
+                </div>
+                <div class="panel-content">
+                    <p id="purchase-confirmation-text">¿Comprar por 100 monedas?</p>
+                    <div class="reset-buttons">
+                        <button id="confirmPurchaseYes">Sí</button>
+                        <button id="confirmPurchaseNo">No</button>
+                    </div>
+                </div>
+            </div>
 
             <div class="control-row" id="action-buttons-row">
                     <button id="backButton" aria-label="Volver">
@@ -2518,6 +2578,14 @@
         const bonusesMenuButton = document.getElementById("bonuses-menu-button");
         const dailyMenuButton = document.getElementById("daily-menu-button");
         const wheelMenuButton = document.getElementById("wheel-menu-button");
+
+        const storePanel = document.getElementById("store-panel");
+        const storeItemsContainer = document.getElementById("store-items-container");
+        const closeStorePanelButton = document.getElementById("close-store-panel");
+        const purchaseConfirmationPanel = document.getElementById("purchase-confirmation-panel");
+        const purchaseConfirmationText = document.getElementById("purchase-confirmation-text");
+        const confirmPurchaseYesButton = document.getElementById("confirmPurchaseYes");
+        const confirmPurchaseNoButton = document.getElementById("confirmPurchaseNo");
 
         const settingsPanelContent = settingsPanel.querySelector('.panel-content');
         const freeSettingsPanelContent = freeSettingsPanel.querySelector('.panel-content');
@@ -3200,8 +3268,10 @@ function setupSlider(slider, display) {
             currentSkin = skinSelector.value;
             applySkin(currentSkin);
             foodSelector.value = profile.food || 'apple';
+            if (!unlockedFoods[foodSelector.value]) foodSelector.value = 'apple';
             currentFood = foodSelector.value;
             applyFood(currentFood);
+            updateFoodSelectorAvailability();
             audioToggleSelector.value = profile.audioGeneral || 'all';
             musicVolumeSlider.value = profile.musicVolume || 75;
             if (musicVolumeValue) musicVolumeValue.textContent = musicVolumeSlider.value;
@@ -3269,6 +3339,18 @@ function setupSlider(slider, display) {
             pan: { asset: mimiSnakeFoodImg, scale: 1.5 },
             oreo: { asset: oreoFoodImg, scale: 1.5 }
         };
+        const FOOD_ORDER = ['apple','croqueta','aguacate','sushi','lotus','cerveza','pan','oreo'];
+        const FOOD_DISPLAY_NAMES = {
+            apple: 'Manzana',
+            croqueta: 'Croqueta',
+            aguacate: 'Aguacate',
+            sushi: 'Sushi',
+            lotus: 'Lotus',
+            cerveza: 'Cerveza',
+            pan: 'Pan',
+            oreo: 'Oreo'
+        };
+        let unlockedFoods = { apple: true };
         let currentFood = 'apple';
         // --- Fin Configuración de Comestibles ---
 
@@ -4022,6 +4104,8 @@ function setupSlider(slider, display) {
             else if (panelId === "reset-confirmation-panel") hiddenClassName = "reset-panel-hidden";
             else if (panelId === "config-menu-panel") hiddenClassName = "config-menu-panel-hidden";
             else if (panelId === "generic-menu-panel") hiddenClassName = "generic-menu-panel-hidden";
+            else if (panelId === "store-panel") hiddenClassName = "store-panel-hidden";
+            else if (panelId === "purchase-confirmation-panel") hiddenClassName = "purchase-confirmation-panel-hidden";
             else {
                 console.error("togglePanel: Clase oculta no definida para el panel:", panelId);
                 return;
@@ -4453,7 +4537,7 @@ function setupSlider(slider, display) {
         if (closeGenericMenuButton) closeGenericMenuButton.addEventListener('click', closeGenericMenuPanel);
         if (profileMenuButton) profileMenuButton.addEventListener('click', openProfileMenu);
         if (customizationMenuButton) customizationMenuButton.addEventListener('click', openCustomizationMenu);
-        if (storeMenuButton) storeMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Tienda'); });
+        if (storeMenuButton) storeMenuButton.addEventListener('click', openStoreMenu);
         if (achievementsMenuButton) achievementsMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Logros'); });
         if (bonusesMenuButton) bonusesMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Bonificaciones'); });
         if (dailyMenuButton) dailyMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Premios diarios'); });
@@ -4522,6 +4606,76 @@ function setupSlider(slider, display) {
             setTimeout(updateMainButtonStates, 0);
         }
 
+        function openStoreMenu() {
+            closeConfigMenuPanel();
+            if (storePanel) {
+                populateStoreItems();
+                storePanel.classList.add('centered-panel');
+                togglePanel(storePanel, storePanel.querySelector('.panel-content'), true);
+            }
+        }
+
+        function closeStoreMenu() {
+            togglePanel(storePanel, storePanel.querySelector('.panel-content'), false);
+            storePanel.classList.remove('centered-panel');
+            setTimeout(updateMainButtonStates, 0);
+        }
+
+        function populateStoreItems() {
+            if (!storeItemsContainer) return;
+            storeItemsContainer.innerHTML = '';
+            FOOD_ORDER.forEach(key => {
+                const item = document.createElement('div');
+                item.className = 'store-item';
+                const foodImg = FOODS[key]?.asset?.src || '';
+                item.style.backgroundImage = `url('https://i.imgur.com/NNbtyMH.png'), url('${foodImg}')`;
+                item.style.backgroundSize = 'contain, 67%';
+                item.style.backgroundRepeat = 'no-repeat';
+                item.style.backgroundPosition = 'center, center 45%';
+
+                const status = document.createElement('div');
+                status.className = 'store-item-status';
+                if (unlockedFoods[key]) {
+                    status.textContent = 'Desbloqueado';
+                    item.classList.add('disabled');
+                } else {
+                    status.textContent = '100';
+                    item.addEventListener('click', () => openPurchaseConfirm(key));
+                    addIconPressEvents(item, item);
+                }
+                item.appendChild(status);
+                storeItemsContainer.appendChild(item);
+            });
+        }
+
+        let foodToPurchase = null;
+        function openPurchaseConfirm(key) {
+            foodToPurchase = key;
+            if (purchaseConfirmationText) purchaseConfirmationText.textContent = `¿Comprar ${FOOD_DISPLAY_NAMES[key]} por 100 monedas?`;
+            purchaseConfirmationPanel.classList.add('centered-panel');
+            togglePanel(purchaseConfirmationPanel, purchaseConfirmationPanel.querySelector('.panel-content'), true);
+        }
+
+        function confirmPurchase() {
+            if (!foodToPurchase) { closePurchaseConfirm(); return; }
+            if (totalCoins >= 100) {
+                totalCoins -= 100;
+                unlockedFoods[foodToPurchase] = true;
+                saveUnlockedFoods();
+                localStorage.setItem('snakeGameCoins', totalCoins.toString());
+                updateCoinDisplay();
+                updateFoodSelectorAvailability();
+            }
+            populateStoreItems();
+            closePurchaseConfirm();
+        }
+
+        function closePurchaseConfirm() {
+            togglePanel(purchaseConfirmationPanel, purchaseConfirmationPanel.querySelector('.panel-content'), false);
+            purchaseConfirmationPanel.classList.remove('centered-panel');
+            foodToPurchase = null;
+        }
+
         function openProfileMenu() {
             closeConfigMenuPanel();
             openSettingsPanel();
@@ -4565,6 +4719,10 @@ function setupSlider(slider, display) {
                 window.location.reload();
             });
         }
+
+        if (closeStorePanelButton) closeStorePanelButton.addEventListener('click', closeStoreMenu);
+        if (confirmPurchaseYesButton) confirmPurchaseYesButton.addEventListener('click', confirmPurchase);
+        if (confirmPurchaseNoButton) confirmPurchaseNoButton.addEventListener('click', closePurchaseConfirm);
 
         // --- Specific Info Panel Logic ---
         const specificHelpTexts = {
@@ -8536,6 +8694,30 @@ async function startGame(isRestart = false) {
             btn.addEventListener('touchcancel', removePressed);
         }
 
+        function saveUnlockedFoods() {
+            localStorage.setItem('snakeGameUnlockedFoods', JSON.stringify(unlockedFoods));
+        }
+
+        function loadUnlockedFoods() {
+            try {
+                const data = JSON.parse(localStorage.getItem('snakeGameUnlockedFoods') || '{}');
+                unlockedFoods = { apple: true, ...data };
+            } catch (e) {
+                unlockedFoods = { apple: true };
+            }
+        }
+
+        function updateFoodSelectorAvailability() {
+            if (!foodSelector) return;
+            Array.from(foodSelector.options).forEach(opt => {
+                opt.disabled = !unlockedFoods[opt.value];
+            });
+            if (!unlockedFoods[foodSelector.value]) {
+                foodSelector.value = 'apple';
+                applyFood('apple');
+            }
+        }
+
         addIconPressEvents(configButton, configButtonIcon);
         addIconPressEvents(backButton, backButtonIcon);
         addIconPressEvents(restartMazeButton, restartMazeButtonIcon);
@@ -8546,6 +8728,9 @@ async function startGame(isRestart = false) {
         addIconPressEvents(resetDataButton, resetDataButton);
         addIconPressEvents(confirmResetYesButton, confirmResetYesButton);
         addIconPressEvents(confirmResetNoButton, confirmResetNoButton);
+        addIconPressEvents(confirmPurchaseYesButton, confirmPurchaseYesButton);
+        addIconPressEvents(confirmPurchaseNoButton, confirmPurchaseNoButton);
+        addIconPressEvents(closeStorePanelButton, closeStorePanelButton);
 
         // Original click listeners for D-Pad 
         upButton.addEventListener("click", () => changeDirection("up"));
@@ -8704,6 +8889,7 @@ async function startGame(isRestart = false) {
             playerProfiles[currentPlayerName] = profile;
             savePlayerProfiles();
             localStorage.setItem('snakeGameCoins', totalCoins.toString());
+            saveUnlockedFoods();
             localStorage.setItem('snakePlayerNames', JSON.stringify(Object.keys(playerProfiles)));
             localStorage.setItem('snakeGamePlayerName', currentPlayerName);
             console.log("Configuraciones guardadas en localStorage.");
@@ -8721,6 +8907,8 @@ async function startGame(isRestart = false) {
             updatePlayerNameSelectors(currentPlayerName);
             applyProfile(playerProfiles[currentPlayerName]);
             updateSfxVolume();
+            loadUnlockedFoods();
+            updateFoodSelectorAvailability();
             const savedCoins = parseInt(localStorage.getItem('snakeGameCoins'), 10);
             totalCoins = Number.isFinite(savedCoins) && savedCoins >= 0 ? savedCoins : 0;
 


### PR DESCRIPTION
## Summary
- implement a new store panel for buying food items
- support unlocking foods with coins and saving to localStorage
- update selectors and settings to respect unlocked foods
- style store grid cells

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686fec3443088333a9c39a2511fb8d24