### PR TITLE
Update grid to 15x15 and resize maze layouts

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4040,8 +4040,8 @@ function setupSlider(slider, display) {
 
 
         // Configuración del juego
-        let GRID_SIZE = 20;
-        const TILE_COUNT = 20;
+        let GRID_SIZE = 15;
+        const TILE_COUNT = 15;
         let tileCountX = TILE_COUNT;
         let tileCountY = TILE_COUNT;
         const DEFAULT_INITIAL_SNAKE_LENGTH = 3; // Used for free mode
@@ -4140,99 +4140,99 @@ function setupSlider(slider, display) {
             // Nivel 1 - bloques en las esquinas
             1: [
                 { x: 0, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 },
-                { x: 18, y: 0 }, { x: 19, y: 0 }, { x: 19, y: 1 },
-                { x: 0, y: 18 }, { x: 0, y: 19 }, { x: 1, y: 19 },
-                { x: 19, y: 18 }, { x: 19, y: 19 }, { x: 18, y: 19 }
+                { x: 13, y: 0 }, { x: 14, y: 0 }, { x: 14, y: 1 },
+                { x: 0, y: 13 }, { x: 0, y: 14 }, { x: 1, y: 14 },
+                { x: 14, y: 13 }, { x: 14, y: 14 }, { x: 13, y: 14 }
             ],
             // Nivel 2 - cuatro bloques centrales de 2x2
             2: [
-                { x: 5, y: 5 }, { x: 6, y: 5 }, { x: 5, y: 6 }, { x: 6, y: 6 },
-                { x: 13, y: 5 }, { x: 14, y: 5 }, { x: 13, y: 6 }, { x: 14, y: 6 },
-                { x: 5, y: 13 }, { x: 6, y: 13 }, { x: 5, y: 14 }, { x: 6, y: 14 },
-                { x: 13, y: 13 }, { x: 14, y: 13 }, { x: 13, y: 14 }, { x: 14, y: 14 }
+                { x: 3, y: 3 }, { x: 4, y: 3 }, { x: 3, y: 4 }, { x: 4, y: 4 },
+                { x: 10, y: 3 }, { x: 11, y: 3 }, { x: 10, y: 4 }, { x: 11, y: 4 },
+                { x: 3, y: 10 }, { x: 4, y: 10 }, { x: 3, y: 11 }, { x: 4, y: 11 },
+                { x: 10, y: 10 }, { x: 11, y: 10 }, { x: 10, y: 11 }, { x: 11, y: 11 }
             ],
             // Nivel 3 - cruz que divide en cuadrantes
             3: (() => {
                 const res = [];
-                for (let i = 0; i < 12; i++) res.push({ x: i + 4, y: 10 });
-                for (let i = 0; i < 12; i++) res.push({ x: 10, y: i + 4 });
+                for (let i = 0; i < 9; i++) res.push({ x: i + 3, y: 7 });
+                for (let i = 0; i < 9; i++) res.push({ x: 7, y: i + 3 });
                 return res;
             })(),
             // Nivel 4 - dos muros verticales con hueco central
             4: (() => {
                 const res = [];
-                for (let y = 1; y < 19; y++) { if (y !== 9 && y !== 10) res.push({ x: 6, y }); }
-                for (let y = 1; y < 19; y++) { if (y !== 9 && y !== 10) res.push({ x: 13, y }); }
+                for (let y = 1; y < 14; y++) { if (y !== 7) res.push({ x: 4, y }); }
+                for (let y = 1; y < 14; y++) { if (y !== 7) res.push({ x: 10, y }); }
                 return res;
             })(),
             // Nivel 5 - rectángulo interior con aperturas en cruz
             5: (() => {
                 const res = [];
-                for (let i = 0; i < 10; i++) { const x = 5 + i; if (x !== 10) res.push({ x, y: 5 }); }
-                for (let i = 0; i < 10; i++) { const x = 5 + i; if (x !== 10) res.push({ x, y: 14 }); }
-                for (let i = 0; i < 8; i++) { const y = 6 + i; if (y !== 10) res.push({ x: 5, y }); }
-                for (let i = 0; i < 8; i++) { const y = 6 + i; if (y !== 10) res.push({ x: 14, y }); }
+                for (let i = 0; i < 8; i++) { const x = 3 + i; if (x !== 7) res.push({ x, y: 3 }); }
+                for (let i = 0; i < 8; i++) { const x = 3 + i; if (x !== 7) res.push({ x, y: 11 }); }
+                for (let i = 0; i < 7; i++) { const y = 4 + i; if (y !== 7) res.push({ x: 3, y }); }
+                for (let i = 0; i < 7; i++) { const y = 4 + i; if (y !== 7) res.push({ x: 11, y }); }
                 return res;
             })(),
             // Nivel 6 - muro vertical con bordes izquierdo e inferior
             6: (() => {
                 const res = [];
-                for (let x = 0; x < 20; x++) {
-    if (x !== 10) res.push({ x, y: 19 });  // bordes inferior, omite x=10
+                for (let x = 0; x < 15; x++) {
+    if (x !== 7) res.push({ x, y: 14 });
 };
-                for (let y = 0; y < 20; y++) {
-    if (y !== 10) res.push({ x: 0, y });   // borde izquierdo, omite y=10
+                for (let y = 0; y < 15; y++) {
+    if (y !== 7) res.push({ x: 0, y });
 };
-                for (let y = 5; y <= 9; y++) res.push({ x: 10, y });
-                for (let y = 11; y <= 15; y++) res.push({ x: 10, y });
+                for (let y = 4; y <= 7; y++) res.push({ x: 7, y });
+                for (let y = 9; y <= 12; y++) res.push({ x: 7, y });
                 return res;
             })(),
             // Nivel 7 - marco alrededor de los bordes con dos líneas horizontales
             7: (() => {
                 const res = [];
-                for (let i=0;i<20;i++) {
-                    if (i !== 10) {
+                for (let i = 0; i < 15; i++) {
+                    if (i !== 7) {
                         res.push({ x: i, y: 0 });
-                        res.push({ x: i, y: 19 });
+                        res.push({ x: i, y: 14 });
                     }
                 }
-                for (let i=1;i<19;i++) {
-                    if (i !== 10) { res.push({x:0,y:i}); res.push({x:19,y:i}); }
+                for (let i = 1; i < 14; i++) {
+                    if (i !== 7) { res.push({ x: 0, y: i }); res.push({ x: 14, y: i }); }
                 }
-                for (let i=0;i<12;i++) { const x = i+4; if (x !== 10) res.push({ x, y: 8 }); }
-                for (let i=0;i<12;i++) { const x = i+4; if (x !== 10) res.push({ x, y: 12 }); }
+                for (let i = 0; i < 9; i++) { const x = i + 3; if (x !== 7) res.push({ x, y: 5 }); }
+                for (let i = 0; i < 9; i++) { const x = i + 3; if (x !== 7) res.push({ x, y: 9 }); }
                 return res;
             })(),
             // Nivel 8 - líneas horizontales y verticales desplazadas
             8: (() => {
                 const res = [];
-                for (let y = 0; y <= 9; y++) res.push({ x: 5, y });
-                for (let y = 11; y <= 19; y++) res.push({ x: 15, y });
-                for (let x = 0; x <= 10; x++) res.push({ x, y: 13 });
-                for (let x = 10; x <= 19; x++) res.push({ x, y: 7 });
+                for (let y = 0; y <= 7; y++) res.push({ x: 3, y });
+                for (let y = 8; y <= 14; y++) res.push({ x: 11, y });
+                for (let x = 0; x <= 7; x++) res.push({ x, y: 10 });
+                for (let x = 7; x <= 14; x++) res.push({ x, y: 5 });
                 return res;
             })(),
             // Nivel 9 - franjas horizontales
             9: (() => {
                 const res = [];
-                for (let i = 0; i < 14; i++) res.push({ x: i + 3, y: 4 });
-                for (let i = 0; i < 14; i++) res.push({ x: i + 3, y: 8 });
-                for (let i = 0; i < 14; i++) res.push({ x: i + 3, y: 12 });
-                for (let i = 0; i < 14; i++) res.push({ x: i + 3, y: 16 });
+                for (let i = 0; i < 11; i++) res.push({ x: i + 2, y: 3 });
+                for (let i = 0; i < 11; i++) res.push({ x: i + 2, y: 6 });
+                for (let i = 0; i < 11; i++) res.push({ x: i + 2, y: 9 });
+                for (let i = 0; i < 11; i++) res.push({ x: i + 2, y: 12 });
                 return res;
             })(),
             // Nivel 10 - franjas horizontales con Marco exterior con huecos
             10: (() => {
                 const res = [];
-                for (let i = 0; i < 16; i++) res.push({ x: i + 2, y: 4 });
-                for (let i = 0; i < 16; i++) res.push({ x: i + 2, y: 8 });
-                for (let i = 0; i < 16; i++) res.push({ x: i + 2, y: 12 });
-                for (let i = 0; i < 16; i++) res.push({ x: i + 2, y: 16 });
+                for (let i = 0; i < 13; i++) res.push({ x: i + 1, y: 3 });
+                for (let i = 0; i < 13; i++) res.push({ x: i + 1, y: 6 });
+                for (let i = 0; i < 13; i++) res.push({ x: i + 1, y: 9 });
+                for (let i = 0; i < 13; i++) res.push({ x: i + 1, y: 12 });
             // Marco exterior con huecos
-                for (let i = 0; i < 20; i++) { if (i !== 1 && i !== 18)  res.push({ x: i,  y: 0  }); }  // arriba
-                for (let i = 0; i < 20; i++) { if (i !== 1 && i !== 18) res.push({ x: i,  y: 19 }); }  // abajo
-                for (let i = 1; i < 19; i++) { if (i !== 10) res.push({ x: 0,  y: i  }); }  // izquierda
-                for (let i = 1; i < 19; i++) { if (i !== 10) res.push({ x: 19, y: i  }); }  // derecha
+                for (let i = 0; i < 15; i++) { if (i !== 1 && i !== 13) res.push({ x: i, y: 0 }); }
+                for (let i = 0; i < 15; i++) { if (i !== 1 && i !== 13) res.push({ x: i, y: 14 }); }
+                for (let i = 1; i < 14; i++) { if (i !== 7) res.push({ x: 0, y: i }); }
+                for (let i = 1; i < 14; i++) { if (i !== 7) res.push({ x: 14, y: i }); }
                 return res;
             })()
         };


### PR DESCRIPTION
## Summary
- enlarge game board by changing `GRID_SIZE` and `TILE_COUNT` to 15
- scale each maze level layout to the new 15x15 grid

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6879e0a8b6388333958d1f72ce490e0f