### PR TITLE
Add scenario selection and store

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3060,9 +3060,22 @@
                             <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
                         </button>
                     </div>
-                    <select id="foodSelector"></select>
+                <select id="foodSelector"></select>
+            </div>
+            <div class="control-group" id="scenario-control-group">
+                <div class="control-label-icon-row">
+                    <label class="control-label" for="scenarioSelector">Escenario:</label>
+                    <button class="setting-info-button" data-setting="scenario" aria-label="Información sobre escenarios">
+                        <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                    </button>
                 </div>
-                <div class="control-group" id="audio-control-group">
+                <select id="scenarioSelector">
+                    <option value="clasico" selected>Clásico</option>
+                    <option value="hierba">Hierba</option>
+                    <option value="volcan">Volcán</option>
+                </select>
+            </div>
+            <div class="control-group" id="audio-control-group">
                     <div class="control-label-icon-row">
                         <label class="control-label" for="audioToggleSelector">Audio General:</label>
                         <button class="setting-info-button" data-setting="audioGeneral" aria-label="Información sobre audio general">
@@ -3295,6 +3308,7 @@
             <button data-tab="general" id="profile-tab-general" class="store-tab active">PERFIL</button>
             <button data-tab="comida" id="profile-tab-comida" class="store-tab">COMIDA</button>
             <button data-tab="disfraces" id="profile-tab-disfraces" class="store-tab">DISFRACES</button>
+            <button data-tab="escenarios" id="profile-tab-escenarios" class="store-tab">ESCENARIOS</button>
         </div>
 
         <div id="profile-general-content">
@@ -3318,9 +3332,10 @@
                 <input type="text" id="newPlayerNameInput" maxlength="10">
             </div>
         </div>
-        <div id="selected-items-row" class="grid grid-cols-2 gap-2 mb-2 mt-2 w-full">
+        <div id="selected-items-row" class="grid grid-cols-3 gap-2 mb-2 mt-2 w-full">
             <div id="selected-skin-item" class="store-item"></div>
             <div id="selected-food-item" class="store-item"></div>
+            <div id="selected-scenario-item" class="store-item"></div>
         </div>
 
         <div class="control-group hidden" id="skin-control-group">
@@ -3351,6 +3366,15 @@
             </div>
             <select id="foodSelector"></select>
         </div>
+        <div class="control-group hidden" id="scenario-control-group">
+            <div class="control-label-icon-row">
+                <label class="control-label" for="scenarioSelector">Escenario:</label>
+                <button class="setting-info-button" data-setting="scenario" aria-label="Información sobre escenarios">
+                    <img class="setting-info-icon" src="https://i.imgur.com/rWe7Ylp.png" alt="info" onerror="this.src='https://placehold.co/24x24/02030D/FFFFFF?text=Err';">
+                </button>
+            </div>
+            <select id="scenarioSelector"></select>
+        </div>
         </div> <!-- end general content -->
 
         <div id="profile-food-content" class="hidden">
@@ -3365,6 +3389,13 @@
             <div id="profile-skin-unlocked" class="grid grid-cols-3 gap-4 w-full mb-2"></div>
             <h4>SIN DESBLOQUEAR</h4>
             <div id="profile-skin-locked" class="grid grid-cols-3 gap-4 w-full"></div>
+        </div>
+
+        <div id="profile-scenario-content" class="hidden">
+            <h4>COLECCION</h4>
+            <div id="profile-scenario-unlocked" class="grid grid-cols-3 gap-4 w-full mb-2"></div>
+            <h4>SIN DESBLOQUEAR</h4>
+            <div id="profile-scenario-locked" class="grid grid-cols-3 gap-4 w-full"></div>
         </div>
 
     </div>
@@ -3382,6 +3413,7 @@
                         <button data-tab="general" id="store-tab-general" class="store-tab active">GENERAL</button>
                         <button data-tab="comida" id="store-tab-comida" class="store-tab">COMIDA</button>
                         <button data-tab="disfraces" id="store-tab-disfraces" class="store-tab">DISFRACES</button>
