### PR TITLE
Ajustar tamaño de panel de récord y su icono

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -601,6 +601,7 @@
             justify-content: flex-start;
             width: 100%;
             padding: 6px 0 4px 22px;
+            min-height: 48px; /* Igual altura que el temporizador de vidas */
         }
         #high-score-display .info-icon-wrapper {
             position: absolute;
@@ -628,6 +629,7 @@
             background-color: #422E58;
             border-radius: 8px;
             padding: 6px 8px 6px 22px;
+            min-height: 48px; /* Mantener misma altura visual que otros paneles */
             width: 100%;
             text-align: center;
         }
@@ -1757,7 +1759,12 @@
             #high-score-display .hs-label-unit { font-size: 0.45rem; }
             #high-score-display .hs-separator { font-size: 0.55rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 85px; }
-            #high-score-display .value-box { padding: 1px 6px 1px 14px; }
+            #high-score-display { min-height: 30px; }
+            #high-score-display .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
+            #high-score-display .value-box {
+                padding: 1px 6px 1px 14px;
+                min-height: 30px;
+            }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
             /* Ajustes para mensaje de monedas ganadas en móviles */
@@ -1894,7 +1901,12 @@
             #high-score-display .hs-label-unit { font-size: 0.4rem; }
             #high-score-display .hs-separator { font-size: 0.45rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 70px; }
-            #high-score-display .value-box { padding: 2px 5px 2px 20px; }
+            #high-score-display { min-height: 34px; }
+            #high-score-display .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
+            #high-score-display .value-box {
+                padding: 2px 5px 2px 20px;
+                min-height: 34px;
+            }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
             /* Ajustes para mensaje de monedas ganadas en móviles extra-pequeños */


### PR DESCRIPTION
## Summary
- igualar visualmente la altura del panel de máxima puntuación
- reducir el icono del récord en móviles y alinear como el de las vidas

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6873776ae1c08333843a56110af717a6