### PR TITLE
Fix snake head flicker

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8731,9 +8731,17 @@ function setupSlider(slider, display) {
             }
 
 
-            if (tileCountX <= 0 || tileCountY <= 0) return; 
+            if (tileCountX <= 0 || tileCountY <= 0) return;
 
-            const currentSkinData = SKINS[currentSkin]; 
+            const currentSkinData = SKINS[currentSkin];
+            let headRenderPos = null;
+            if (snake.length > 0) {
+                const ph = prevSnake[0] || snake[0];
+                headRenderPos = {
+                    x: interpolateCoord(ph.x, snake[0].x, tileCountX, moveProgress),
+                    y: interpolateCoord(ph.y, snake[0].y, tileCountY, moveProgress)
+                };
+            }
 
             if (!gameOver) {
                 if (obstacles.length > 0) {
@@ -8745,6 +8753,9 @@ function setupSlider(slider, display) {
                                     : prevSnake[prevSnake.length - 1]) || snake[i];
                     const renderX = interpolateCoord(prevSeg.x, snake[i].x, tileCountX, moveProgress);
                     const renderY = interpolateCoord(prevSeg.y, snake[i].y, tileCountY, moveProgress);
+                    if (headRenderPos && Math.abs(renderX - headRenderPos.x) < 0.001 && Math.abs(renderY - headRenderPos.y) < 0.001) {
+                        continue;
+                    }
                     const segmentX = renderX * GRID_SIZE;
                     const segmentY = renderY * GRID_SIZE;
                     const skinData = SKINS[currentSkin];


### PR DESCRIPTION
## Summary
- avoid drawing a body segment if it overlaps with the head
- calculate the head position early in the draw routine

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c4d6be480833386d24ebeed3d6237