### PR TITLE
Add margin between player selector and selected items

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3312,7 +3312,7 @@
                 <input type="text" id="newPlayerNameInput" maxlength="10">
             </div>
         </div>
-        <div id="selected-items-row" class="grid grid-cols-2 gap-2 mb-2 w-full">
+        <div id="selected-items-row" class="grid grid-cols-2 gap-2 mb-2 mt-2 w-full">
             <div id="selected-skin-item" class="store-item"></div>
             <div id="selected-food-item" class="store-item"></div>
         </div>


### PR DESCRIPTION
## Summary
- add top margin to the selected costume and food row in profile panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68795cc173108333b6fedd6ef4b7e43f