### PR TITLE
Ajusta tamaño e interespaciado en barra de info del selector

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -167,8 +167,8 @@
 
         #selector-info-bar {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 25px;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 15px;
             width: 100%;
             margin: 0 auto 5px auto;
             position: relative;
@@ -230,6 +230,7 @@
             min-width: 80px;
             min-height: 55px;
             box-sizing: border-box;
+            width: 100%;
         }
         #selector-info-bar .value-box {
             background-color: #422E58;
@@ -1565,7 +1566,7 @@
             #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
-            #selector-info-bar { gap: 10px; }
+            #selector-info-bar { gap: 8px; }
             #selector-info-bar .info-group { min-height: 40px; padding: 2px 5px 2px 15px; min-width: 80px;}
             #selector-info-bar .value-box { padding: 2px 8px 2px 15px; }
             #selector-info-bar .info-label { font-size: 0.6em; }
@@ -1668,7 +1669,7 @@
              #top-info-bar .info-label { font-size: 0.55em; }
              #top-info-bar .info-value { font-size: 0.7em; }
              #top-info-bar .info-group { min-width: 60px;}
-             #selector-info-bar { gap: 10px; }
+             #selector-info-bar { gap: 8px; }
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
              #selector-info-bar .info-group { min-width: 80px; min-height: 48px; padding: 5px 5px 5px 26px; }


### PR DESCRIPTION
## Summary
- iguala la distribución de columnas en `#selector-info-bar` y le reduce la separación
- garantiza que cada bloque de información ocupe todo el ancho disponible
- reduce el `gap` en los estilos responsivos

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_6870e67aa56c833397c1c978fcf02645