### PR TITLE
Fix first snake segment overlap

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -4051,6 +4051,7 @@ function setupSlider(slider, display) {
         let initialSnakeLength = DEFAULT_INITIAL_SNAKE_LENGTH;
         const MAX_STREAK = 5;
         const STREAK_ANIMATION_DURATION = 1000; // ms that streak value is shown above head
+        const FIRST_SEGMENT_OFFSET_PX = 2;
         
         // Mapping for difficulty display names
         const DIFFICULTY_DISPLAY_NAMES = {
@@ -8766,7 +8767,13 @@ function setupSlider(slider, display) {
                     const dx = normalizedDiff(prev.x, snake[i].x, tileCountX);
                     const dy = normalizedDiff(prev.y, snake[i].y, tileCountY);
                     ctx.save();
-                    ctx.translate(segmentX + GRID_SIZE / 2, segmentY + GRID_SIZE / 2);
+                    let extraX = 0;
+                    let extraY = 0;
+                    if (i === 1) {
+                        extraX = -dx * FIRST_SEGMENT_OFFSET_PX;
+                        extraY = -dy * FIRST_SEGMENT_OFFSET_PX;
+                    }
+                    ctx.translate(segmentX + GRID_SIZE / 2 + extraX, segmentY + GRID_SIZE / 2 + extraY);
                     let rotation = 0;
                     let scaleX = 1;
                     let scaleY = 1;


### PR DESCRIPTION
## Summary
- add constant `FIRST_SEGMENT_OFFSET_PX`
- shift the first body segment slightly away from the head when drawing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687c643d3d8c833380115a548e201f44