### PR TITLE
Improve in-game info bar

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -157,12 +157,44 @@
 
         #top-info-bar {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            gap: 8px;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 10px;
             width: 100%;
-            margin: 0 auto 5px auto;
+            margin: 0 auto 4px auto;
             position: relative;
             z-index: 10;
+            padding: 4px;
+            border: 2px solid #2B1D3A;
+            border-radius: 10px;
+            box-shadow: 0 2px 0 #422E58;
+        }
+        #top-info-bar::before {
+            content: '';
+            position: absolute;
+            width: calc(100%);
+            height: calc(100%);
+            background: linear-gradient(
+                #D3BAE8 0%,
+                #D3BAE8 50%,
+                #583F7D 50%,
+                #583F7D 100%
+            );
+            border-radius: 10px;
+            pointer-events: none;
+            z-index: -2;
+        }
+        #top-info-bar::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 0;
+            width: 100%;
+            height: 90%;
+            background-color: #8C64AF;
+            border-radius: 10px;
+            transform: translateY(-50%);
+            pointer-events: none;
+            z-index: -1;
         }
 
         #selector-info-bar {
@@ -208,17 +240,36 @@
         }
 
         #top-info-bar .info-group {
+            position: relative;
             display: flex;
-            flex-direction: column;
             align-items: center;
-            justify-content: center;
-            background-color: #374151;
+            justify-content: flex-start;
             border-radius: 8px;
-            padding: 8px 10px;
+            padding: 6px 8px 6px 22px;
             min-width: 80px;
-            min-height: 55px;
+            min-height: 48px;
             box-sizing: border-box;
+            width: 100%;
+        }
+        #top-info-bar .value-box {
+            background-color: #422E58;
+            border-radius: 8px;
+            padding: 6px 8px 6px 22px;
+            width: 100%;
             text-align: center;
+        }
+        #top-info-bar .info-icon-wrapper {
+            position: absolute;
+            left: 0;
+            top: 50%;
+            transform: translate(15%, -50%);
+            width: 40px;
+            height: 40px;
+        }
+        #top-info-bar .info-icon-wrapper img {
+            width: 100%;
+            height: 100%;
+            display: block;
         }
         #selector-info-bar .info-group {
             position: relative;
@@ -261,18 +312,16 @@
             color: #f5f5f5;
         }
         #top-info-bar .info-label {
-            font-size: 0.65em;
-            color: #a0aec0;
-            margin-bottom: 4px;
-            display: block;
-            line-height: 1.1;
-            word-break: break-word;
+            display: none;
         }
         #top-info-bar .info-value {
             font-size: 0.85em;
             color: #f5f5f5;
             font-family: 'Press Start 2P', sans-serif;
             line-height: 1.3;
+        }
+        #target-score-divider {
+            margin: 0 2px;
         }
         #selector-info-bar .info-label {
             font-size: 0.65em;
@@ -1567,9 +1616,12 @@
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
 
-            #top-info-bar .info-group { min-height: 50px; padding: 6px; min-width: 70px;}
+            #top-info-bar { gap: 0px; margin: 0 auto 6px auto; }
+            #top-info-bar .info-group { min-height: 30px; padding: 1px 4px 1px 14px; min-width: 80px; }
+            #top-info-bar .value-box { padding: 1px 6px 1px 14px; }
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
+            #top-info-bar .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             #selector-info-bar { gap: 0px; margin: 0 auto 6px auto; }
             #selector-info-bar .info-group { min-height: 30px; padding: 1px 4px 1px 14px; min-width: 80px; }
             #selector-info-bar .value-box { padding: 1px 6px 1px 14px; }
@@ -1682,7 +1734,9 @@
 
              #top-info-bar .info-label { font-size: 0.55em; }
              #top-info-bar .info-value { font-size: 0.7em; }
-             #top-info-bar .info-group { min-width: 60px;}
+             #top-info-bar .info-group { min-width: 80px; min-height: 34px; padding: 2px 4px 2px 20px; }
+             #top-info-bar .value-box { padding: 2px 5px 2px 20px; }
+             #top-info-bar .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
              #selector-info-bar { gap: 0px; margin: 0 auto 6px auto; }
              #selector-info-bar .info-label { font-size: 0.55em; }
              #selector-info-bar .info-value { font-size: 0.7em; }
@@ -2258,28 +2312,32 @@
 
         <div id="top-info-bar">
             <div id="coins-info-group" class="info-group">
-                <span class="info-label">Monedas:</span>
-                <div class="flex items-center justify-center relative">
-                    <svg class="coin-icon" viewBox="0 0 24 24" fill="none">
-                        <circle cx="12" cy="12" r="9" fill="#FCD34D" stroke="#D97706" stroke-width="2" />
-                    </svg>
+                <div class="info-icon-wrapper">
+                    <img src="https://i.imgur.com/Vrci2mu.png" alt="Monedas" class="info-icon">
+                </div>
+                <div class="value-box">
                     <span id="coinValue" class="info-value">0</span>
                     <span id="earnedCoinsMessage" class="earned-coins-msg hidden">+0</span>
                 </div>
             </div>
             <div id="points-info-group" class="info-group">
-                <span class="info-label">Puntos:</span>
-                <div class="flex items-center justify-center relative">
+                <div class="info-icon-wrapper">
+                    <img src="https://i.imgur.com/GLYt7PU.png" alt="Puntos" class="info-icon">
+                </div>
+                <div class="value-box">
                     <span id="lifeTimerValue" class="info-value hidden absolute">Lleno</span>
-                    <span id="scoreValue" class="info-value">0</span>
-                    <span id="target-score-divider" class="info-value mx-1 hidden">/</span>
-                    <span id="targetScoreValue" class="info-value hidden">0</span>
+                    <span id="scoreValue" class="info-value">0</span><span id="target-score-divider" class="info-value mx-1 hidden">/</span><span id="targetScoreValue" class="info-value hidden">0</span>
                     <span id="livesValue" class="info-value absolute hidden">5</span>
                 </div>
             </div>
             <div id="time-info-group" class="info-group">
-                <span id="timeLengthLabel" class="info-label">Tiempo:</span>
-                <span id="timeLengthValue" class="info-value">60</span>
+                <div class="info-icon-wrapper">
+                    <img src="https://i.imgur.com/7Z1CJGl.png" alt="Tiempo" class="info-icon">
+                </div>
+                <div class="value-box">
+                    <span id="timeLengthLabel" class="info-label hidden">Tiempo:</span>
+                    <span id="timeLengthValue" class="info-value">60</span>
+                </div>
             </div>
         </div>
         
@@ -8846,6 +8904,10 @@ async function startGame(isRestart = false) {
                 modeTransitionStart = null;
                 introOptionAvailable = true;
                 modeSelectIndex = 0;
+                if (gameMode === 'classification' || gameMode === 'freeMode') {
+                    clearGameTimersAndMusic();
+                    gameTimeElapsed = 0;
+                }
                 gameMode = '';
 
                 // Cancel any in-progress transitions


### PR DESCRIPTION
## Summary
- restyle the top info bar to match level selector
- swap in-game values into a layout with icons for coins, points, and time
- keep hidden label for time value so scripts work
- reset timer when exiting free or ranking mode
- tighten spacing around score/target divider

## Testing
- `grep -n "GLYt7PU" -n 'Snake Github.html'`
- `grep -n "7Z1CJGl" 'Snake Github.html'`


------
https://chatgpt.com/codex/tasks/task_b_6871051667c48333979fc2052590261a