### PR TITLE
Ajustar tamaño de panel de récord y iconos

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -601,6 +601,7 @@
             justify-content: flex-start;
             width: 100%;
             padding: 6px 0 4px 22px;
+            min-height: 48px; /* Igual altura que el temporizador de vidas */
         }
         #high-score-display .info-icon-wrapper {
             position: absolute;
@@ -1757,6 +1758,8 @@
             #high-score-display .hs-label-unit { font-size: 0.45rem; }
             #high-score-display .hs-separator { font-size: 0.55rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 85px; }
+            #high-score-display { min-height: 30px; }
+            #high-score-display .info-icon-wrapper { width: 26px; height: 26px; }
             #high-score-display .value-box { padding: 1px 6px 1px 14px; }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
@@ -1894,6 +1897,8 @@
             #high-score-display .hs-label-unit { font-size: 0.4rem; }
             #high-score-display .hs-separator { font-size: 0.45rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 70px; }
+            #high-score-display { min-height: 34px; }
+            #high-score-display .info-icon-wrapper { width: 32px; height: 32px; }
             #high-score-display .value-box { padding: 2px 5px 2px 20px; }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 


### PR DESCRIPTION
## Summary
- igualar la altura del panel de máxima puntuación al del temporizador de vida
- reducir el icono de máxima puntuación en móviles para mantener proporciones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6873776ae1c08333843a56110af717a6