### PR TITLE
Fix classification panel height

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -484,7 +484,8 @@
             font-family: 'Press Start 2P', sans-serif;
         }
         #progress-panel.classification-mode #current-world-info-group .info-value {
-            margin-top: 4px;  
+            /* Mantener la misma altura que en el resto de modos */
+            margin-top: 0;
             font-size: 0.7em;
         }
 


### PR DESCRIPTION
## Summary
- ensure progress panel items keep same height across game modes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68738429f1fc8333a1350ba7cdc8d636