+                        <button data-tab="escenarios" id="store-tab-escenarios" class="store-tab">ESCENARIOS</button>
                     </div>
                     <div id="store-items-container" class="grid grid-cols-3 gap-4 w-full"></div>
                 </div>
@@ -3565,6 +3597,7 @@
         const audioToggleSelector = document.getElementById("audioToggleSelector");
         const skinSelectors = document.querySelectorAll("#skinSelector");
         const foodSelectors = document.querySelectorAll("#foodSelector");
+        const scenarioSelectors = document.querySelectorAll("#scenarioSelector");
         const playerNameSelectors = document.querySelectorAll("#playerNameSelector");
         const confirmAddPlayerButton = document.getElementById("confirm-add-player-button");
         const deletePlayerNameButton = document.getElementById("delete-player-name-button");
@@ -3676,12 +3709,16 @@
         const profileGeneralContent = document.getElementById('profile-general-content');
         const profileFoodContent = document.getElementById('profile-food-content');
         const profileSkinContent = document.getElementById('profile-skin-content');
+        const profileScenarioContent = document.getElementById('profile-scenario-content');
         const profileSelectedSkin = document.getElementById('selected-skin-item');
         const profileSelectedFood = document.getElementById('selected-food-item');
+        const profileSelectedScenario = document.getElementById('selected-scenario-item');
         const profileFoodUnlocked = document.getElementById('profile-food-unlocked');
         const profileFoodLocked = document.getElementById('profile-food-locked');
         const profileSkinUnlocked = document.getElementById('profile-skin-unlocked');
         const profileSkinLocked = document.getElementById('profile-skin-locked');
+        const profileScenarioUnlocked = document.getElementById('profile-scenario-unlocked');
+        const profileScenarioLocked = document.getElementById('profile-scenario-locked');
         const selectConfirmationPanel = document.getElementById('select-confirmation-panel');
         const selectConfirmationText = document.getElementById('select-confirmation-text');
         const confirmSelectYesButton = document.getElementById('confirmSelectYes');
@@ -4087,6 +4124,31 @@ function setupSlider(slider, display) {
             mimiSnake: 1000,
             blackCat: 1000,
             orangeCat: 1000
+        };
+
+        const SCENARIO_DISPLAY_NAMES = {
+            clasico: 'Clásico',
+            hierba: 'Hierba',
+            volcan: 'Volcán'
+        };
+        const SCENARIO_ORDER = ['clasico','hierba','volcan'];
+        const SCENARIO_PRICES = { clasico: 0, hierba: 1000, volcan: 1000 };
+        const SCENARIOS = {
+            clasico: {
+                menuImg: 'https://i.imgur.com/vPDsYgo.png',
+                bg: '',
+                borderColor: '#422E58'
+            },
+            hierba: {
+                menuImg: 'https://i.imgur.com/vPDsYgo.png',
+                bg: 'https://i.imgur.com/4j1TQeg.png',
+                borderColor: '#1b5e20'
+            },
+            volcan: {
+                menuImg: 'https://i.imgur.com/vPDsYgo.png',
+                bg: 'https://i.imgur.com/9HKK3mM.png',
+                borderColor: '#7f1d1d'
+            }
         };
 
         // Nombres descriptivos de cada mundo
@@ -4548,6 +4610,7 @@ function setupSlider(slider, display) {
                 currentMazeLevel: 1,
                 mazeLevelStars: Array(MAZE_LEVEL_COUNT).fill(0),
                 freeModeSettings: { ...FREE_MODE_DEFAULTS }
+                ,scenario: 'clasico'
             };
         }
 
@@ -4600,6 +4663,12 @@ function setupSlider(slider, display) {
             }
             currentFood = foodSelectors.length ? foodSelectors[0].value : 'apple';
             applyFood(currentFood);
