### PR TITLE
Improve mobile selector info bar spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1565,7 +1565,9 @@
             #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
-            #selector-info-bar .info-group { min-height: 55px; padding: 8px 5px 8px 26px; min-width: 80px;}
+            #selector-info-bar { gap: 15px; }
+            #selector-info-bar .info-group { min-height: 50px; padding: 6px 5px 6px 26px; min-width: 80px;}
+            #selector-info-bar .value-box { padding: 6px 8px 6px 26px; }
             #selector-info-bar .info-label { font-size: 0.6em; }
             #selector-info-bar .info-value { font-size: 0.8em; }
             #selector-info-bar .info-icon-wrapper { width: 30px; height: 30px; transform: translate(10%, -50%); }
@@ -1666,9 +1668,11 @@
              #top-info-bar .info-label { font-size: 0.55em; }
              #top-info-bar .info-value { font-size: 0.7em; }
              #top-info-bar .info-group { min-width: 60px;}
+             #selector-info-bar { gap: 10px; }
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
-             #selector-info-bar .info-group { min-width: 80px;}
+             #selector-info-bar .info-group { min-width: 80px; min-height: 48px; padding: 5px 5px 5px 26px; }
+             #selector-info-bar .value-box { padding: 5px 6px 5px 26px; }
              #selector-info-bar .info-icon-wrapper { width: 40px; height: 40px; transform: translate(10%, -50%); }
 
             #current-world-info-group .info-label { font-size: 0.55em; }


### PR DESCRIPTION
## Summary
- shrink gap and min-height on mobile to widen value containers in game type selector
- decrease padding of selector info values on small screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6870e2c9e2088333a1525099a15443a2