### PR TITLE
Fix profile menu duplicate selector

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5530,7 +5530,7 @@ function setupSlider(slider, display) {
            if (playerNameInfoButton) playerNameInfoButton.classList.add('hidden');
            if (playerSelectControlGroup) playerSelectControlGroup.classList.remove('hidden');
            if (addPlayerControlGroup) addPlayerControlGroup.classList.remove('hidden');
-           if (playerNameControlGroup) playerNameControlGroup.classList.remove('hidden');
+           if (playerNameControlGroup) playerNameControlGroup.classList.add('hidden');
             skinControlGroup.classList.remove('hidden');
             foodControlGroup.classList.remove('hidden');
             difficultyControlGroup.classList.add('hidden');


### PR DESCRIPTION
## Summary
- hide the single player selector when opening the Profile menu so only the manage row remains

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68761b9dd8fc8333a829e2cd76f74508