### PR TITLE
Disable maze obstacles on veteran and legendary levels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7689,11 +7689,13 @@ function setupSlider(slider, display) {
             reactionEndTime = 0;
         }
 
-        function generateMazeLevel(levelIndex) {
+       function generateMazeLevel(levelIndex) {
             obstacles = [];
-            const layout = MAZE_LAYOUTS[((levelIndex - 1) % MAZE_LEVELS_PER_DIFFICULTY) + 1];
-            if (layout) {
-                obstacles = layout.map(pos => ({ x: pos.x, y: pos.y, img: obstacleImg }));
+            if (levelIndex <= MAZE_LEVELS_PER_DIFFICULTY * 2) {
+                const layout = MAZE_LAYOUTS[((levelIndex - 1) % MAZE_LEVELS_PER_DIFFICULTY) + 1];
+                if (layout) {
+                    obstacles = layout.map(pos => ({ x: pos.x, y: pos.y, img: obstacleImg }));
+                }
             }
         }
 
@@ -10341,12 +10343,8 @@ async function startGame(isRestart = false) {
                 if (rank >= 2) startWorld6LightningMechanics();
                 if (rank >= 3) {
                     startWorld4FalseFoodMechanics();
-                    const count = cfg.obstacleCount;
-                    if (rank >= 4) {
-                        startWorld8Obstacles(count);
-                    } else {
-                        startWorld6Obstacles(count);
-                    }
+                    // En modo laberinto no generamos obstáculos adicionales en
+                    // dificultades veterano o legendario
                     startWorld7MirrorMechanics();
                 }
                 startMazeLevel();


### PR DESCRIPTION
## Summary
- update maze level generation to skip obstacles when level index is above 20
- avoid spawning extra obstacles in veteran/legendary maze difficulties

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ea8147fa88333b17282cf055e1f47