### PR TITLE
Fix unlocked food and coins persistence

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -9137,11 +9137,12 @@ async function startGame(isRestart = false) {
             } else {
                 currentPlayerName = Object.keys(playerProfiles)[0];
             }
+            loadUnlockedFoods(); // Load foods before applying profile
             updatePlayerNameSelectors(currentPlayerName);
             applyProfile(playerProfiles[currentPlayerName]);
             updateSfxVolume();
-            loadUnlockedFoods();
             updateFoodSelectorAvailability();
+            populateStoreItems();
             const savedCoins = parseInt(localStorage.getItem('snakeGameCoins'), 10);
             totalCoins = Number.isFinite(savedCoins) && savedCoins >= 0 ? savedCoins : 0;
 


### PR DESCRIPTION
## Summary
- ensure unlocked food data is loaded before applying the player profile
- refresh store items when game settings load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870c5eb96848333a12a162bbba29bfc