### PR TITLE
Increase star spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -504,6 +504,9 @@
             border-radius: 8px;
             padding: 6px 8px;
             width: 100%;
+            display: flex;
+            justify-content: center;
+            align-items: center;
         }
 
         #progress-lives-info-group {
@@ -565,12 +568,12 @@
         #star-progress-container {
             display: grid;
             grid-template-columns: repeat(5, auto);
-            gap: 12px;
+            gap: 25px;
             padding: 0;
             justify-items: center;
             align-items: center;
             width: max-content;
-            max-width: 260px;
+            max-width: 290px;
             margin: 0 auto;
         }
         .progress-star {
@@ -1770,13 +1773,16 @@
             #star-progress-wrapper .value-box {
                 padding: 2px 4px;
                 min-height: 32px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
             }
             #progress-lives-info-group .info-group { min-height: 30px; padding: 1px 4px 1px 14px; }
             #progress-lives-info-group .value-box { padding: 1px 6px 1px 14px; }
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { max-width: 200px; gap: 10px;}
+            #star-progress-container { max-width: 230px; gap: 19px;}
 
 
             #d-pad-container {
@@ -1898,13 +1904,16 @@
             #star-progress-wrapper .value-box {
                 padding: 3px 4px;
                 min-height: 34px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
             }
             #progress-lives-info-group .info-group { min-height: 34px; padding: 2px 4px 2px 20px; }
             #progress-lives-info-group .value-box { padding: 2px 5px 2px 20px; }
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { max-width: 170px; gap: 8px;}
+            #star-progress-container { max-width: 190px; gap: 16px;}
 
 
             #d-pad-container {


### PR DESCRIPTION
## Summary
- increase the star gap on desktop to 25px and adjust max-width
- scale gaps for tablet and mobile for proportional spacing
- center the stars vertically in the progress panel on all sizes

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6871ef52362c8333a36a73595e0df5b9