### PR TITLE
Fix buttons when opening Free Mode settings

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -9212,8 +9212,12 @@ async function startGame(isRestart = false) {
             }
             
             if (!screenState.gameActuallyStarted) { 
-                draw(); 
-                updateMainButtonStates(); 
+                draw();
+                if (selectedMode === 'freeMode') {
+                    setTimeout(updateMainButtonStates, 0);
+                } else {
+                    updateMainButtonStates();
+                }
                 return;
             }
             
@@ -9847,7 +9851,11 @@ async function startGame(isRestart = false) {
                     maybeShowInitialHelpForMode(selectedMode);
                 }
                 draw();
-                updateMainButtonStates();
+                if (selectedMode === 'freeMode') {
+                    setTimeout(updateMainButtonStates, 0);
+                } else {
+                    updateMainButtonStates();
+                }
             } else {
                 startGame(false);
             }


### PR DESCRIPTION
## Summary
- disable main buttons when Free Mode settings panel opens by delaying button update

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_687859771b7c8333b404a4bfbc25c372