### PR TITLE
Improve menu title styling

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1664,21 +1664,61 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            color: #f3f3f3;
+            color: #4E3967;
             margin-bottom: 3px;
+            padding: 6px 8px;
+            border: 2px solid #2B1D3A;
+            border-radius: 10px;
+            box-shadow: 0 2px 0 #422E58;
+        }
+        .settings-header::before,
+        .info-header::before,
+        .specific-info-header::before,
+        .reset-header::before {
+            content: '';
+            position: absolute;
+            left: -2px;
+            top: -2px;
+            width: calc(100% + 4px);
+            height: calc(100% + 4px);
+            background: linear-gradient(
+                #D3BAE8 0%,
+                #D3BAE8 50%,
+                #583F7D 50%,
+                #583F7D 100%
+            );
+            border-radius: 10px;
+            pointer-events: none;
+            z-index: -2;
+        }
+        .settings-header::after,
+        .info-header::after,
+        .specific-info-header::after,
+        .reset-header::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 0;
+            width: 100%;
+            height: 80%;
+            background-color: #8C64AF;
+            border-radius: 10px;
+            transform: translateY(-50%);
+            pointer-events: none;
+            z-index: -1;
         }
         .settings-header h2, .info-header h2, .specific-info-header h2, .reset-header h2 {
             font-size: 1.4em;
             margin: 0;
             font-family: 'Press Start 2P', sans-serif;
-            color: #f3f3f3;
+            color: inherit;
             letter-spacing: 1px;
             text-shadow:
-                0px 0px 2px #422E58,
-                -2px -2px 0 #422E58,
-                2px -2px 0 #422E58,
-                -2px  2px 0 #422E58,
-                2px  2px 0 #422E58;
+                0px 0px 1px #422E58,
+                -1px -1px 0 #D0B5E2,
+                1px -1px 0 #D0B5E2,
+                -1px  1px 0 #D0B5E2,
+                1px  1px 0 #D0B5E2;
         }
         .settings-header .header-title-group {
             display: flex;
@@ -1754,7 +1794,7 @@
         }
         .info-header h2#main-info-title {
             font-size: 1.4em;
-            color: #f3f3f3;
+            color: inherit;
         }
         #info-panel-content h4,
         #specific-info-content h4 {


### PR DESCRIPTION
## Summary
- enhance the look of menu titles with gradient backgrounds
- unify header text color and shadows
- ensure info panel header inherits new style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687ffe04c31c833389f66000f603efe9