### PR TITLE
Fix layout by removing stray closing tag

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2871,9 +2871,8 @@
                     </div>
                     <div class="value-box">
                         <span id="progressLifeTimerValue" class="info-value">Lleno</span>
-                    </div>
-                </div>
-            </div>
+        </div>
+    </div>
             <div id="star-progress-wrapper" class="panel-card">
                 <div id="star-progress-container" class="value-box hidden">
                 </div>
@@ -3362,7 +3361,6 @@
         </div>
 
     </div>
-</div>
 </div>
             <div id="store-panel" class="store-panel-hidden">
                 <div class="settings-header">


### PR DESCRIPTION
## Summary
- fix unmatched closing div in profile panel causing layout issues

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6879ed8c03208333a08f1b359b2d6ec1