### PR TITLE
Add achievements menu

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1467,10 +1467,10 @@
             display: block;
         }
 
-        .settings-panel-hidden, .info-panel-hidden, .specific-info-panel-hidden, .free-settings-panel-hidden, .reset-panel-hidden, .config-menu-panel-hidden, .generic-menu-panel-hidden, .store-panel-hidden, .profile-panel-hidden, .purchase-confirmation-panel-hidden, .delete-confirmation-panel-hidden, .out-of-lives-panel-hidden, .select-confirmation-panel-hidden {
+        .settings-panel-hidden, .info-panel-hidden, .specific-info-panel-hidden, .free-settings-panel-hidden, .reset-panel-hidden, .config-menu-panel-hidden, .generic-menu-panel-hidden, .store-panel-hidden, .profile-panel-hidden, .achievements-panel-hidden, .purchase-confirmation-panel-hidden, .delete-confirmation-panel-hidden, .out-of-lives-panel-hidden, .select-confirmation-panel-hidden {
             display: none !important;
         }
-        #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel, #store-panel, #profile-panel, #purchase-confirmation-panel, #delete-confirmation-panel, #out-of-lives-panel, #select-confirmation-panel {
+        #settings-panel, #info-panel, #specific-info-panel, #free-settings-panel, #reset-confirmation-panel, #config-menu-panel, #generic-menu-panel, #store-panel, #profile-panel, #achievements-panel, #purchase-confirmation-panel, #delete-confirmation-panel, #out-of-lives-panel, #select-confirmation-panel {
             position: fixed;
             left: 0;
             transform: scale(0);
@@ -1507,6 +1507,13 @@
             box-sizing: border-box;
         }
         #store-panel .panel-content {
+            padding-right: 10px;
+        }
+        #achievements-panel {
+            max-height: 90vh;
+            box-sizing: border-box;
+        }
+        #achievements-panel .panel-content {
             padding-right: 10px;
         }
         #profile-panel {
@@ -1618,6 +1625,7 @@
         #generic-menu-panel.centered-panel,
         #store-panel.centered-panel,
         #profile-panel.centered-panel,
+        #achievements-panel.centered-panel,
         #purchase-confirmation-panel.centered-panel,
         #delete-confirmation-panel.centered-panel,
         #out-of-lives-panel.centered-panel,
@@ -1633,6 +1641,7 @@
         #generic-menu-panel.centered-panel.panel-visible,
         #store-panel.centered-panel.panel-visible,
         #profile-panel.centered-panel.panel-visible,
+        #achievements-panel.centered-panel.panel-visible,
         #purchase-confirmation-panel.centered-panel.panel-visible,
         #delete-confirmation-panel.centered-panel.panel-visible,
         #out-of-lives-panel.centered-panel.panel-visible,
@@ -1648,6 +1657,7 @@
         #generic-menu-panel.panel-visible,
         #store-panel.panel-visible,
         #profile-panel.panel-visible,
+        #achievements-panel.panel-visible,
         #purchase-confirmation-panel.panel-visible,
         #delete-confirmation-panel.panel-visible,
         #out-of-lives-panel.panel-visible,
@@ -1792,7 +1802,8 @@
         #free-settings-panel .panel-content::-webkit-scrollbar,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar,
         #store-panel .panel-content::-webkit-scrollbar,
-        #profile-panel .panel-content::-webkit-scrollbar {
+        #profile-panel .panel-content::-webkit-scrollbar,
+        #achievements-panel .panel-content::-webkit-scrollbar {
             width: 8px;
         }
         #info-panel-content::-webkit-scrollbar-track,
@@ -1803,7 +1814,8 @@
         #free-settings-panel .panel-content::-webkit-scrollbar-track,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar-track,
         #store-panel .panel-content::-webkit-scrollbar-track,
