### PR TITLE
Adjust score font size for adventure and maze

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -329,6 +329,9 @@
             font-family: 'Press Start 2P', sans-serif;
             line-height: 1.3;
         }
+        #points-info-group .info-value {
+            font-size: 0.75em;
+        }
         #target-score-divider {
             margin: 0 2px;
         }
@@ -1872,6 +1875,7 @@
             #top-info-bar .value-box { padding: 1px 6px 1px 14px; }
             #top-info-bar .info-label { font-size: 0.6em; }
             #top-info-bar .info-value { font-size: 0.8em; }
+            #points-info-group .info-value { font-size: 0.7em; }
             #top-info-bar .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             #selector-info-bar { gap: 0px; margin: 0 auto 6px auto; }
             #selector-info-bar .info-group { min-height: 30px; padding: 1px 4px 1px 14px; min-width: 80px; }
@@ -2021,6 +2025,7 @@
 
              #top-info-bar .info-label { font-size: 0.55em; }
              #top-info-bar .info-value { font-size: 0.7em; }
+             #points-info-group .info-value { font-size: 0.6em; }
              #top-info-bar .info-group { min-width: 80px; min-height: 34px; padding: 2px 4px 2px 20px; }
              #top-info-bar .value-box { padding: 2px 5px 2px 20px; }
              #top-info-bar .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }


### PR DESCRIPTION
## Summary
- lower points font size for regular layout
- tweak points font in responsive CSS queries

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687bdaeeee688333b551c2d99ede7c13