### PR TITLE
Remove player management from config

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5015,9 +5015,10 @@ function setupSlider(slider, display) {
             skinControlGroup.classList.remove('hidden');
             foodControlGroup.classList.remove('hidden');
             if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
+            if (playerSelectControlGroup) playerSelectControlGroup.classList.add('hidden');
+            if (addPlayerControlGroup) addPlayerControlGroup.classList.add('hidden');
+
             if (panelOpenedFromSplash) {
-                if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
-                if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
                 difficultyControlGroup.classList.add('hidden');
                 skinControlGroup.classList.add('hidden');
                 foodControlGroup.classList.add('hidden');
@@ -5025,8 +5026,6 @@ function setupSlider(slider, display) {
                 resetDataButton.classList.remove('hidden');
                 resetDataButton.classList.add('interactive-mode');
             } else {
-                if (playerSelectControlGroup) playerSelectControlGroup.classList.add('hidden');
-                if (addPlayerControlGroup) addPlayerControlGroup.classList.add('hidden');
                 resetDataButton.classList.add('hidden');
                 resetDataButton.classList.remove('interactive-mode');
             }


### PR DESCRIPTION
## Summary
- hide the add/remove player controls when opening the standard configuration panel
- keep these controls visible in the profile submenu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68761962c21083338dbcb61ef2b3d94b