-        #profile-panel .panel-content::-webkit-scrollbar-track {
+        #profile-panel .panel-content::-webkit-scrollbar-track,
+        #achievements-panel .panel-content::-webkit-scrollbar-track {
             background: #2d1d3a;
             border-radius: 4px;
         }
@@ -1815,7 +1827,8 @@
         #free-settings-panel .panel-content::-webkit-scrollbar-thumb,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb,
         #store-panel .panel-content::-webkit-scrollbar-thumb,
-        #profile-panel .panel-content::-webkit-scrollbar-thumb {
+        #profile-panel .panel-content::-webkit-scrollbar-thumb,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb {
             background: #442F58;
             border-radius: 4px;
         }
@@ -1836,7 +1849,9 @@
         #store-panel .panel-content::-webkit-scrollbar-thumb:hover,
         #store-panel .panel-content::-webkit-scrollbar-thumb:active,
         #profile-panel .panel-content::-webkit-scrollbar-thumb:hover,
-        #profile-panel .panel-content::-webkit-scrollbar-thumb:active {
+        #profile-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb:active {
             background: #8f66af;
         }
 
@@ -2175,6 +2190,7 @@
         #generic-menu-panel { z-index: 2101; }
         #store-panel { z-index: 2101; }
         #profile-panel { z-index: 2101; }
+        #achievements-panel { z-index: 2101; }
         #purchase-confirmation-panel { z-index: 2103; }
         #delete-confirmation-panel { z-index: 2103; }
         #select-confirmation-panel { z-index: 2103; }
@@ -2713,6 +2729,24 @@
           background-color: #8f66af;
           color: #1F2937;
         }
+
+        .achievement-category h4 {
+          margin: 0 0 4px 0;
+          font-family: 'Press Start 2P', sans-serif;
+          font-size: 0.8rem;
+          color: #C084FC;
+        }
+        .achievement-item {
+          display: flex;
+          justify-content: space-between;
+          padding: 4px 6px;
+          background-color: #374151;
+          border-radius: 6px;
+          font-size: 0.7rem;
+          color: #f3f3f3;
+          font-family: 'Press Start 2P', sans-serif;
+        }
+        .achievement-item + .achievement-item { margin-top: 4px; }
 
         #purchase-item-preview {
           margin: 0 auto 8px;
@@ -3420,6 +3454,17 @@
                     <div id="store-items-container" class="grid grid-cols-3 gap-4 w-full"></div>
                 </div>
             </div>
+            <div id="achievements-panel" class="achievements-panel-hidden">
+                <div class="settings-header">
+                    <h2>LOGROS</h2>
+                    <button id="close-achievements-panel" class="close-button" aria-label="Cerrar">
+                        <img src="https://i.imgur.com/w5E6xdU.png" alt="Cerrar">
+                    </button>
+                </div>
+                <div class="panel-content">
+                    <div id="achievements-container" class="flex flex-col gap-2"></div>
+                </div>
+            </div>
             <div id="modal-overlay" class="hidden"></div>
             <div id="purchase-confirmation-panel" class="purchase-confirmation-panel-hidden">
                 <div class="reset-header">
@@ -3687,11 +3732,14 @@
         const wheelMenuButton = document.getElementById("wheel-menu-button");
 
         const storePanel = document.getElementById("store-panel");
+        const achievementsPanel = document.getElementById("achievements-panel");
         const profilePanel = document.getElementById("profile-panel");
         const closeProfilePanelButton = document.getElementById("close-profile-panel");
         const storeItemsContainer = document.getElementById("store-items-container");
         const storeTabButtons = document.querySelectorAll('#store-tabs .store-tab');
         const closeStorePanelButton = document.getElementById("close-store-panel");
+        const closeAchievementsPanelButton = document.getElementById("close-achievements-panel");
+        const achievementsContainer = document.getElementById("achievements-container");
         const purchaseConfirmationPanel = document.getElementById("purchase-confirmation-panel");
         const purchaseItemPreview = document.getElementById("purchase-item-preview");
         const purchaseConfirmationText = document.getElementById("purchase-confirmation-text");
