### PR TITLE
Skip overlapping body segments

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8731,7 +8731,11 @@ function setupSlider(slider, display) {
                     obstacles.forEach(ob => drawObstacle(ob));
                 }
                 // Draw snake body
+                const headPos = snake[0];
                 for (let i = 1; i < snake.length; i++) {
+                    if (snake[i].x === headPos.x && snake[i].y === headPos.y) {
+                        continue; // Avoid drawing body segment over the head
+                    }
                     const segmentX = snake[i].x * GRID_SIZE;
                     const segmentY = snake[i].y * GRID_SIZE;
                     const skinData = SKINS[currentSkin];


### PR DESCRIPTION
## Summary
- revert previous attempt at smooth movement
- skip drawing snake body segments that overlap the head

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687c0feddb5c8333ac909f90ad779111