### PR TITLE
Refine menu heading styles

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1.0, minimum-scale=1.0, viewport-fit=cover">
     <title>Snake Mobile</title>
     <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.js"></script>
     <style>
@@ -391,11 +392,13 @@
             z-index: 10;
         }
         #title-panel h2 {
-            font-size: 1.4em;
+            font-size: 1.6em;
             margin: 0;
-            color: #f3f3f3;
-            font-family: 'Press Start 2P', sans-serif;
-            letter-spacing: 1px;
+            font-family: 'Bebas Neue', cursive;
+            letter-spacing: 2px;
+            background: linear-gradient(90deg, #FDE68A, #C084FC);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
             text-shadow:
                 0px 0px 2px #422E58,
                 -2px -2px 0 #422E58,
@@ -1668,11 +1671,13 @@
             margin-bottom: 3px;
         }
         .settings-header h2, .info-header h2, .specific-info-header h2, .reset-header h2 {
-            font-size: 1.4em;
+            font-size: 1.6em;
             margin: 0;
-            font-family: 'Press Start 2P', sans-serif;
-            color: #f3f3f3;
-            letter-spacing: 1px;
+            font-family: 'Bebas Neue', cursive;
+            letter-spacing: 2px;
+            background: linear-gradient(90deg, #FDE68A, #C084FC);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
             text-shadow:
                 0px 0px 2px #422E58,
                 -2px -2px 0 #422E58,


### PR DESCRIPTION
## Summary
- add Bebas Neue font for headers
- apply gradient text and new font to all menu titles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ffe04c31c833389f66000f603efe9