### PR TITLE
Ensures stars panel spans full width

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -575,9 +575,8 @@
             gap: 25px;
             justify-items: center;
             align-items: center;
-            width: max-content;
-            max-width: 290px;
-            margin: 0 auto;
+            width: 100%;
+            margin: 0;
         }
         .progress-star {
             width: 38px;
@@ -1824,7 +1823,7 @@
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { max-width: 230px; gap: 19px;}
+            #star-progress-container { width: 100%; gap: 19px; }
 
 
             #d-pad-container {
@@ -1960,7 +1959,7 @@
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { max-width: 190px; gap: 16px;}
+            #star-progress-container { width: 100%; gap: 16px; }
 
 
             #d-pad-container {


### PR DESCRIPTION
## Summary
- make the star panel use full width so the purple container no longer shrinks to the stars
- keep high score panel intact

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6873849135cc8333a7eac68b0ce33538