### PR TITLE
Fix head texture flicker

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8733,7 +8733,13 @@ function setupSlider(slider, display) {
 
             if (tileCountX <= 0 || tileCountY <= 0) return; 
 
-            const currentSkinData = SKINS[currentSkin]; 
+            const currentSkinData = SKINS[currentSkin];
+
+            const prevHead = prevSnake[0] || snake[0];
+            const headRender = {
+                x: interpolateCoord(prevHead.x, snake[0].x, tileCountX, moveProgress),
+                y: interpolateCoord(prevHead.y, snake[0].y, tileCountY, moveProgress)
+            };
 
             if (!gameOver) {
                 if (obstacles.length > 0) {
@@ -8745,6 +8751,10 @@ function setupSlider(slider, display) {
                                     : prevSnake[prevSnake.length - 1]) || snake[i];
                     const renderX = interpolateCoord(prevSeg.x, snake[i].x, tileCountX, moveProgress);
                     const renderY = interpolateCoord(prevSeg.y, snake[i].y, tileCountY, moveProgress);
+
+                    if (i === 1 && Math.abs(renderX - headRender.x) < 1e-6 && Math.abs(renderY - headRender.y) < 1e-6) {
+                        continue;
+                    }
                     const segmentX = renderX * GRID_SIZE;
                     const segmentY = renderY * GRID_SIZE;
                     const skinData = SKINS[currentSkin];
@@ -8867,11 +8877,7 @@ function setupSlider(slider, display) {
 
                 // Draw snake head
                 if (snake.length > 0) {
-                    const prevHead = prevSnake[0] || snake[0];
-                    const head = {
-                        x: interpolateCoord(prevHead.x, snake[0].x, tileCountX, moveProgress),
-                        y: interpolateCoord(prevHead.y, snake[0].y, tileCountY, moveProgress)
-                    };
+                    const head = headRender;
                     if (currentSkinData && currentSkinData.snakeHeadAsset) {
                         let imgToDraw;
                         let baseImageForUp = currentSkinData.snakeHeadAsset.upDown;


### PR DESCRIPTION
## Summary
- prevent the first body segment from drawing over the head during movement
- compute head position once and reuse it for drawing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c4d6be480833386d24ebeed3d6237