### PR TITLE
Reset score when leaving free mode

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -11032,8 +11032,9 @@ async function startGame(isRestart = false) {
             }
 
             score = 0;
-            streakMultiplier = 1; 
-            gameOver = false; 
+            streakMultiplier = 1;
+            gameOver = false;
+            updateScoreDisplay();
             direction = "right"; 
             nextDirection = "right"; // Asegurar que nextDirection también se reinicia
             
@@ -11584,6 +11585,9 @@ async function startGame(isRestart = false) {
                 gameMode = '';
                 if (gameContainer) gameContainer.classList.add('hidden');
                 if (splashScreen) splashScreen.classList.remove('hidden');
+                score = 0;
+                streakMultiplier = 1;
+                updateScoreDisplay();
             } else {
                 // Return to mode selection
                 showModeSelect = true;
@@ -11620,6 +11624,9 @@ async function startGame(isRestart = false) {
                 restartMazeButton.classList.add('hidden');
                 startButtonWrapperEl.classList.remove('split');
                 draw();
+                score = 0;
+                streakMultiplier = 1;
+                updateScoreDisplay();
             }
             updateGameModeUI();
             updateMainButtonStates();


### PR DESCRIPTION
## Summary
- reset score when leaving to splash or mode select
- reset score display at the start of each game

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_688cba0630688333b032a3c37465ba5f