### PR TITLE
Shrink selector info bar

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -168,12 +168,12 @@
         #selector-info-bar {
             display: grid;
             grid-template-columns: repeat(3, minmax(0, 1fr));
-            gap: 15px;
+            gap: 10px;
             width: 100%;
-            margin: 0 auto 5px auto;
+            margin: 0 auto 4px auto;
             position: relative;
             z-index: 10;
-            padding: 6px;
+            padding: 4px;
             border: 2px solid #2B1D3A;
             border-radius: 10px;
             box-shadow: 0 2px 0 #422E58;
@@ -226,16 +226,16 @@
             align-items: center;
             justify-content: flex-start;
             border-radius: 8px;
-            padding: 8px 10px 8px 26px;
+            padding: 6px 8px 6px 22px;
             min-width: 80px;
-            min-height: 55px;
+            min-height: 48px;
             box-sizing: border-box;
             width: 100%;
         }
         #selector-info-bar .value-box {
             background-color: #422E58;
             border-radius: 8px;
-            padding: 8px 10px 8px 26px;
+            padding: 6px 8px 6px 22px;
             width: 100%;
             text-align: center;
         }
@@ -243,9 +243,9 @@
             position: absolute;
             left: 0;
             top: 50%;
-            transform: translate(20%, -50%);
-            width: 48px;
-            height: 48px;
+            transform: translate(15%, -50%);
+            width: 40px;
+            height: 40px;
         }
         #selector-info-bar .info-icon-wrapper img {
             width: 100%;
@@ -1571,11 +1571,11 @@
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
             #selector-info-bar { gap: 0px; }
-            #selector-info-bar .info-group { min-height: 40px; padding: 2px 5px 2px 15px; min-width: 80px;}
-            #selector-info-bar .value-box { padding: 2px 8px 2px 15px; }
+            #selector-info-bar .info-group { min-height: 34px; padding: 2px 4px 2px 14px; min-width: 80px;}
+            #selector-info-bar .value-box { padding: 2px 6px 2px 14px; }
             #selector-info-bar .info-label { font-size: 0.6em; }
             #selector-info-bar .info-value { font-size: 0.8em; }
-            #selector-info-bar .info-icon-wrapper { width: 30px; height: 30px; transform: translate(15%, -50%); }
+            #selector-info-bar .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
 
             /* Slightly shift lives and recovery timer to the right on mobile */
             #livesValue { left: -42px; }
@@ -1686,9 +1686,9 @@
              #selector-info-bar { gap: 0px; }
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
-             #selector-info-bar .info-group { min-width: 80px; min-height: 48px; padding: 5px 5px 5px 26px; }
-             #selector-info-bar .value-box { padding: 5px 6px 5px 26px; }
-             #selector-info-bar .info-icon-wrapper { width: 40px; height: 40px; transform: translate(15%, -50%); }
+             #selector-info-bar .info-group { min-width: 80px; min-height: 38px; padding: 4px 4px 4px 20px; }
+             #selector-info-bar .value-box { padding: 4px 5px 4px 20px; }
+             #selector-info-bar .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
 
             /* Adjust value positioning on smaller screens */
             #selectorCoinValue,


### PR DESCRIPTION
## Summary
- reduce the padding and icon size in the game selector info bar
- adjust mobile breakpoints for a shorter info bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6870fb2777bc833386097c73c7133fa3