### PR TITLE
Fix default time in free mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4458,8 +4458,8 @@ function setupSlider(slider, display) {
         let gameOverByTimeout = false;
         let gameOverByInactivity = false;
         let gameIntervalId;
-        let gameTimeRemaining;
-        let gameTimeElapsed;
+        let gameTimeRemaining = 0;
+        let gameTimeElapsed = 0;
         let gameTimerIntervalId;
         let lastMovementTime;
         let inactivityIntervalId;


### PR DESCRIPTION
## Summary
- ensure free mode timer starts at `00:00` by initializing `gameTimeElapsed` and `gameTimeRemaining` to zero

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6878b198b5e08333ab85f2a7588f5c9d