### PR TITLE
Fix golden food hue filter

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5544,7 +5544,8 @@ function setupSlider(slider, display) {
                     const drawSize = GRID_SIZE * foodData.scale;
                     const offset = (drawSize - GRID_SIZE) / 2;
                     if (currentFoodItem.isGolden) {
-                        ctx.filter = 'hue-rotate(-50deg) brightness(1.4)';
+                        drawImageWithTint(ctx, foodImg, x * GRID_SIZE - offset, y * GRID_SIZE - offset, drawSize, drawSize, 'rgba(255,215,0,0.35)');
+                        ctx.filter = 'brightness(1.2)';
                     }
                     ctx.drawImage(foodImg, x * GRID_SIZE - offset, y * GRID_SIZE - offset, drawSize, drawSize);
                     ctx.filter = 'none';


### PR DESCRIPTION
## Summary
- adjust golden food filter to use golden tint overlay and brightness instead of hue rotation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6871f7fdb8e08333a630b09897a93fef