### PR TITLE
Fix selector info layout

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -167,7 +167,7 @@
 
         #selector-info-bar {
             display: grid;
-            grid-template-columns: repeat(3, minmax(0, 1fr));
+            grid-template-columns: repeat(3, 1fr);
             gap: 15px;
             width: 100%;
             margin: 0 auto 5px auto;
@@ -238,6 +238,7 @@
             padding: 8px 10px 8px 26px;
             width: 100%;
             text-align: center;
+            box-sizing: border-box;
         }
         #selector-info-bar .info-icon-wrapper {
             position: absolute;
@@ -795,7 +796,13 @@
         #livesValue { left: -56px; right: auto; text-align: left; }
         #lifeTimerValue { left: -13px; }
 
-        #selectorLivesValue,
+        #selectorLivesValue {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+        }
+
         #selectorLifeTimerValue {
             position: static;
             transform: none;


### PR DESCRIPTION
## Summary
- use `box-sizing: border-box` so padding doesn't shrink life timer container
- simplify grid columns for equal widths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870ea47e8b08333b0c6ea5b55170d47