### PR TITLE
Replace menu shadow style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1440,8 +1440,7 @@
             box-shadow:
                 inset 0 0 0 4px #8f66af,
                 inset 0 4px 6px #D6BCE9,
-                4px 4px 6px #442F58,
-                0 10px 30px rgba(0,0,0,0.6);
+                0 2px 0 #422E58;
             z-index: 2100;
             width: 100%;
             max-width: var(--game-max-width);


### PR DESCRIPTION
## Summary
- match menu box-shadows with flat start button shadow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6872378aaae883338c4f40b3302563d6