### PR TITLE
Adjust high score display width

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -503,7 +503,8 @@
             background-color: #422E58;
             border-radius: 8px;
             padding: 6px 8px;
-            width: 100%;
+            width: max-content;
+            margin: 0 auto;
             display: flex;
             justify-content: center;
             align-items: center;
@@ -596,7 +597,8 @@
             display: flex;
             align-items: center;
             justify-content: flex-start;
-            width: 100%;
+            width: max-content;
+            margin: 0 auto;
             padding: 6px 0 4px 22px;
         }
         #high-score-display .info-icon-wrapper {
@@ -1800,6 +1802,8 @@
                 display: flex;
                 justify-content: center;
                 align-items: center;
+                width: max-content;
+                margin: 0 auto;
             }
             #progress-lives-info-group .info-group { min-height: 30px; padding: 1px 4px 1px 14px; }
             #progress-lives-info-group .value-box { padding: 1px 6px 1px 14px; }
@@ -1930,6 +1934,8 @@
                 display: flex;
                 justify-content: center;
                 align-items: center;
+                width: max-content;
+                margin: 0 auto;
             }
             #progress-lives-info-group .info-group { min-height: 34px; padding: 2px 4px 2px 20px; }
             #progress-lives-info-group .value-box { padding: 2px 5px 2px 20px; }


### PR DESCRIPTION
## Summary
- shrink the high score display so its purple box does not stretch the whole panel
- keep the same behaviour on mobile by overriding the mobile media queries as well

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68736797c5488333bc007cee9d012206