### PR TITLE
Fix lives decrement in classification mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7368,7 +7368,7 @@ function setupSlider(slider, display) {
             draw();
             managePostGameOverMusicAndAnimation();
 
-            if (!levelEffectivelyWon) {
+            if (gameMode === 'classification' || !levelEffectivelyWon) {
                 loseLife();
             }
 


### PR DESCRIPTION
## Summary
- ensure lives are deducted when losing in Classification mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6878662819508333b3c93e259902971a