### PR TITLE
Fix head overlay flicker

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8652,7 +8652,7 @@ function setupSlider(slider, display) {
                 const remaining = SPEED_BOOST_DURATION - (Date.now() - speedBoost.startTime);
                 if (remaining > 0) {
                     speedBoostOverlayColor = speedBoost.color === 'yellow' ? 'rgba(255,255,0,0.3)' : 'rgba(255,0,0,0.3)';
-                    speedBoostVisible = remaining > 1000 || Math.floor(remaining / 100) % 2 === 0;
+                    speedBoostVisible = true; // keep overlay visible without flicker
                 }
             }
             let mirrorVisible = false;
@@ -8669,7 +8669,7 @@ function setupSlider(slider, display) {
                 }
                 const remaining = effectDuration - (Date.now() - mirrorEffect.startTime);
                 if (remaining > 0) {
-                    mirrorVisible = remaining > 1000 || Math.floor(remaining / 100) % 2 === 0;
+                    mirrorVisible = true; // keep overlay visible without flicker
                 } else {
                     mirrorEffect.active = false;
                 }
@@ -8741,6 +8741,7 @@ function setupSlider(slider, display) {
                 }
                 // Draw snake body
                 for (let i = 1; i < snake.length; i++) {
+                    const hideSegment = i === 1;
                     const prevSeg = (i - 1 < prevSnake.length ? prevSnake[i - 1]
                                     : prevSnake[prevSnake.length - 1]) || snake[i];
                     const renderX = interpolateCoord(prevSeg.x, snake[i].x, tileCountX, moveProgress);
@@ -8766,6 +8767,7 @@ function setupSlider(slider, display) {
                     const dx = normalizedDiff(prev.x, snake[i].x, tileCountX);
                     const dy = normalizedDiff(prev.y, snake[i].y, tileCountY);
                     ctx.save();
+                    if (hideSegment) ctx.globalAlpha = 0;
                     ctx.translate(segmentX + GRID_SIZE / 2, segmentY + GRID_SIZE / 2);
                     let rotation = 0;
                     let scaleX = 1;
@@ -8834,6 +8836,8 @@ function setupSlider(slider, display) {
                         }
                         ctx.restore();
                     } else {
+                        ctx.save();
+                        if (hideSegment) ctx.globalAlpha = 0;
                         ctx.fillStyle = skinData.bodyTintColor || '#A8F031';
                         ctx.fillRect(segmentX, segmentY, GRID_SIZE, GRID_SIZE);
                         if (speedBoostVisible) {
@@ -8848,6 +8852,7 @@ function setupSlider(slider, display) {
                             ctx.fillRect(segmentX, segmentY, GRID_SIZE, GRID_SIZE);
                             ctx.globalCompositeOperation = 'source-over';
                         }
+                        ctx.restore();
                     }
                 }
 


### PR DESCRIPTION
## Summary
- remove flicker logic from speed boost and mirror effects so textures over the snake head stay stable
- hide the first snake segment so it's not visible under smaller head graphics

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687c4d6be480833386d24ebeed3d6237