### PR TITLE
Add profile info sections

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1545,6 +1545,21 @@
             height: 100%;
             object-fit: contain;
         }
+        #profile-info-button {
+            position: static;
+            top: auto;
+            right: auto;
+            transform: none;
+            background-color: transparent;
+            width: 28px;
+            height: 28px;
+            margin: 0 6px;
+        }
+        #profile-info-button .setting-info-icon {
+            width: 100%;
+            height: 100%;
+            object-fit: contain;
+        }
         #free-settings-panel {
             max-height: 90vh;
             box-sizing: border-box;
@@ -2652,6 +2667,9 @@
                         <button id="classification-info-button" class="setting-info-button hidden" aria-label="Información del modo clasificación" data-setting="difficulty">
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
+                        <button id="profile-info-button" class="setting-info-button hidden" aria-label="Información sobre perfil">
+                            <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                        </button>
                     </div>
                     <button id="close-settings-button" aria-label="Cerrar configuración">&times;</button>
                 </div>
@@ -2662,7 +2680,7 @@
                     <div class="control-group" id="player-name-control-group">
                         <div class="control-label-icon-row">
                             <label class="control-label" for="playerNameSelector">Jugador:</label>
-                            <button class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
+                            <button id="player-name-info-button" class="setting-info-button" data-setting="playerName" aria-label="Información sobre nombre del jugador">
                                 <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                             </button>
                         </div>
@@ -2700,6 +2718,26 @@
                         </thead>
                         <tbody id="classification-ranking-list"></tbody>
                     </table>
+                </div>
+                <div class="control-row" id="player-manage-row">
+                    <div class="control-group hidden" id="player-select-control-group">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="playerNameSelector">Jugador:</label>
+                            <button id="delete-player-name-button" class="setting-info-button" aria-label="Eliminar jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/w5E6xdU.png" alt="Eliminar" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <select id="playerNameSelector"></select>
+                    </div>
+                    <div class="control-group hidden" id="add-player-control-group">
+                        <div class="control-label-icon-row">
+                            <label class="control-label" for="newPlayerNameInput">Añadir</label>
+                            <button id="confirm-add-player-button" class="setting-info-button" aria-label="Confirmar nuevo jugador">
+                                <img class="setting-info-icon" src="https://i.imgur.com/ZGgSVye.png" alt="Añadir" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                            </button>
+                        </div>
+                        <input type="text" id="newPlayerNameInput" maxlength="10">
+                    </div>
                 </div>
                 <div class="control-group" id="skin-control-group">
                     <div class="control-label-icon-row">
@@ -2871,10 +2909,11 @@
 
             <div id="info-panel" class="info-panel-hidden">
                 <div class="info-header">
-                    <h2 id="main-info-title">INFORMACION</h2>
+                    <h2 id="main-info-title">INFORMACIÓN</h2>
                     <button id="close-info-button" aria-label="Cerrar información">&times;</button>
                 </div>
                 <div id="info-panel-content">
+                    <h4>Jugador</h4>
                     <p>¡Prepárate para la clásica diversión de la serpiente con un toque moderno y desafiante!¡Cada partida es una nueva oportunidad para superarte!</p>
 
                     <h4>Cómo Jugar</h4>
@@ -2883,6 +2922,12 @@
                     <h4>Tipos de juego</h4>
                     <p>Accede a la pantalla principal para conocer los diferentes tipos de juego: <strong>Aventura</strong>, <strong>Laberinto</strong>, <strong>Clasificación</strong> y <strong>Libre</strong>. Para más información, puedes pulsar sobre los iconos que te irás encontrando durante el juego.</p>
                     <p style="text-align: center; margin-top: 6px;"><strong>¡Diviértete y que crezca la serpiente!</strong></p>
+
+                    <h4>Disfraz</h4>
+                    <p>Desbloquea disfraces con estética temática u original, juega con el look que más te guste y convierte tu experiencia en algo único y divertido</p><p>La elección del disfraz es <strong>puramente estética</strong>.<p>¡Así que <strong>siéntete libre de experimentar</strong> sin preocuparte por ventajas o desventajas en el juego!</p>
+
+                    <h4>Comestible</h4>
+                    <p>Selecciona el alimento que quieres que aparezca en el escenario entre todos los que hayas desbloqueado. Esta elección <strong>solo afecta al aspecto visual</strong> y no modifica la jugabilidad.</p>
                 </div>
             </div>
 
