### PR TITLE
Increase star spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -565,7 +565,7 @@
         #star-progress-container {
             display: grid;
             grid-template-columns: repeat(5, auto);
-            gap: 12px;
+            gap: 16px;
             padding: 0;
             justify-items: center;
             align-items: center;
@@ -1776,7 +1776,7 @@
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { max-width: 200px; gap: 10px;}
+            #star-progress-container { max-width: 200px; gap: 12px;}
 
 
             #d-pad-container {
@@ -1904,7 +1904,7 @@
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { max-width: 170px; gap: 8px;}
+            #star-progress-container { max-width: 170px; gap: 10px;}
 
 
             #d-pad-container {


### PR DESCRIPTION
## Summary
- increase the default spacing between stars in the progress panel
- adjust responsive values to keep the gap larger across screen sizes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_6871ef52362c8333a36a73595e0df5b9