### PR TITLE
Add skin and food options to profile menu

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5490,8 +5490,8 @@ function setupSlider(slider, display) {
             if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
             if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
-            skinControlGroup.classList.add('hidden');
-            foodControlGroup.classList.add('hidden');
+            skinControlGroup.classList.remove('hidden');
+            foodControlGroup.classList.remove('hidden');
             difficultyControlGroup.classList.add('hidden');
             audioControlGroup.classList.add('hidden');
             musicVolumeControlGroup.classList.add('hidden');


### PR DESCRIPTION
## Summary
- show skin and food control groups when opening the profile menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6874f93e90d8833386d0d06ae47b3f0b