### PR TITLE
Fix texture flicker on snake head

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8652,7 +8652,7 @@ function setupSlider(slider, display) {
                 const remaining = SPEED_BOOST_DURATION - (Date.now() - speedBoost.startTime);
                 if (remaining > 0) {
                     speedBoostOverlayColor = speedBoost.color === 'yellow' ? 'rgba(255,255,0,0.3)' : 'rgba(255,0,0,0.3)';
-                    speedBoostVisible = remaining > 1000 || Math.floor(remaining / 100) % 2 === 0;
+                    speedBoostVisible = remaining > 0;
                 }
             }
             let mirrorVisible = false;
@@ -8669,7 +8669,7 @@ function setupSlider(slider, display) {
                 }
                 const remaining = effectDuration - (Date.now() - mirrorEffect.startTime);
                 if (remaining > 0) {
-                    mirrorVisible = remaining > 1000 || Math.floor(remaining / 100) % 2 === 0;
+                    mirrorVisible = remaining > 0;
                 } else {
                     mirrorEffect.active = false;
                 }


### PR DESCRIPTION
## Summary
- ensure speed boost overlay stays visible instead of blinking at the end
- show mirror effect overlay continuously for its duration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c4d6be480833386d24ebeed3d6237