### PR TITLE
Improve food tint overlays

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7235,7 +7235,7 @@ function setupSlider(slider, display) {
                 offsetY = (drawHeight - GRID_SIZE) / 2;
                 foodVisualTopY = item.y * GRID_SIZE - offsetY;
                 foodVisualHeight = drawHeight;
-                drawImageWithTint(ctx, img, item.x * GRID_SIZE - offsetX, item.y * GRID_SIZE - offsetY, drawWidth, drawHeight, 'rgba(255,0,0,0.2)');
+                drawImageWithTint(ctx, img, item.x * GRID_SIZE - offsetX, item.y * GRID_SIZE - offsetY, drawWidth, drawHeight, 'rgba(255,0,0,0.3)');
             } else {
                 drawWidth = GRID_SIZE - 4;
                 drawHeight = GRID_SIZE - 4;
@@ -7574,7 +7574,7 @@ function setupSlider(slider, display) {
                 offsetY = (drawHeight - GRID_SIZE) / 2;
                 foodVisualTopY = item.y * GRID_SIZE - offsetY;
                 foodVisualHeight = drawHeight;
-                drawImageWithTint(ctx, img, item.x * GRID_SIZE - offsetX, item.y * GRID_SIZE - offsetY, drawWidth, drawHeight, 'rgba(0,0,255,0.2)');
+                drawImageWithTint(ctx, img, item.x * GRID_SIZE - offsetX, item.y * GRID_SIZE - offsetY, drawWidth, drawHeight, 'rgba(0,0,255,0.3)');
             } else {
                 drawWidth = GRID_SIZE - 4;
                 drawHeight = GRID_SIZE - 4;


### PR DESCRIPTION
## Summary
- accentuate the red tint for fake food
- accentuate the blue tint for mirror food

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68814ea305ac83339fde469d2787cda3