### PR TITLE
Restore previous movement logic

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8732,6 +8732,9 @@ function setupSlider(slider, display) {
                 }
                 // Draw snake body
                 for (let i = 1; i < snake.length; i++) {
+                    if (snake[i].x === snake[0].x && snake[i].y === snake[0].y) {
+                        continue;
+                    }
                     const segmentX = snake[i].x * GRID_SIZE;
                     const segmentY = snake[i].y * GRID_SIZE;
                     const skinData = SKINS[currentSkin];


### PR DESCRIPTION
## Summary
- revert smooth-rendering changes
- skip drawing body segments if they overlap the snake head

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687c0feddb5c8333ac909f90ad779111