### PR TITLE
Replace panel shadows with flat gradient style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1437,11 +1437,7 @@
             background-color: #1F2937;
             padding: 15px;
             border-radius: 12px;
-            box-shadow:
-                inset 0 0 0 4px #8f66af,
-                inset 0 4px 6px #D6BCE9,
-                4px 4px 6px #442F58,
-                0 10px 30px rgba(0,0,0,0.6);
+            box-shadow: 0 2px 0 #422E58;
             z-index: 2100;
             width: 100%;
             max-width: var(--game-max-width);
@@ -1451,6 +1447,38 @@
             border: 2px solid #2d1d3a;
             opacity: 0;
             transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+        }
+
+        #settings-panel::before, #info-panel::before, #specific-info-panel::before, #free-settings-panel::before, #reset-confirmation-panel::before, #config-menu-panel::before, #generic-menu-panel::before, #store-panel::before, #purchase-confirmation-panel::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(
+                #D3BAE8 0%,
+                #D3BAE8 50%,
+                #583F7D 50%,
+                #583F7D 100%
+            );
+            border-radius: 12px;
+            pointer-events: none;
+            z-index: -2;
+        }
+
+        #settings-panel::after, #info-panel::after, #specific-info-panel::after, #free-settings-panel::after, #reset-confirmation-panel::after, #config-menu-panel::after, #generic-menu-panel::after, #store-panel::after, #purchase-confirmation-panel::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 0;
+            width: 100%;
+            height: 90%;
+            background-color: #8C64AF;
+            border-radius: 12px;
+            transform: translateY(-50%);
+            pointer-events: none;
+            z-index: -1;
         }
 
 .panel-content {


### PR DESCRIPTION
## Summary
- revert panel backgrounds
- apply gradient-based shading used by start button

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687234d6f07083338826c43187a54d0e