### PR TITLE
Fix selector info layout

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -795,7 +795,13 @@
         #livesValue { left: -56px; right: auto; text-align: left; }
         #lifeTimerValue { left: -13px; }
 
-        #selectorLivesValue,
+        #selectorLivesValue {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+
         #selectorLifeTimerValue {
             position: static;
             transform: none;


### PR DESCRIPTION
## Summary
- style life number with absolute positioning so it doesn't shrink the recovery timer container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870ea47e8b08333b0c6ea5b55170d47