@@ -5127,6 +5175,24 @@ function setupSlider(slider, display) {
         let currentFood = 'apple';
         let currentScene = 'classic';
         let totalGems = 0;
+        const ACHIEVEMENTS_DATA = [
+            { category: 'Monedas conseguidas', thresholds: [100, 500, 1000], rewardBase: 1 },
+            { category: 'Puntos conseguidos', thresholds: [1000, 5000, 10000], rewardBase: 1 },
+            { category: 'Gemas conseguidas', thresholds: [50, 100, 200], rewardBase: 1 },
+            { category: 'Estrellas de laberinto', thresholds: [5, 15, 30], rewardBase: 2 },
+            { category: 'Niveles de modo laberinto superados', thresholds: [10, 20, 30, 40], rewardBase: 2 },
+            { category: 'Mundos superados', thresholds: [1, 2, 3, 4], rewardBase: 2 },
+            { category: 'Partidas en modo libre', thresholds: [5, 25, 50], rewardBase: 1 },
+            { category: 'Partidas en modo clasificación', thresholds: [5, 25, 50], rewardBase: 1 },
+            { category: 'Puntos conseguidos en nivel novato', thresholds: [1000, 5000, 10000], rewardBase: 1 },
+            { category: 'Puntos conseguidos en nivel explorador', thresholds: [1000, 5000, 10000], rewardBase: 1 },
+            { category: 'Puntos conseguidos en nivel veterano', thresholds: [1000, 5000, 10000], rewardBase: 2 },
+            { category: 'Puntos conseguidos en nivel legendario', thresholds: [1000, 5000, 10000], rewardBase: 3 },
+            { category: 'Disfraces desbloqueados', thresholds: [5, 10, 20], rewardBase: 2 },
+            { category: 'Comestibles desbloqueados', thresholds: [5, 10, 20], rewardBase: 2 },
+            { category: 'Escenarios desbloqueados', thresholds: [3, 6, 9], rewardBase: 2 },
+            { category: 'Añade un jugador', thresholds: [1], rewardBase: 2 }
+        ];
         const HEART_PRICE = 100;
         const GEM_PRICE = 1000;
         let storeTab = 'general';
@@ -6065,6 +6131,7 @@ function setupSlider(slider, display) {
             else if (panelId === "generic-menu-panel") hiddenClassName = "generic-menu-panel-hidden";
             else if (panelId === "store-panel") hiddenClassName = "store-panel-hidden";
             else if (panelId === "profile-panel") hiddenClassName = "profile-panel-hidden";
+            else if (panelId === "achievements-panel") hiddenClassName = "achievements-panel-hidden";
             else if (panelId === "purchase-confirmation-panel") hiddenClassName = "purchase-confirmation-panel-hidden";
             else if (panelId === "delete-confirmation-panel") hiddenClassName = "delete-confirmation-panel-hidden";
             else if (panelId === "out-of-lives-panel") hiddenClassName = "out-of-lives-panel-hidden";
@@ -6592,7 +6659,7 @@ function setupSlider(slider, display) {
         if (closeGenericMenuButton) closeGenericMenuButton.addEventListener('click', closeGenericMenuPanel);
         if (profileMenuButton) profileMenuButton.addEventListener('click', openProfileMenu);
         if (storeMenuButton) storeMenuButton.addEventListener('click', openStoreMenu);
-        if (achievementsMenuButton) achievementsMenuButton.addEventListener('click', () => { openGenericMenuPanel('Logros'); });
+        if (achievementsMenuButton) achievementsMenuButton.addEventListener('click', openAchievementsMenu);
         if (bonusesMenuButton) bonusesMenuButton.addEventListener('click', () => { openGenericMenuPanel('Bonificaciones'); });
         if (dailyMenuButton) dailyMenuButton.addEventListener('click', () => { openGenericMenuPanel('Premios diarios'); });
         if (wheelMenuButton) wheelMenuButton.addEventListener('click', () => { openGenericMenuPanel('Ruleta de premios'); });
@@ -6682,6 +6749,22 @@ function setupSlider(slider, display) {
 
         function closeStoreMenu() {
             togglePanel(storePanel, storePanel.querySelector('.panel-content'), false);
+            setTimeout(updateMainButtonStates, 0);
+        }
+
+        function openAchievementsMenu() {
+            if (!achievementsPanel) return;
+            populateAchievements();
+            const isConfigMenuVisible = !configMenuPanel.classList.contains('config-menu-panel-hidden') && configMenuPanel.classList.contains('panel-visible');
+            achievementsPanel.classList.remove('centered-panel');
+            togglePanel(achievementsPanel, achievementsPanel.querySelector('.panel-content'), true);
+            if (isConfigMenuVisible) {
+                matchPanelSizeWithElement(configMenuPanel, achievementsPanel);
+            }
+        }
+
+        function closeAchievementsMenu() {
+            togglePanel(achievementsPanel, achievementsPanel.querySelector('.panel-content'), false);
             setTimeout(updateMainButtonStates, 0);
         }
 
@@ -6902,6 +6985,27 @@ function setupSlider(slider, display) {
             purchaseInfo = null;
         }
 
+        function populateAchievements() {
+            if (!achievementsContainer) return;
+            achievementsContainer.innerHTML = '';
+            ACHIEVEMENTS_DATA.forEach(cat => {
+                const section = document.createElement('div');
+                section.className = 'achievement-category';
+                const h4 = document.createElement('h4');
+                h4.textContent = cat.category.toUpperCase();
+                section.appendChild(h4);
+                const ul = document.createElement('ul');
+                cat.thresholds.forEach((th, idx) => {
+                    const li = document.createElement('li');
+                    li.className = 'achievement-item';
+                    li.innerHTML = `Consigue ${th} - <strong>${(idx + 1) * cat.rewardBase}</strong> gemas`;
+                    ul.appendChild(li);
+                });
+                section.appendChild(ul);
+                achievementsContainer.appendChild(section);
+            });
+        }
+
         let playerToDelete = null;
         function openDeleteConfirm(name) {
             playerToDelete = name;
@@ -7016,6 +7120,7 @@ function setupSlider(slider, display) {
         }
 
         if (closeStorePanelButton) closeStorePanelButton.addEventListener('click', closeStoreMenu);
+        if (closeAchievementsPanelButton) closeAchievementsPanelButton.addEventListener('click', closeAchievementsMenu);
         if (closeProfilePanelButton) closeProfilePanelButton.addEventListener('click', closeProfileMenu);
         if (confirmPurchaseYesButton) confirmPurchaseYesButton.addEventListener('click', confirmPurchase);
         if (confirmPurchaseNoButton) confirmPurchaseNoButton.addEventListener('click', closePurchaseConfirm);
@@ -11686,6 +11791,7 @@ async function startGame(isRestart = false) {
         addIconPressEvents(closeGenericMenuButton, closeGenericMenuButton);
         addIconPressEvents(closeProfilePanelButton, closeProfilePanelButton);
         addIconPressEvents(closeStorePanelButton, closeStorePanelButton);
+        addIconPressEvents(closeAchievementsPanelButton, closeAchievementsPanelButton);
         addIconPressEvents(closeOutOfLivesPanelButton, closeOutOfLivesPanelButton);
         addIconPressEvents(getLivesStoreButton, getLivesStoreButton);
         addIconPressEvents(getLivesBonusesButton, getLivesBonusesButton);


### PR DESCRIPTION
## Summary
- create an achievements panel for the menu
- allow opening/closing the achievements menu
- define basic achievement categories and render them
- style achievement items

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688bde40d788833399f2e46fa4302757