### PR TITLE
Apply zoom-out exit for splash panels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5066,7 +5066,9 @@ function setupSlider(slider, display) {
             setTimeout(() => { // Ensure buttons are updated after panel animation
                 updateMainButtonStates();
             }, 0);
-            settingsPanel.classList.remove('centered-panel');
+            setTimeout(() => {
+                settingsPanel.classList.remove('centered-panel');
+            }, 300);
 
             if (panelOpenedFromSplash && splashScreen && !splashScreen.classList.contains('hidden')) {
                 if (gameContainer) gameContainer.classList.add('hidden');
@@ -5280,7 +5282,9 @@ function setupSlider(slider, display) {
             setTimeout(() => {
                 updateMainButtonStates();
             }, 0);
-            infoPanel.classList.remove('centered-panel');
+            setTimeout(() => {
+                infoPanel.classList.remove('centered-panel');
+            }, 300);
 
             if (panelOpenedFromSplash && splashScreen && !splashScreen.classList.contains('hidden')) {
                 if (gameContainer) gameContainer.classList.add('hidden');


### PR DESCRIPTION
## Summary
- ensure info and settings panels on the splash screen keep their zoom animation when closing by delaying removal of the `centered-panel` class

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6875d55ee1808333b9f0a3f8326ecb17