+            scenarioSelectors.forEach(sel => sel.value = profile.scenario || 'clasico');
+            if (scenarioSelectors.length && !unlockedScenarios[scenarioSelectors[0].value]) {
+                scenarioSelectors.forEach(sel => sel.value = 'clasico');
+            }
+            currentScenario = scenarioSelectors.length ? scenarioSelectors[0].value : 'clasico';
+            applyScenario(currentScenario);
             updateProfileSelectedItems();
             updateFoodSelectorAvailability();
             audioToggleSelector.value = profile.audioGeneral || 'all';
@@ -4648,6 +4717,9 @@ function setupSlider(slider, display) {
         }
         function getSelectedFood() {
             return foodSelectors.length ? foodSelectors[0].value : 'apple';
+        }
+        function getSelectedScenario() {
+            return scenarioSelectors.length ? scenarioSelectors[0].value : 'clasico';
         }
         function updatePlayerNameSelectors(selectedName) {
             playerNames = Object.keys(playerProfiles);
@@ -4792,7 +4864,9 @@ function setupSlider(slider, display) {
         };
         let unlockedFoods = { apple: true };
         let unlockedSkins = { snake: true };
+        let unlockedScenarios = { clasico: true };
         let currentFood = 'apple';
+        let currentScenario = 'clasico';
         let totalGems = 0;
         const HEART_PRICE = 100;
         const GEM_PRICE = 1000;
@@ -5444,6 +5518,17 @@ function setupSlider(slider, display) {
             console.log(`Comestible aplicado: ${currentFood}`);
             if (!gameIntervalId && ctx) {
                 draw();
+            }
+        }
+
+        function applyScenario(scenarioName) {
+            currentScenario = scenarioName;
+            const container = document.querySelector('.game-container');
+            if (container) {
+                container.style.backgroundImage = SCENARIOS[scenarioName].bg ? `url(${SCENARIOS[scenarioName].bg})` : '';
+            }
+            if (canvasEl) {
+                canvasEl.style.borderColor = SCENARIOS[scenarioName].borderColor;
             }
         }
         
@@ -6348,6 +6433,30 @@ function setupSlider(slider, display) {
                     item.appendChild(status);
                     storeItemsContainer.appendChild(item);
                 });
