### PR TITLE
Adjust mobile classification panel spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1758,11 +1758,11 @@
             #high-score-display .hs-label-unit { font-size: 0.65rem; }
             #high-score-display .hs-separator { font-size: 0.65rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 85px; }
-            #high-score-display { min-height: 30px; }
+            #high-score-display { min-height: 26px; }
             #high-score-display .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             #high-score-display .value-box {
-                padding: 1px 6px 1px 14px;
-                min-height: 30px;
+                padding: 0 5px 0 12px;
+                min-height: 26px;
             }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
@@ -1810,10 +1810,10 @@
             #current-world-info-group .info-label { font-size: 0.6em; }
             #current-world-info-group .info-value { font-size: 0.8em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.7em; }
-            #star-progress-wrapper { min-height: 36px; padding: 2px 4px; }
+            #star-progress-wrapper { min-height: 32px; padding: 1px 2px; }
             #star-progress-wrapper .value-box {
-                padding: 2px 4px;
-                min-height: 32px;
+                padding: 1px 2px;
+                min-height: 28px;
                 display: flex;
                 justify-content: center;
                 align-items: center;
@@ -1900,11 +1900,11 @@
             #high-score-display .hs-label-unit { font-size: 0.4rem; }
             #high-score-display .hs-separator { font-size: 0.45rem; }
             #high-score-display #hs-skin-value.hs-value { max-width: 70px; }
-            #high-score-display { min-height: 34px; }
+            #high-score-display { min-height: 30px; }
             #high-score-display .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             #high-score-display .value-box {
-                padding: 2px 5px 2px 20px;
-                min-height: 34px;
+                padding: 1px 4px 1px 16px;
+                min-height: 30px;
             }
             /* --- FIN DE MEDIA QUERY CORREGIDA PARA #high-score-display --- */
 
@@ -1946,10 +1946,10 @@
             #current-world-info-group .info-value { font-size: 0.7em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.6em; }
             #current-world-info-group { min-width: 60px; min-height: 34px; padding: 2px 4px 2px 20px; cursor: pointer;}
-            #star-progress-wrapper { min-height: 40px; padding: 3px 4px; }
+            #star-progress-wrapper { min-height: 34px; padding: 2px 2px; }
             #star-progress-wrapper .value-box {
-                padding: 3px 4px;
-                min-height: 34px;
+                padding: 2px 2px;
+                min-height: 30px;
                 display: flex;
                 justify-content: center;
                 align-items: center;


### PR DESCRIPTION
## Summary
- tweak mobile layout for classification mode
- reduce padding and min-heights for high-score panel
- shrink surrounding panel spacing for smaller screens

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_b_68741063ae648333a13c88128a83c2fc