### PR TITLE
Delay item eat reaction

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4476,9 +4476,10 @@ function setupSlider(slider, display) {
         let difficulty = 'principiante';
         let freeDifficulty = 'personalizado';
         let snakeSpeed = 150; 
-        let foodTimeRemaining = 0; 
-        let foodDisappearTimeoutId; 
+        let foodTimeRemaining = 0;
+        let foodDisappearTimeoutId;
         let foodVisualTimerIntervalId;
+        let eatReactionTimeoutId = null;
         let streakMultiplier = 1; 
         let lastWarningSoundSecond = -1; 
 
@@ -4681,6 +4682,7 @@ function setupSlider(slider, display) {
         const LIGHTNING_LIFESPAN = 5000;
         const SPEED_BOOST_DURATION = 3000;
         const REACTION_DISPLAY_TIME = 300;
+        const PRE_EAT_DELAY_MS = 100;
         let obstacles = [];
         let snakeSpawnRow = 0;
         let falseFoodItems = [];
@@ -4713,6 +4715,14 @@ function setupSlider(slider, display) {
         function setReaction(type) {
             currentReaction = type;
             reactionEndTime = Date.now() + REACTION_DISPLAY_TIME;
+        }
+
+        function scheduleEatReaction(type) {
+            if (eatReactionTimeoutId) clearTimeout(eatReactionTimeoutId);
+            eatReactionTimeoutId = setTimeout(() => {
+                setReaction(type);
+                eatReactionTimeoutId = null;
+            }, PRE_EAT_DELAY_MS);
         }
         let speedBoost = { active: false, color: '', change: 0, startTime: 0 };
 
@@ -8494,7 +8504,11 @@ function setupSlider(slider, display) {
                 case "right": nextHeadX++; break;
             }
 
-            if (currentFoodItem.x !== undefined && nextHeadX === currentFoodItem.x && nextHeadY === currentFoodItem.y) {
+            const willEatFood = currentFoodItem.x !== undefined && nextHeadX === currentFoodItem.x && nextHeadY === currentFoodItem.y;
+            const willEatFalse = falseFoodItems.some(ff => ff.x === nextHeadX && ff.y === nextHeadY);
+            const willEatLightning = lightningItems.some(li => li.x === nextHeadX && li.y === nextHeadY);
+            const willEatMirror = mirrorItems.some(mi => mi.x === nextHeadX && mi.y === nextHeadY);
+            if (willEatFood || willEatFalse || willEatLightning || willEatMirror) {
                 setReaction('preEat');
             }
 
@@ -8526,7 +8540,7 @@ function setupSlider(slider, display) {
                 if (currentFoodItem.isGolden) gained *= 2;
                 score += gained;
                 if(areSfxEnabled) playSound('eat');
-                setReaction(currentFoodItem.isGolden ? 'eatGolden' : 'eat');
+                scheduleEatReaction(currentFoodItem.isGolden ? 'eatGolden' : 'eat');
 
                 growth = 1;
                 clearTimeout(foodDisappearTimeoutId);
@@ -8567,7 +8581,7 @@ function setupSlider(slider, display) {
                     if ((gameMode === 'levels' && currentWorld >= 6) || (gameMode === 'classification' && rank >= 2)) startStreakAnimation(streakMultiplier);
                     removeFalseFoodItem(ff);
                     if (areSfxEnabled) playSound('badEat');
-                    setReaction('eatFalse');
+                    scheduleEatReaction('eatFalse');
                 }
             }
             for (let i = lightningItems.length - 1; i >= 0; i--) {
@@ -8576,7 +8590,7 @@ function setupSlider(slider, display) {
                     activateSpeedBoost(lt.color);
                     removeLightningItem(lt);
                     if (areSfxEnabled) playSound('eat');
-                    setReaction('eatSpeed');
+                    scheduleEatReaction('eatSpeed');
                 }
             }
             for (let i = mirrorItems.length - 1; i >= 0; i--) {
@@ -8586,7 +8600,7 @@ function setupSlider(slider, display) {
                     mirrorEffect = { active: true, startTime: Date.now() };
                     removeMirrorItem(mi);
                     if (areSfxEnabled) playSound('eat');
-                    setReaction('eatMirror');
+                    scheduleEatReaction('eatMirror');
                 }
             }
             for (const ob of obstacles) {


### PR DESCRIPTION
## Summary
- add `PRE_EAT_DELAY_MS` constant
- delay the snake's eat reaction instead of pausing the game
- trigger preEat before consuming any item
- delay reactions for false food, speed and mirror items

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687897c84b648333b4d93239003fc0c1