### PR TITLE
Add loading screen and preload images

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -48,6 +48,85 @@
             display: none !important;
         }
 
+        #loading-screen {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background-color: #111827;
+            z-index: 2500;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        #loading-content {
+            width: 100%;
+            max-width: var(--game-max-width);
+            height: 100%;
+            display: flex;
+            background-color: #02010a;
+            background-image: url(https://i.imgur.com/rYyiiMo.png);
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+            flex-direction: column;
+            justify-content: space-between;
+            align-items: center;
+            padding: 20px 0;
+            border-radius: 12px;
+            box-sizing: border-box;
+        }
+
+        #loading-bottom-image {
+            width: 100%;
+            max-width: var(--game-max-width);
+            height: auto;
+            max-height: calc(25vh + 60px);
+            object-fit: contain;
+            box-sizing: border-box;
+            padding-top: 40px;
+            padding-bottom: 40px;
+        }
+
+        .loader {
+            -webkit-perspective: 700px;
+            perspective: 700px;
+        }
+
+        .loader > span {
+            font-size: 130px;
+            display: inline-block;
+            animation: flip 2.6s infinite linear;
+            transform-origin: 0 70%;
+            transform-style: preserve-3d;
+            -webkit-transform-style: preserve-3d;
+            color: #8C64AF;
+            font-family: 'Press Start 2P', sans-serif;
+        }
+
+        .loader > span:nth-child(even) {
+            color: white;
+        }
+
+        @keyframes flip {
+            35% {
+                transform: rotateX(360deg);
+            }
+            100% {
+                transform: rotateX(360deg);
+            }
+        }
+
+        .loader > span:nth-child(2) { animation-delay: 0.3s; }
+        .loader > span:nth-child(3) { animation-delay: 0.6s; }
+        .loader > span:nth-child(4) { animation-delay: 0.9s; }
+        .loader > span:nth-child(5) { animation-delay: 1.2s; }
+        .loader > span:nth-child(6) { animation-delay: 1.5s; }
+        .loader > span:nth-child(7) { animation-delay: 1.8s; }
+        .loader > span:nth-child(8) { animation-delay: 2.1s; }
+
         #splash-screen {
             position: fixed;
             top: 0;
@@ -2850,6 +2929,14 @@
     </style>
 </head>
 <body>
+        <div id="loading-screen">
+            <div id="loading-content">
+                <div class="loader">
+                    <span>C</span><span>A</span><span>R</span><span>G</span><span>A</span><span>N</span><span>D</span><span>O</span>
+                </div>
+                <img id="loading-bottom-image" src="https://i.imgur.com/YJ1xHZO.png" alt="Imagen inferior" onerror="this.src='https://placehold.co/600x150/02030D/FFFFFF?text=Load+Error';">
+            </div>
+        </div>
         <div id="splash-screen">
             <div id="splash-content">
                 <img id="splash-top-image" src="https://i.imgur.com/kG4NmSM.png" alt="Logotipo superior del splash" onerror="this.src='https://placehold.co/600x200/02030D/FFFFFF?text=Splash+Top+Error'; console.error('Error loading splash-top-image');">
@@ -3534,8 +3621,9 @@
         }
 
         // Selección de elementos del DOM
-        const splashScreen = document.getElementById("splash-screen"); 
-        const canvasEl = document.getElementById("gameCanvas"); 
+        const splashScreen = document.getElementById("splash-screen");
+        const loadingScreen = document.getElementById("loading-screen");
+        const canvasEl = document.getElementById("gameCanvas");
         let ctx; 
         const gameContainer = document.querySelector('.game-container'); 
         const coinValueDisplay = document.getElementById("coinValue");
@@ -3822,6 +3910,7 @@ function setupSlider(slider, display) {
 
 
         // --- INICIO: Declaración de Objetos Image ---
+        const preloadImagesList = [];
         const classicSnakeHeadLeftImg = new Image();
         const classicSnakeHeadDownImg = new Image();
         const classicFoodImg = new Image();
@@ -5222,6 +5311,8 @@ function setupSlider(slider, display) {
                 starFullImg, starEmptyImg
             ];
 
+            preloadImagesList.push(...allWorldImages);
+
             allWorldImages.forEach(img => {
                 img.onload = () => {
                     worldImagesLoaded++;
@@ -5263,8 +5354,10 @@ function setupSlider(slider, display) {
             modeSelectFreeImg.src = 'https://i.imgur.com/6cMWnrC.png';
             modeSelectClassificationImg.src = 'https://i.imgur.com/t5n37Mw.png';
             modeSelectMazeImg.src = 'https://i.imgur.com/WY3lrHv.png';
+            const selectionImages = [modeSelectIntroImg, modeSelectLevelsImg, modeSelectFreeImg, modeSelectClassificationImg, modeSelectMazeImg];
+            preloadImagesList.push(...selectionImages);
 
-            [modeSelectIntroImg, modeSelectLevelsImg, modeSelectFreeImg, modeSelectClassificationImg, modeSelectMazeImg].forEach(img => {
+            selectionImages.forEach(img => {
                 img.onload = () => { if (showModeSelect && ctx) requestAnimationFrame(draw); };
                 img.onerror = () => { console.error(`Error al cargar imagen: ${img.src}`); if (showModeSelect && ctx) requestAnimationFrame(draw); };
             });
@@ -5410,9 +5503,11 @@ function setupSlider(slider, display) {
                     orangeCatReactionEatSpeedLeftImg, orangeCatReactionEatSpeedDownImg,
                     orangeCatReactionEatFalseLeftImg, orangeCatReactionEatFalseDownImg,
                     orangeCatReactionEatMirrorLeftImg, orangeCatReactionEatMirrorDownImg,
-                    obstacleImg, lightningYellowImg, lightningRedImg,
-                    ...Object.values(FOODS).map(f => f.asset)
-                ];
+                obstacleImg, lightningYellowImg, lightningRedImg,
+                ...Object.values(FOODS).map(f => f.asset)
+            ];
+
+            preloadImagesList.push(...allImageObjects);
 
             allImageObjects.forEach(imgObj => {
                 imgObj.onload = () => {
@@ -5427,6 +5522,23 @@ function setupSlider(slider, display) {
                         requestAnimationFrame(draw);
                     }
                 };
+            });
+        }
+
+        function preloadAllImages() {
+            return new Promise(resolve => {
+                let loaded = 0;
+                const total = preloadImagesList.length;
+                if (total === 0) { resolve(); return; }
+                const check = () => { if (++loaded === total) resolve(); };
+                preloadImagesList.forEach(img => {
+                    if (img.complete) {
+                        check();
+                    } else {
+                        img.addEventListener('load', check, { once: true });
+                        img.addEventListener('error', check, { once: true });
+                    }
+                });
             });
         }
 
@@ -11462,10 +11574,18 @@ async function startGame(isRestart = false) {
 
         }
 
-        window.onload = () => {
+        window.onload = async () => {
+            if (splashScreen) splashScreen.classList.add('hidden');
+            if (loadingScreen) loadingScreen.classList.remove('hidden');
+
             loadSkinImages();
             loadWorldImages();
             loadModeSelectionImages();
+            await preloadAllImages();
+
+            if (loadingScreen) loadingScreen.classList.add('hidden');
+            if (splashScreen) splashScreen.classList.remove('hidden');
+
             loadGameSettings(); // Loads settings including audio preferences and volume
             loadLives();
             setInterval(checkLifeRecovery, 1000);


### PR DESCRIPTION
## Summary
- add loading screen markup and styles
- preload all game images before showing splash
- show loading animation while images load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687eabb10ce88333ab776eecbaaf4e3e