+            } else if (storeTab === 'escenarios') {
+                SCENARIO_ORDER.forEach(key => {
+                    const item = document.createElement('div');
+                    item.className = 'store-item';
+
+                    const img = document.createElement('img');
+                    img.className = 'store-item-img';
+                    img.src = SCENARIOS[key].menuImg;
+                    item.appendChild(img);
+
+                    const status = document.createElement('div');
+                    status.className = 'store-item-status';
+                    if (unlockedScenarios[key]) {
+                        status.textContent = '';
+                        item.classList.add('purchased');
+                    } else {
+                        status.textContent = SCENARIO_PRICES[key].toString();
+                        item.classList.add('locked');
+                        item.addEventListener('click', () => openPurchaseConfirm('scenario', key));
+                        addIconPressEvents(item, item);
+                    }
+                    item.appendChild(status);
+                    storeItemsContainer.appendChild(item);
+                });
             } else {
                 const generalItems = [
                     { key: 'heart', price: HEART_PRICE, img: 'https://i.imgur.com/WrI2XXx.png' },
@@ -6383,6 +6492,8 @@ function setupSlider(slider, display) {
                     img.src = FOODS[key]?.asset?.src || '';
                 } else if (type === 'skin') {
                     img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
+                } else if (type === 'scenario') {
+                    img.src = SCENARIOS[key].menuImg;
                 } else if (type === 'general') {
                     img.src = key === 'heart' ? 'https://i.imgur.com/WrI2XXx.png' : 'https://i.imgur.com/gPGsaCO.png';
                 }
@@ -6396,6 +6507,9 @@ function setupSlider(slider, display) {
             } else if (type === 'skin') {
                 price = SKIN_PRICES[key];
                 name = SKIN_DISPLAY_NAMES[key];
+            } else if (type === 'scenario') {
+                price = SCENARIO_PRICES[key];
+                name = SCENARIO_DISPLAY_NAMES[key];
             } else if (type === 'general') {
                 price = key === 'heart' ? HEART_PRICE : GEM_PRICE;
                 name = key === 'heart' ? 'coraz\u00F3n' : 'gema';
@@ -6427,6 +6541,15 @@ function setupSlider(slider, display) {
                     unlockedSkins[purchaseInfo.key] = true;
                     saveUnlockedSkins();
                     updateSkinSelectorAvailability();
+                    success = true;
+                }
+            } else if (purchaseInfo.type === 'scenario') {
+                price = SCENARIO_PRICES[purchaseInfo.key];
+                if (totalCoins >= price) {
+                    totalCoins -= price;
+                    unlockedScenarios[purchaseInfo.key] = true;
+                    saveUnlockedScenarios();
+                    updateScenarioSelectorAvailability();
                     success = true;
                 }
             } else if (purchaseInfo.type === 'general') {
@@ -6616,12 +6739,16 @@ function setupSlider(slider, display) {
             if (profileGeneralContent) profileGeneralContent.classList.add('hidden');
             if (profileFoodContent) profileFoodContent.classList.add('hidden');
             if (profileSkinContent) profileSkinContent.classList.add('hidden');
+            if (profileScenarioContent) profileScenarioContent.classList.add('hidden');
             if (tab === 'comida') {
                 if (profileFoodContent) profileFoodContent.classList.remove('hidden');
                 populateProfileFoodTab();
             } else if (tab === 'disfraces') {
                 if (profileSkinContent) profileSkinContent.classList.remove('hidden');
                 populateProfileSkinTab();
+            } else if (tab === 'escenarios') {
+                if (profileScenarioContent) profileScenarioContent.classList.remove('hidden');
+                populateProfileScenarioTab();
             } else {
                 if (profileGeneralContent) profileGeneralContent.classList.remove('hidden');
                 updateProfileSelectedItems();
@@ -6639,6 +6766,9 @@ function setupSlider(slider, display) {
         });
         if (profileSelectedFood) profileSelectedFood.addEventListener('click', () => {
             switchProfileTab('comida');
+        });
+        if (profileSelectedScenario) profileSelectedScenario.addEventListener('click', () => {
+            switchProfileTab('escenarios');
         });
 
         // --- Specific Info Panel Logic ---
@@ -10577,6 +10707,13 @@ async function startGame(isRestart = false) {
             updateProfileSelectedItems();
         }));
 
+        scenarioSelectors.forEach(sel => sel.addEventListener('change', function() {
+            scenarioSelectors.forEach(s => { if (s !== this) s.value = this.value; });
+            applyScenario(this.value);
+            saveGameSettings();
+            updateProfileSelectedItems();
+        }));
+
         playerNameSelectors.forEach(sel => sel.addEventListener('change', function() {
             const previous = currentPlayerName;
             const keepDifficulty = difficultySelector.value;
@@ -10971,12 +11108,25 @@ async function startGame(isRestart = false) {
             localStorage.setItem('snakeGameUnlockedSkins', JSON.stringify(unlockedSkins));
         }
 
-        function loadUnlockedSkins() {
+       function loadUnlockedSkins() {
+           try {
+               const data = JSON.parse(localStorage.getItem('snakeGameUnlockedSkins') || '{}');
+               unlockedSkins = { snake: true, ...data };
+           } catch (e) {
+               unlockedSkins = { snake: true };
+           }
+       }
+
+        function saveUnlockedScenarios() {
+            localStorage.setItem('snakeGameUnlockedScenarios', JSON.stringify(unlockedScenarios));
+        }
+
+        function loadUnlockedScenarios() {
             try {
-                const data = JSON.parse(localStorage.getItem('snakeGameUnlockedSkins') || '{}');
-                unlockedSkins = { snake: true, ...data };
+                const data = JSON.parse(localStorage.getItem('snakeGameUnlockedScenarios') || '{}');
+                unlockedScenarios = { clasico: true, ...data };
             } catch (e) {
-                unlockedSkins = { snake: true };
+                unlockedScenarios = { clasico: true };
             }
         }
 
@@ -11018,6 +11168,23 @@ async function startGame(isRestart = false) {
             }
         }
 
+        function updateScenarioSelectorAvailability() {
+            if (!scenarioSelectors.length) return;
+            scenarioSelectors.forEach(sel => {
+                Array.from(sel.options).forEach(opt => {
+                    opt.disabled = !unlockedScenarios[opt.value];
+                });
+                if (!unlockedScenarios[sel.value]) {
+                    sel.value = 'clasico';
+                }
+            });
+            const current = scenarioSelectors[0].value;
+            if (!unlockedScenarios[current]) {
+                scenarioSelectors.forEach(sel => sel.value = 'clasico');
+                applyScenario('clasico');
+            }
+        }
+
         function updateProfileSelectedItems() {
             if (profileSelectedSkin) {
                 profileSelectedSkin.innerHTML = '';
@@ -11034,6 +11201,14 @@ async function startGame(isRestart = false) {
                 img.className = 'store-item-img';
                 img.src = FOODS[getSelectedFood()]?.asset?.src || '';
                 profileSelectedFood.appendChild(img);
+            }
+            if (profileSelectedScenario) {
+                profileSelectedScenario.innerHTML = '';
+                profileSelectedScenario.className = 'store-item purchased profile-clickable';
+                const img = document.createElement('img');
+                img.className = 'store-item-img';
+                img.src = SCENARIOS[getSelectedScenario()].menuImg;
+                profileSelectedScenario.appendChild(img);
             }
         }
 
@@ -11083,11 +11258,35 @@ async function startGame(isRestart = false) {
             });
         }
 
+        function populateProfileScenarioTab() {
+            if (!profileScenarioUnlocked || !profileScenarioLocked) return;
+            profileScenarioUnlocked.innerHTML = '';
+            profileScenarioLocked.innerHTML = '';
+            SCENARIO_ORDER.forEach(key => {
+                const item = document.createElement('div');
+                item.className = 'store-item';
+                const img = document.createElement('img');
+                img.className = 'store-item-img';
+                img.src = SCENARIOS[key].menuImg;
+                item.appendChild(img);
+                if (unlockedScenarios[key]) {
+                    item.classList.add('purchased', 'profile-clickable');
+                    item.addEventListener('click', () => openSelectConfirm('scenario', key, 'select'));
+                } else {
+                    item.classList.add('locked');
+                    item.addEventListener('click', () => openSelectConfirm('scenario', key, 'store'));
+                }
+                addIconPressEvents(item, item);
+                (unlockedScenarios[key] ? profileScenarioUnlocked : profileScenarioLocked).appendChild(item);
+            });
+        }
+
         let selectInfo = null;
         function openSelectConfirm(type, key, action) {
             selectInfo = { type, key, action };
             if (selectConfirmationText) {
-                const name = type === 'food' ? FOOD_DISPLAY_NAMES[key] : SKIN_DISPLAY_NAMES[key];
+                const name = type === 'food' ? FOOD_DISPLAY_NAMES[key] :
+                              type === 'skin' ? SKIN_DISPLAY_NAMES[key] : SCENARIO_DISPLAY_NAMES[key];
                 selectConfirmationText.textContent = action === 'select' ? `¿Usar ${name}?` : `¿Ver ${name} en la tienda?`;
             }
             selectConfirmationPanel.classList.add('centered-panel');
@@ -11101,15 +11300,20 @@ async function startGame(isRestart = false) {
                 if (selectInfo.type === 'food') {
                     foodSelectors.forEach(sel => sel.value = selectInfo.key);
                     applyFood(selectInfo.key);
-                } else {
+                } else if (selectInfo.type === 'skin') {
                     skinSelectors.forEach(sel => sel.value = selectInfo.key);
                     applySkin(selectInfo.key);
+                } else {
+                    scenarioSelectors.forEach(sel => sel.value = selectInfo.key);
+                    applyScenario(selectInfo.key);
                 }
                 saveGameSettings();
                 updateProfileSelectedItems();
                 switchProfileTab('general');
             } else if (selectInfo.action === 'store') {
-                const targetTab = selectInfo.type === 'food' ? 'comida' : 'disfraces';
+                let targetTab = 'disfraces';
+                if (selectInfo.type === 'food') targetTab = 'comida';
+                else if (selectInfo.type === 'scenario') targetTab = 'escenarios';
                 closeSelectConfirm();
                 closeProfileMenu();
                 // wait for the profile panel closing animation to finish before
@@ -11154,6 +11358,7 @@ async function startGame(isRestart = false) {
         addIconPressEvents(confirmSelectNoButton, confirmSelectNoButton);
         addIconPressEvents(profileSelectedSkin, profileSelectedSkin);
         addIconPressEvents(profileSelectedFood, profileSelectedFood);
+        addIconPressEvents(profileSelectedScenario, profileSelectedScenario);
         addIconPressEvents(closeSettingsButton, closeSettingsButton);
         addIconPressEvents(closeFreeSettingsButton, closeFreeSettingsButton);
         addIconPressEvents(closeInfoButton, closeInfoButton);
@@ -11310,6 +11515,7 @@ async function startGame(isRestart = false) {
             profile.difficulty = difficultySelector.value;
             profile.skin = getSelectedSkin();
             profile.food = getSelectedFood();
+            profile.scenario = getSelectedScenario();
             profile.audioGeneral = audioToggleSelector.value;
             profile.musicVolume = musicVolumeSlider.value;
             profile.sfxVolume = sfxVolumeSlider.value;
@@ -11328,6 +11534,7 @@ async function startGame(isRestart = false) {
             localStorage.setItem('snakeGameGems', totalGems.toString());
             saveUnlockedSkins();
             saveUnlockedFoods();
+            saveUnlockedScenarios();
             localStorage.setItem('snakePlayerNames', JSON.stringify(Object.keys(playerProfiles)));
             localStorage.setItem('snakeGamePlayerName', currentPlayerName);
             console.log("Configuraciones guardadas en localStorage.");
@@ -11348,12 +11555,14 @@ async function startGame(isRestart = false) {
             totalGems = Number.isFinite(savedGems) && savedGems >= 0 ? savedGems : 0;
             loadUnlockedFoods(); // Load foods before applying profile
             loadUnlockedSkins();
+            loadUnlockedScenarios();
             updateFoodSelectorOptions(playerProfiles[currentPlayerName]?.food || 'apple');
             updatePlayerNameSelectors(currentPlayerName);
             applyProfile(playerProfiles[currentPlayerName]);
             updateSfxVolume();
             updateFoodSelectorAvailability();
             updateSkinSelectorAvailability();
+            updateScenarioSelectorAvailability();
             populateStoreItems();
 
             // Always start with no mode selected
@@ -11446,6 +11655,7 @@ async function startGame(isRestart = false) {
 
             applySkin(currentSkin); // Apply skin based on loaded settings
             applyFood(currentFood);
+            applyScenario(currentScenario);
 
             // Reset screen states for a fresh start after splash
             screenState.gameActuallyStarted = false; 


### PR DESCRIPTION
## Summary
- introduce scenario data
- allow choosing scenarios in profile panel
- include new scenarios section in the store
- persist selected scenario and availability
- apply scenario styles at runtime

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6881cb38da608333b9fe8edebdcb951a