### PR TITLE
Fix menu overlay

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2077,7 +2077,9 @@
         }
 
         #reset-confirmation-panel { z-index: 2102; }
-        #store-panel { z-index: 2100; }
+        #settings-panel { z-index: 2101; }
+        #generic-menu-panel { z-index: 2101; }
+        #store-panel { z-index: 2101; }
         #purchase-confirmation-panel { z-index: 2103; }
         #modal-overlay {
             position: fixed;
@@ -4702,60 +4704,36 @@ function setupSlider(slider, display) {
         }
 
         function positionPanel(panelElement) {
-            if (panelElement.classList.contains('centered-panel')) {
-                panelElement.style.top = '50%';
-                panelElement.style.bottom = 'auto';
-                panelElement.style.height = 'auto';
-                return;
-            }
-            let topReferenceElement = progressPanel;
-            if (progressPanel.classList.contains('hidden') || !progressPanel.offsetParent) {
-                if (!titlePanel.classList.contains('hidden') && titlePanel.offsetParent) {
-                    topReferenceElement = titlePanel;
-                } else {
-                    topReferenceElement = showModeSelect ? selectorInfoBar : topInfoBar;
-                    if (topReferenceElement.classList.contains('hidden') || !topReferenceElement.offsetParent) {
-                        topReferenceElement = gameContainer;
-                    }
-                }
-            }
-            
-            const mobileControlsEl = document.getElementById('mobile-controls'); 
-
-            if (!topReferenceElement || !mobileControlsEl || !panelElement || !gameContainer) { 
-                console.error("positionPanel: Elemento(s) clave(s) para el posicionamiento no encontrado(s).");
+            if (panelElement.classList.contains("centered-panel")) {
+                panelElement.style.top = "50%";
+                panelElement.style.bottom = "auto";
+                panelElement.style.height = "auto";
+                panelElement.style.left = "50%";
                 return;
             }
 
-            const topRefRect = topReferenceElement.getBoundingClientRect();
-            const mobileControlsRect = mobileControlsEl.getBoundingClientRect(); 
-            const gameContainerRect = gameContainer.getBoundingClientRect();
-            const panelVerticalMargin = 5; 
-
-            let panelTopPosition = topRefRect.top - gameContainerRect.top;
-            if (topReferenceElement === gameContainer) panelTopPosition = 0; 
-            
-            panelElement.style.top = panelTopPosition + 'px';
-            
-            let panelBottomLimit;
-            if (mobileControlsEl.offsetParent === null) {
-                panelBottomLimit = gameContainerRect.height - panelVerticalMargin;
-            } else {
-                panelBottomLimit = mobileControlsRect.top - gameContainerRect.top - panelVerticalMargin;
+            if (!panelElement || !gameContainer || !canvasEl) {
+                console.error("positionPanel: Elemento(s) clave(s) para el posicionamiento no encontrado(s)." );
+                return;
             }
-            let availablePanelHeight = panelBottomLimit - panelTopPosition;
 
-            panelElement.style.height = Math.max(100, availablePanelHeight) + 'px';
-            panelElement.style.bottom = 'auto';
-            const limitSource = mobileControlsEl.offsetParent === null ? 'Contenedor' : 'D-Pad';
-            console.log(`Panel ${panelElement.id} posicionado. Top: ${panelElement.style.top}, Height: ${panelElement.style.height}, Referencia superior: ${topReferenceElement.id}, Límite inferior: ${limitSource}`);
+            const canvasRect = canvasEl.getBoundingClientRect();
+
+            panelElement.style.top = canvasRect.top + "px";
+            panelElement.style.left = canvasRect.left + "px";
+            panelElement.style.height = canvasRect.height + "px";
+            panelElement.style.width = canvasRect.width + "px";
+            panelElement.style.bottom = "auto";
         }
 
         function updateMainButtonStates() {
             const isSettingsVisible = !settingsPanel.classList.contains("settings-panel-hidden") && settingsPanel.classList.contains("panel-visible");
             const isInfoVisible = !infoPanel.classList.contains("info-panel-hidden") && infoPanel.classList.contains("panel-visible");
             const isFreeSettingsVisible = freeSettingsPanel && !freeSettingsPanel.classList.contains("free-settings-panel-hidden") && freeSettingsPanel.classList.contains("panel-visible");
-            const isAnyMainPanelEffectivelyOpen = isSettingsVisible || isInfoVisible || isFreeSettingsVisible;
+            const isConfigMenuVisible = !configMenuPanel.classList.contains("config-menu-panel-hidden") && configMenuPanel.classList.contains("panel-visible");
+            const isGenericMenuVisible = !genericMenuPanel.classList.contains("generic-menu-panel-hidden") && genericMenuPanel.classList.contains("panel-visible");
+            const isStoreVisible = storePanel && !storePanel.classList.contains("store-panel-hidden") && storePanel.classList.contains("panel-visible");
+            const isAnyMainPanelEffectivelyOpen = isSettingsVisible || isInfoVisible || isFreeSettingsVisible || isConfigMenuVisible || isGenericMenuVisible || isStoreVisible;
 
             if (isAnyMainPanelEffectivelyOpen) {
                 startButton.disabled = true;
@@ -4848,7 +4826,12 @@ function setupSlider(slider, display) {
             if (!sourceElement || !targetPanel) return;
             const srcRect = sourceElement.getBoundingClientRect();
             targetPanel.style.top = srcRect.top + 'px';
+            targetPanel.style.left = srcRect.left + 'px';
             targetPanel.style.height = srcRect.height + 'px';
+            targetPanel.style.width = srcRect.width + 'px';
+            if (sourceElement.style.transform) {
+                targetPanel.style.transform = sourceElement.style.transform;
+            }
         }
 
         // --- Panel Management Refactor ---
@@ -4894,9 +4877,15 @@ function setupSlider(slider, display) {
 
                 panelElement.classList.remove(hiddenClassName);
                 positionPanel(panelElement);
-                
+                if (!panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'scale(0.95)';
+                }
+
                 requestAnimationFrame(() => {
                     panelElement.classList.add(visibleClassName);
+                    if (!panelElement.classList.contains('centered-panel')) {
+                        panelElement.style.transform = 'scale(1)';
+                    }
                     const targetScrollElement = contentContainer || panelElement;
                     if (targetScrollElement) {
                         targetScrollElement.scrollTop = 0;
@@ -4943,20 +4932,26 @@ function setupSlider(slider, display) {
                     settingsPanel.querySelectorAll('.setting-info-button').forEach(btn => btn.disabled = false);
                 }
             } else { // Hiding a panel
-                panelElement.classList.remove(visibleClassName); 
+                panelElement.classList.remove(visibleClassName);
+                if (!panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'scale(0.95)';
+                }
                 setTimeout(() => {
-                    panelElement.classList.add(hiddenClassName); 
+                    panelElement.classList.add(hiddenClassName);
                     panelElement.style.top = '';
                     panelElement.style.bottom = '';
                     panelElement.style.height = '';
+                    panelElement.style.width = '';
+                    panelElement.style.left = '';
+                    panelElement.style.transform = '';
                     // Caller of togglePanel(..., false) is now responsible for updateMainButtonStates
-                }, 300); 
+                }, 300);
             }
         }
 
 
         function openSettingsPanel() {
-            settingsPanel.classList.add('centered-panel');
+            settingsPanel.classList.remove('centered-panel');
             togglePanel(settingsPanel, settingsPanelContent, true);
             updateSfxVolume();
             // Show or hide certain settings when accessed from the splash screen
@@ -5082,12 +5077,12 @@ function setupSlider(slider, display) {
             }
         }
 
-       function openFreeSettingsPanel() {
-           freeSettingsPanel.classList.add('centered-panel');
-           togglePanel(freeSettingsPanel, freeSettingsPanelContent, true);
-           if (freeDifficultySelector) {
-               freeDifficultySelector.value = freeDifficulty;
-           }
+        function openFreeSettingsPanel() {
+            freeSettingsPanel.classList.remove('centered-panel');
+            togglePanel(freeSettingsPanel, freeSettingsPanelContent, true);
+            if (freeDifficultySelector) {
+                freeDifficultySelector.value = freeDifficulty;
+            }
            populateFreeSettingsInputs();
             displayHighScoreInPanel();
             updateFreeSettingsLockState();
@@ -5216,6 +5211,8 @@ function setupSlider(slider, display) {
                 const splashContent = document.getElementById('splash-content');
                 requestAnimationFrame(() => {
                     matchPanelSizeWithElement(splashContent, infoPanel);
+                    infoPanel.style.left = '50%';
+                    infoPanel.style.width = '';
                     infoPanel.classList.remove('centered-panel');
                 });
             }
@@ -5319,10 +5316,10 @@ function setupSlider(slider, display) {
         if (profileMenuButton) profileMenuButton.addEventListener('click', openProfileMenu);
         if (customizationMenuButton) customizationMenuButton.addEventListener('click', openCustomizationMenu);
         if (storeMenuButton) storeMenuButton.addEventListener('click', openStoreMenu);
-        if (achievementsMenuButton) achievementsMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Logros'); });
-        if (bonusesMenuButton) bonusesMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Bonificaciones'); });
-        if (dailyMenuButton) dailyMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Premios diarios'); });
-        if (wheelMenuButton) wheelMenuButton.addEventListener('click', () => { closeConfigMenuPanel(); openGenericMenuPanel('Ruleta de premios'); });
+        if (achievementsMenuButton) achievementsMenuButton.addEventListener('click', () => { openGenericMenuPanel('Logros'); });
+        if (bonusesMenuButton) bonusesMenuButton.addEventListener('click', () => { openGenericMenuPanel('Bonificaciones'); });
+        if (dailyMenuButton) dailyMenuButton.addEventListener('click', () => { openGenericMenuPanel('Premios diarios'); });
+        if (wheelMenuButton) wheelMenuButton.addEventListener('click', () => { openGenericMenuPanel('Ruleta de premios'); });
         if (applyFreeSettingsBottomButton) applyFreeSettingsBottomButton.addEventListener('click', applyFreeSettings);
         if (freeDifficultySelector) freeDifficultySelector.addEventListener('change', () => {
             freeDifficulty = freeDifficultySelector.value;
@@ -5365,7 +5362,7 @@ function setupSlider(slider, display) {
         }
 
         function openConfigMenuPanel() {
-            configMenuPanel.classList.add('centered-panel');
+            configMenuPanel.classList.remove('centered-panel');
             togglePanel(configMenuPanel, configMenuPanel.querySelector('.panel-content'), true);
         }
 
@@ -5379,6 +5376,10 @@ function setupSlider(slider, display) {
             if (genericMenuTitle) genericMenuTitle.textContent = title || '';
             genericMenuPanel.classList.add('centered-panel');
             togglePanel(genericMenuPanel, genericMenuPanel.querySelector('.panel-content'), true);
+            requestAnimationFrame(() => {
+                matchPanelSizeWithElement(configMenuPanel, genericMenuPanel);
+                genericMenuPanel.classList.remove('centered-panel');
+            });
         }
 
         function closeGenericMenuPanel() {
@@ -5388,11 +5389,14 @@ function setupSlider(slider, display) {
         }
 
         function openStoreMenu() {
-            closeConfigMenuPanel();
             if (storePanel) {
                 populateStoreItems();
                 storePanel.classList.add('centered-panel');
                 togglePanel(storePanel, storePanel.querySelector('.panel-content'), true);
+                requestAnimationFrame(() => {
+                    matchPanelSizeWithElement(configMenuPanel, storePanel);
+                    storePanel.classList.remove('centered-panel');
+                });
             }
         }
 
@@ -5473,8 +5477,11 @@ function setupSlider(slider, display) {
         }
 
         function openProfileMenu() {
-            closeConfigMenuPanel();
             openSettingsPanel();
+            requestAnimationFrame(() => {
+                matchPanelSizeWithElement(configMenuPanel, settingsPanel);
+                settingsPanel.classList.remove('centered-panel');
+            });
             if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
             if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
@@ -5487,8 +5494,11 @@ function setupSlider(slider, display) {
         }
 
         function openCustomizationMenu() {
-            closeConfigMenuPanel();
             openSettingsPanel();
+            requestAnimationFrame(() => {
+                matchPanelSizeWithElement(configMenuPanel, settingsPanel);
+                settingsPanel.classList.remove('centered-panel');
+            });
             if (playerSelectControlGroup) playerSelectControlGroup.classList.add('hidden');
             if (addPlayerControlGroup) addPlayerControlGroup.classList.add('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- set menu panels to match canvas bounds via `positionPanel`
- sync submenu dimensions and position with the main menu
- keep menus scaled correctly while visible and reset styles on close
- ensure info panel opens with previous splash alignment
- open settings and free settings panels without `centered-panel` so they fill the canvas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68749ed87e448333b9891466803c3b77