### PR TITLE
Implement consistent panel zoom animations

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4870,14 +4870,18 @@ function setupSlider(slider, display) {
 
                 panelElement.classList.remove(hiddenClassName);
                 positionPanel(panelElement);
-                if (!panelElement.classList.contains('centered-panel')) {
-                    panelElement.style.transform = 'scale(0)';
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
+                    panelElement.style.transform = 'translateX(-50%) scale(0)';
                 }
 
                 requestAnimationFrame(() => {
                     panelElement.classList.add(visibleClassName);
-                    if (!panelElement.classList.contains('centered-panel')) {
-                        panelElement.style.transform = 'scale(1)';
+                    if (panelElement.classList.contains('centered-panel')) {
+                        panelElement.style.transform = 'translate(-50%, -50%) scale(1)';
+                    } else {
+                        panelElement.style.transform = 'translateX(-50%) scale(1)';
                     }
                     const targetScrollElement = contentContainer || panelElement;
                     if (targetScrollElement) {
@@ -4926,8 +4930,10 @@ function setupSlider(slider, display) {
                 }
             } else { // Hiding a panel
                 panelElement.classList.remove(visibleClassName);
-                if (!panelElement.classList.contains('centered-panel')) {
-                    panelElement.style.transform = 'scale(0)';
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
+                    panelElement.style.transform = 'translateX(-50%) scale(0)';
                 }
                 setTimeout(() => {
                     panelElement.classList.add(hiddenClassName);


### PR DESCRIPTION
## Summary
- animate all menu panels from scale 0 to 1 regardless of placement
- ensure centered panels also zoom smoothly when opening and closing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6875dbfbade483339a5b1483119c4d05