### PR TITLE
Reduce lateral gap of high score panel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -510,7 +510,7 @@
         }
 
         #progress-panel.classification-mode #star-progress-wrapper .value-box {
-            width: 95%;
+            width: 98%;
         }
 
         #progress-panel.classification-mode #star-progress-wrapper {


### PR DESCRIPTION
## Summary
- tweak classification mode high score width to reduce side margins

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687374e1b454833387a7ca89854fedf7