### PR TITLE
Fix selector info panel on mobile

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1565,9 +1565,10 @@
             #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
-            #selector-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
+            #selector-info-bar .info-group { min-height: 55px; padding: 8px 10px 8px 26px; min-width: 80px;}
             #selector-info-bar .info-label { font-size: 0.6em; }
             #selector-info-bar .info-value { font-size: 0.8em; }
+            #selector-info-bar .info-icon-wrapper { width: 40px; height: 40px; transform: translate(10%, -50%); }
 
             /* Slightly shift lives and recovery timer to the right on mobile */
             #livesValue { left: -42px; }
@@ -1667,7 +1668,8 @@
              #top-info-bar .info-group { min-width: 60px;}
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
-             #selector-info-bar .info-group { min-width: 60px;}
+             #selector-info-bar .info-group { min-width: 80px;}
+             #selector-info-bar .info-icon-wrapper { width: 40px; height: 40px; transform: translate(10%, -50%); }
 
             #current-world-info-group .info-label { font-size: 0.55em; }
             #current-world-info-group .info-value { font-size: 0.7em; }


### PR DESCRIPTION
## Summary
- fix layout of selector info panel on small screens by increasing tile size and adjusting icon position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870dedd22748333bb4df2ab8edf2f12