@@ -3108,6 +3153,9 @@
         if (worldInfoButton) worldInfoButton.removeAttribute('data-setting');
         const mazeInfoButton = document.getElementById("maze-info-button");
         const classificationInfoButton = document.getElementById("classification-info-button");
+        const profileInfoButton = document.getElementById("profile-info-button");
+        if (profileInfoButton) profileInfoButton.removeAttribute('data-setting');
+        const playerNameInfoButton = document.getElementById("player-name-info-button");
         
         const progressPanel = document.getElementById("progress-panel");
         const titlePanel = document.getElementById("title-panel"); 
@@ -4966,6 +5014,8 @@ function setupSlider(slider, display) {
             }
             togglePanel(settingsPanel, settingsPanelContent, true);
             updateSfxVolume();
+            if (profileInfoButton) profileInfoButton.classList.add('hidden');
+            if (playerNameInfoButton) playerNameInfoButton.classList.remove('hidden');
             // Show or hide certain settings when accessed from the splash screen
             if (!gameMode) difficultyControlGroup.classList.add('hidden');
             else difficultyControlGroup.classList.remove('hidden');
@@ -5087,6 +5137,8 @@ function setupSlider(slider, display) {
                 if (gameContainer) gameContainer.classList.add('hidden');
                 panelOpenedFromSplash = false;
             }
+            if (profileInfoButton) profileInfoButton.classList.add('hidden');
+            if (playerNameInfoButton) playerNameInfoButton.classList.remove('hidden');
         }
 
         function openFreeSettingsPanel() {
@@ -5482,6 +5534,8 @@ function setupSlider(slider, display) {
            openSettingsPanel();
            matchPanelSizeWithElement(configMenuPanel, settingsPanel);
            if (settingsTitle) settingsTitle.textContent = 'PERFIL';
+           if (profileInfoButton) profileInfoButton.classList.remove('hidden');
+           if (playerNameInfoButton) playerNameInfoButton.classList.add('hidden');
            if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
            if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
@@ -5591,6 +5645,33 @@ function setupSlider(slider, display) {
                 Array.from(sourcePanel.querySelectorAll('select, input[type="range"], .setting-info-button')).forEach(el => el.disabled = true);
                 Array.from(sourcePanel.querySelectorAll('.control-group.interactive-mode')).forEach(el => el.classList.remove("interactive-mode")); // Visually indicate disabled state
             }
+
+            togglePanel(specificInfoPanel, specificInfoContent, true);
+            if (sourcePanel) {
+                matchPanelSizeWithElement(sourcePanel, specificInfoPanel);
+            }
+            applyScrollbarPadding(specificInfoContent);
+        }
+
+        function openProfileInfoPanel() {
+            if (!specificInfoPanel || !specificInfoTitle || !specificInfoContent) return;
+
+            let sourcePanel = null;
+            if (!settingsPanel.classList.contains('settings-panel-hidden')) {
+                sourcePanel = settingsPanel;
+            } else if (freeSettingsPanel && !freeSettingsPanel.classList.contains('free-settings-panel-hidden')) {
+                sourcePanel = freeSettingsPanel;
+            }
+            if (sourcePanel) {
+                Array.from(sourcePanel.querySelectorAll('select, input[type="range"], .setting-info-button')).forEach(el => el.disabled = true);
+                Array.from(sourcePanel.querySelectorAll('.control-group.interactive-mode')).forEach(el => el.classList.remove('interactive-mode'));
+            }
+
+            specificInfoTitle.textContent = 'INFORMACIÓN';
+            specificInfoContent.innerHTML =
+                `<h4>Jugador</h4>${specificHelpTexts.playerName.text}` +
+                `<h4>Disfraz</h4>${specificHelpTexts.skin.text}` +
+                `<h4>Comestible</h4>${specificHelpTexts.food.text}`;
 
             togglePanel(specificInfoPanel, specificInfoContent, true);
             if (sourcePanel) {
@@ -5714,6 +5795,10 @@ function setupSlider(slider, display) {
                 button.addEventListener('touchcancel', () => icon.classList.remove('icon-button-pressed'));
             }
         });
+
+        if (profileInfoButton) {
+            profileInfoButton.addEventListener('click', openProfileInfoPanel);
+        }
 
         if (worldInfoButton) {
             worldInfoButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- restructure profile help content
- introduce `openProfileInfoPanel` and use for profile info button
- show Disfraz and Comestible help in profile info

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6875f2877ce48333b5201a2df4039343