### PR TITLE
Update classification difficulty covers

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5549,10 +5549,10 @@ function setupSlider(slider, display) {
             freeModeEndImg.src = 'https://i.imgur.com/dWseJe2.png';
             freeModeInactivityImg.src = 'https://i.imgur.com/G4j8uBX.png';
             classificationModeCoverImg.src = 'https://i.imgur.com/EaIYb0R.png';
-            classificationDifficultyImages.principiante.src = 'https://i.imgur.com/z4SlhGV.png';
-            classificationDifficultyImages.explorador.src = 'https://i.imgur.com/QCxdQQh.png';
-            classificationDifficultyImages.veterano.src = 'https://i.imgur.com/kEDCBEZ.png';
-            classificationDifficultyImages.legendario.src = 'https://i.imgur.com/Mohv1u4.png';
+            classificationDifficultyImages.principiante.src = 'https://i.imgur.com/1VU204A.png';
+            classificationDifficultyImages.explorador.src = 'https://i.imgur.com/USRNwSW.png';
+            classificationDifficultyImages.veterano.src = 'https://i.imgur.com/YGLj8Ss.png';
+            classificationDifficultyImages.legendario.src = 'https://i.imgur.com/OQw0DGB.png';
 
             mazeModeCoverImg.src = 'https://i.imgur.com/6zcf86e.png';
             mazeLevelCoverImg.src = 'https://i.imgur.com/8asDGaZ.png';


### PR DESCRIPTION
## Summary
- update mode clasificación difficulty cover images to new URLs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688606f3333c8333acd3b6c6ad9e1172