### PR TITLE
Fix store tab navigation from profile

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -10936,9 +10936,9 @@ async function startGame(isRestart = false) {
                 updateProfileSelectedItems();
                 switchProfileTab('general');
             } else if (selectInfo.action === 'store') {
+                const targetTab = selectInfo.type === 'food' ? 'comida' : 'disfraces';
                 closeSelectConfirm();
                 closeProfileMenu();
-                const targetTab = selectInfo.type === 'food' ? 'comida' : 'disfraces';
                 // wait for the profile panel closing animation to finish before
                 // showing the store, otherwise the store panel may not appear
                 setTimeout(() => openStoreMenuWithTab(targetTab), 310);


### PR DESCRIPTION
## Summary
- fix logic order when jumping to store from profile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687953a99c2483338666dd8fe3f78795