### PR TITLE
Fix life purchase queue logic

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -6310,7 +6310,7 @@ function setupSlider(slider, display) {
             if (!purchaseInfo) { closePurchaseConfirm(); return; }
             let price = 0;
             let success = false;
-            let failureMessage = null;
+            let failureMessage;
             if (purchaseInfo.type === 'food') {
                 price = FOODS[purchaseInfo.key].price;
                 if (totalCoins >= price) {
@@ -6335,8 +6335,11 @@ function setupSlider(slider, display) {
                     if (totalCoins >= price && playerLives < MAX_LIVES) {
                         totalCoins -= price;
                         playerLives++;
+                        if (lifeRestoreQueue.length > 0) lifeRestoreQueue.shift();
+                        if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
                         saveLives();
                         updateLivesDisplay();
+                        updateLifeTimerDisplay();
                         success = true;
                     } else if (playerLives >= MAX_LIVES) {
                         failureMessage = 'Vidas al máximo';


### PR DESCRIPTION
## Summary
- when buying lives, remove old timers and reset timer display
- show default insufficient funds message if short on coins

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687ab92c4f608333a3f2e8f7b81fe15b