### PR TITLE
Fix initial info display in free mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -9616,7 +9616,12 @@ async function startGame(isRestart = false) {
                     screenState.showMazeCover = true;
                 }
                 updateGameModeUI();
-                maybeShowInitialHelpForMode(selectedMode);
+                if (selectedMode === 'freeMode') {
+                    // Delay help display so the free settings panel finishes opening
+                    setTimeout(() => maybeShowInitialHelpForMode(selectedMode), 300);
+                } else {
+                    maybeShowInitialHelpForMode(selectedMode);
+                }
                 draw();
                 updateMainButtonStates();
             } else {


### PR DESCRIPTION
## Summary
- open help panel with a delay when first selecting free mode to ensure it renders correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68764f233a788333bfdb8d8a13f785fe