### PR TITLE
Fix mobile progress panel display

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1766,10 +1766,11 @@
             #current-world-info-group .info-label { font-size: 0.6em; }
             #current-world-info-group .info-value { font-size: 0.8em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.7em; }
-            #star-progress-wrapper { min-height: 30px; padding: 1px 4px; }
-            #star-progress-wrapper .value-box { padding: 1px 4px; }
+            #star-progress-wrapper { min-height: 36px; padding: 2px 4px; }
+            #star-progress-wrapper .value-box { padding: 2px 4px; }
             #progress-lives-info-group .info-group { min-height: 30px; padding: 1px 4px 1px 14px; }
             #progress-lives-info-group .value-box { padding: 1px 6px 1px 14px; }
+            #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
             #star-progress-container { max-width: 200px; gap: 10px;}
@@ -1890,10 +1891,11 @@
             #current-world-info-group .info-value { font-size: 0.7em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.6em; }
             #current-world-info-group { min-width: 60px; min-height: 34px; padding: 2px 4px 2px 20px; cursor: pointer;}
-            #star-progress-wrapper { min-height: 34px; padding: 2px 4px; }
-            #star-progress-wrapper .value-box { padding: 2px 4px; }
+            #star-progress-wrapper { min-height: 40px; padding: 3px 4px; }
+            #star-progress-wrapper .value-box { padding: 3px 4px; }
             #progress-lives-info-group .info-group { min-height: 34px; padding: 2px 4px 2px 20px; }
             #progress-lives-info-group .value-box { padding: 2px 5px 2px 20px; }
+            #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
             #star-progress-container { max-width: 170px; gap: 8px;}


### PR DESCRIPTION
## Summary
- make life recovery timer font match other values on mobile
- enlarge star progress container on smaller screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6871e44fbec08333bf4104ccebf32918