### PR TITLE
Fix submenus alignment after scaling

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1457,8 +1457,8 @@
         }
         #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel, #store-panel, #purchase-confirmation-panel {
             position: fixed;
-            left: 50%;
-            transform: translateX(-50%) scale(0);
+            left: 0;
+            transform: scale(0);
             background-color: #1F2937;
             padding: 15px;
             border-radius: 12px;
@@ -1589,7 +1589,7 @@
         #store-panel.panel-visible,
         #purchase-confirmation-panel.panel-visible {
             opacity: 1;
-            transform: translateX(-50%) scale(1);
+            transform: scale(1);
         }
 
          #specific-info-panel {
@@ -4822,9 +4822,6 @@ function setupSlider(slider, display) {
             targetPanel.style.left = srcRect.left + 'px';
             targetPanel.style.height = srcRect.height + 'px';
             targetPanel.style.width = srcRect.width + 'px';
-            if (sourceElement.style.transform) {
-                targetPanel.style.transform = sourceElement.style.transform;
-            }
         }
 
         // --- Panel Management Refactor ---
@@ -4870,13 +4867,17 @@ function setupSlider(slider, display) {
 
                 panelElement.classList.remove(hiddenClassName);
                 positionPanel(panelElement);
-                if (!panelElement.classList.contains('centered-panel')) {
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
                     panelElement.style.transform = 'scale(0)';
                 }
 
                 requestAnimationFrame(() => {
                     panelElement.classList.add(visibleClassName);
-                    if (!panelElement.classList.contains('centered-panel')) {
+                    if (panelElement.classList.contains('centered-panel')) {
+                        panelElement.style.transform = 'translate(-50%, -50%) scale(1)';
+                    } else {
                         panelElement.style.transform = 'scale(1)';
                     }
                     const targetScrollElement = contentContainer || panelElement;
@@ -4926,7 +4927,9 @@ function setupSlider(slider, display) {
                 }
             } else { // Hiding a panel
                 panelElement.classList.remove(visibleClassName);
-                if (!panelElement.classList.contains('centered-panel')) {
+                if (panelElement.classList.contains('centered-panel')) {
+                    panelElement.style.transform = 'translate(-50%, -50%) scale(0)';
+                } else {
                     panelElement.style.transform = 'scale(0)';
                 }
                 setTimeout(() => {
@@ -5202,7 +5205,11 @@ function setupSlider(slider, display) {
         }
 
         function openInfoPanel() {
-            infoPanel.classList.add('centered-panel');
+            if (panelOpenedFromSplash) {
+                infoPanel.classList.add('centered-panel');
+            } else {
+                infoPanel.classList.remove('centered-panel');
+            }
             togglePanel(infoPanel, infoPanelContent, true);
             if (panelOpenedFromSplash) {
                 const splashContent = document.getElementById('splash-content');
@@ -5210,7 +5217,7 @@ function setupSlider(slider, display) {
                     if (splashContent) {
                         const rect = splashContent.getBoundingClientRect();
                         infoPanel.style.width = rect.width + 'px';
-                        infoPanel.style.left = (rect.left + rect.width / 2) + 'px';
+                        infoPanel.style.left = rect.left + 'px';
                     }
                 });
             }
@@ -5371,35 +5378,25 @@ function setupSlider(slider, display) {
 
         function openGenericMenuPanel(title) {
             if (genericMenuTitle) genericMenuTitle.textContent = (title || '').toUpperCase();
-            genericMenuPanel.classList.add('centered-panel');
             togglePanel(genericMenuPanel, genericMenuPanel.querySelector('.panel-content'), true);
-            requestAnimationFrame(() => {
-                matchPanelSizeWithElement(configMenuPanel, genericMenuPanel);
-                genericMenuPanel.classList.remove('centered-panel');
-            });
+            matchPanelSizeWithElement(configMenuPanel, genericMenuPanel);
         }
 
         function closeGenericMenuPanel() {
             togglePanel(genericMenuPanel, genericMenuPanel.querySelector('.panel-content'), false);
-            genericMenuPanel.classList.remove('centered-panel');
             setTimeout(updateMainButtonStates, 0);
         }
 
         function openStoreMenu() {
             if (storePanel) {
                 populateStoreItems();
-                storePanel.classList.add('centered-panel');
                 togglePanel(storePanel, storePanel.querySelector('.panel-content'), true);
-                requestAnimationFrame(() => {
-                    matchPanelSizeWithElement(configMenuPanel, storePanel);
-                    storePanel.classList.remove('centered-panel');
-                });
+                matchPanelSizeWithElement(configMenuPanel, storePanel);
             }
         }
 
         function closeStoreMenu() {
             togglePanel(storePanel, storePanel.querySelector('.panel-content'), false);
-            storePanel.classList.remove('centered-panel');
             setTimeout(updateMainButtonStates, 0);
         }
 
@@ -5475,13 +5472,10 @@ function setupSlider(slider, display) {
 
        function openProfileMenu() {
            openSettingsPanel();
-           requestAnimationFrame(() => {
-               matchPanelSizeWithElement(configMenuPanel, settingsPanel);
-               settingsPanel.classList.remove('centered-panel');
-           });
-            if (settingsTitle) settingsTitle.textContent = 'PERFIL';
-            if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
-            if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
+           matchPanelSizeWithElement(configMenuPanel, settingsPanel);
+           if (settingsTitle) settingsTitle.textContent = 'PERFIL';
+           if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
+           if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
             skinControlGroup.classList.remove('hidden');
             foodControlGroup.classList.remove('hidden');
@@ -5590,15 +5584,11 @@ function setupSlider(slider, display) {
                 Array.from(sourcePanel.querySelectorAll('.control-group.interactive-mode')).forEach(el => el.classList.remove("interactive-mode")); // Visually indicate disabled state
             }
 
-            specificInfoPanel.classList.add('centered-panel');
             togglePanel(specificInfoPanel, specificInfoContent, true);
             if (sourcePanel) {
-                requestAnimationFrame(() => {
-                    matchPanelSizeWithElement(sourcePanel, specificInfoPanel);
-                    specificInfoPanel.classList.remove('centered-panel');
-                    applyScrollbarPadding(specificInfoContent);
-                });
+                matchPanelSizeWithElement(sourcePanel, specificInfoPanel);
             }
+            applyScrollbarPadding(specificInfoContent);
         }
 
         function closeSpecificInfoPanel() {


### PR DESCRIPTION
## Summary
- adjust info panel centering only when opened from splash screen
- open generic and store menus without the temporary `centered-panel` class
- position profile menu and info subpanels directly over the config panel
- remove leftover centering logic in closing handlers

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6875dbfbade483339a5b1483119c4d05