### PR TITLE
Estilo degradado solo en paneles

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -836,14 +836,47 @@
             display: flex;
             flex-direction: column;
             justify-content: space-between;
-            background-color: #374151;
-            border-radius: 8px;
             padding: 8px 12px;
             flex: 1;
             min-width: 100px;
             box-sizing: border-box;
-            transition: background-color 0.2s ease;
+            transition: filter 0.2s ease;
             min-height: 50px;
+            border: 2px solid #2B1D3A;
+            border-radius: 10px;
+            box-shadow: 0 2px 0 #422E58;
+        }
+
+        .control-group::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(
+                #D3BAE8 0%,
+                #D3BAE8 50%,
+                #583F7D 50%,
+                #583F7D 100%
+            );
+            border-radius: 10px;
+            pointer-events: none;
+            z-index: -2;
+        }
+
+        .control-group::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 0;
+            width: 100%;
+            height: 90%;
+            background-color: #8C64AF;
+            border-radius: 10px;
+            transform: translateY(-50%);
+            pointer-events: none;
+            z-index: -1;
         }
 
         /* Extra space below the music and SFX volume sliders */
@@ -1054,11 +1087,11 @@
             flex: 1;
         }
         
-        .control-group.interactive-mode { 
-            background-color: #4A5568; 
+        .control-group.interactive-mode {
+            filter: brightness(0.95);
         }
         .control-group.interactive-mode:hover {
-            background-color: #5A6578; 
+            filter: brightness(1.05);
             cursor: pointer;
         }
         .control-group.interactive-mode:hover #difficultySelector,


### PR DESCRIPTION
## Summary
- restaurar el estilo original de los contenedores de menú
- aplicar el mismo estilo degradado del mensaje de monedas a `.control-group`
- ajustar interactividad con brillo en los paneles

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687239ea6964833381f4d52ca2efe92b