### PR TITLE
Fix coin gain animation layering

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -959,23 +959,24 @@
             position: absolute;
             top: 50%;
             left: 100%;
-            transform: translateX(-50px) translateY(-50%);
+            transform: translateX(40px) translateY(-50%);
             color: #4ade80;
             font-size: 1em;
             white-space: nowrap;
             opacity: 0;
             transition: opacity 0.3s, transform 0.5s;
             pointer-events: none;
+            z-index: 30;
         }
 
         #earnedCoinsMessage.show {
             opacity: 1;
-            transform: translateX(-55px) translateY(-50%);
+            transform: translateX(10px) translateY(-50%);
         }
 
         #earnedCoinsMessage.hide {
             opacity: 0;
-            transform: translateX(-100px) translateY(-50%);
+            transform: translateX(80px) translateY(-50%);
         }
 
         #livesValue {
@@ -1860,13 +1861,14 @@
             /* Ajustes para mensaje de monedas ganadas en móviles */
             #earnedCoinsMessage {
                 font-size: 0.8em;
-                transform: translateX(-30px) translateY(-50%);
+                transform: translateX(30px) translateY(-50%);
+                z-index: 30;
             }
             #earnedCoinsMessage.show {
-                transform: translateX(-35px) translateY(-50%);
+                transform: translateX(5px) translateY(-50%);
             }
             #earnedCoinsMessage.hide {
-                transform: translateX(-70px) translateY(-50%);
+                transform: translateX(60px) translateY(-50%);
             }
 
 
@@ -2007,13 +2009,14 @@
             /* Ajustes para mensaje de monedas ganadas en móviles extra-pequeños */
             #earnedCoinsMessage {
                 font-size: 0.75em;
-                transform: translateX(-25px) translateY(-40%);
+                transform: translateX(25px) translateY(-40%);
+                z-index: 30;
             }
             #earnedCoinsMessage.show {
-                transform: translateX(-30px) translateY(-40%);
+                transform: translateX(0px) translateY(-40%);
             }
             #earnedCoinsMessage.hide {
-                transform: translateX(-60px) translateY(-40%);
+                transform: translateX(50px) translateY(-40%);
             }
 
             #title-panel { min-height: 36px; padding: 6px; }


### PR DESCRIPTION
## Summary
- adjust earned coins message positioning to avoid overlap
- keep message above other HUD elements
- tweak mobile styles for entry/exit animation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687e9a22325c83338c2b5c710202dc12