### PR TITLE
Fix panel alignment with canvas

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1457,8 +1457,8 @@
         }
         #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel, #store-panel, #purchase-confirmation-panel {
             position: fixed;
-            left: 50%;
-            transform: translateX(-50%) scale(0);
+            left: 0;
+            transform: scale(0);
             background-color: #1F2937;
             padding: 15px;
             border-radius: 12px;
@@ -1589,7 +1589,7 @@
         #store-panel.panel-visible,
         #purchase-confirmation-panel.panel-visible {
             opacity: 1;
-            transform: translateX(-50%) scale(1);
+            transform: scale(1);
         }
 
          #specific-info-panel {
@@ -4822,9 +4822,6 @@ function setupSlider(slider, display) {
             targetPanel.style.left = srcRect.left + 'px';
             targetPanel.style.height = srcRect.height + 'px';
             targetPanel.style.width = srcRect.width + 'px';
-            if (sourceElement.style.transform) {
-                targetPanel.style.transform = sourceElement.style.transform;
-            }
         }
 
         // --- Panel Management Refactor ---
@@ -4870,13 +4867,17 @@ function setupSlider(slider, display) {
 
                 panelElement.classList.remove(hiddenClassName);
                 positionPanel(panelElement);
-                if (!panelElement.classList.contains('centered-panel')) {
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
                     panelElement.style.transform = 'scale(0)';
                 }
 
                 requestAnimationFrame(() => {
                     panelElement.classList.add(visibleClassName);
-                    if (!panelElement.classList.contains('centered-panel')) {
+                    if (panelElement.classList.contains('centered-panel')) {
+                        panelElement.style.transform = 'translate(-50%, -50%) scale(1)';
+                    } else {
                         panelElement.style.transform = 'scale(1)';
                     }
                     const targetScrollElement = contentContainer || panelElement;
@@ -4926,7 +4927,9 @@ function setupSlider(slider, display) {
                 }
             } else { // Hiding a panel
                 panelElement.classList.remove(visibleClassName);
-                if (!panelElement.classList.contains('centered-panel')) {
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
                     panelElement.style.transform = 'scale(0)';
                 }
                 setTimeout(() => {


### PR DESCRIPTION
## Summary
- remove horizontal translation for non-centered panels
- ensure JS uses only scale transforms for canvas-aligned menus
- stop copying transforms when matching panel sizes so submenus scale correctly

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6875dbfbade483339a5b1483119c4d05