### PR TITLE
Improve menu title style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -393,15 +393,19 @@
         #title-panel h2 {
             font-size: 1.4em;
             margin: 0;
-            color: #f3f3f3;
             font-family: 'Press Start 2P', sans-serif;
             letter-spacing: 1px;
+            background: linear-gradient(45deg, #FFE46D, #FF7A94);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
             text-shadow:
                 0px 0px 2px #422E58,
                 -2px -2px 0 #422E58,
                 2px -2px 0 #422E58,
                 -2px  2px 0 #422E58,
-                2px  2px 0 #422E58;
+                2px  2px 0 #422E58,
+                0 0 8px rgba(255, 122, 148, 0.75);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
@@ -1671,14 +1675,18 @@
             font-size: 1.4em;
             margin: 0;
             font-family: 'Press Start 2P', sans-serif;
-            color: #f3f3f3;
             letter-spacing: 1px;
+            background: linear-gradient(45deg, #FFE46D, #FF7A94);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
             text-shadow:
                 0px 0px 2px #422E58,
                 -2px -2px 0 #422E58,
                 2px -2px 0 #422E58,
                 -2px  2px 0 #422E58,
-                2px  2px 0 #422E58;
+                2px  2px 0 #422E58,
+                0 0 8px rgba(255, 122, 148, 0.75);
         }
         .settings-header .header-title-group {
             display: flex;


### PR DESCRIPTION
## Summary
- enhance style of `#title-panel h2`
- add gradient styling for menu headers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ffe04c31c833389f66000f603efe9