### PR TITLE
Add profile player management panel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2701,6 +2701,26 @@
                         <tbody id="classification-ranking-list"></tbody>
                     </table>
                 </div>
+                <div class="control-row" id="player-manage-row">
+                    <div class="control-group hidden" id="player-select-control-group">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="playerNameSelector">Jugador:</label>
+                            <button id="delete-player-name-button" class="setting-info-button" aria-label="Eliminar jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/w5E6xdU.png" alt="Eliminar" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <select id="playerNameSelector"></select>
+                    </div>
+                    <div class="control-group hidden" id="add-player-control-group">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="newPlayerNameInput">Añadir</label>
+                            <button id="confirm-add-player-button" class="setting-info-button" aria-label="Confirmar nuevo jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <input type="text" id="newPlayerNameInput" maxlength="10">
+                    </div>
+                </div>
                 <div class="control-group" id="skin-control-group">
                     <div class="control-label-icon-row">
                         <label class="control-label" for="skinSelector">Disfraz:</label>


### PR DESCRIPTION
## Summary
- add style rules for player management buttons
- add player selection and new player UI in profile menu
- fixed icons for add/remove player buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6875f2877ce48333b5201a2df4039343