### PR TITLE
Show claim button in progress line

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -10089,13 +10089,6 @@ function setupSlider(slider, display) {
                     rewardContainer.appendChild(rewardImg);
                     top.appendChild(rewardContainer);
 
-                    if (achievementsState[a.id] && achievementsState[a.id].achieved && !achievementsState[a.id].claimed) {
-                        const btn = document.createElement('button');
-                        btn.textContent = 'RECLAMAR';
-                        btn.addEventListener('click', () => claimAchievement(a.id));
-                        top.appendChild(btn);
-                    }
-
                     item.appendChild(top);
 
                     const progressLine = document.createElement('div');
@@ -10108,10 +10101,18 @@ function setupSlider(slider, display) {
                     fill.style.width = Math.min(100, progressVal / a.threshold * 100) + '%';
                     bar.appendChild(fill);
                     progressLine.appendChild(bar);
-                    const progressText = document.createElement('span');
-                    progressText.className = 'achievement-progress-text';
-                    progressText.textContent = progressVal + '/' + a.threshold;
-                    progressLine.appendChild(progressText);
+                    const state = achievementsState[a.id] || { achieved: false, claimed: false };
+                    if (state.achieved && !state.claimed) {
+                        const btn = document.createElement('button');
+                        btn.textContent = 'RECLAMAR';
+                        btn.addEventListener('click', () => claimAchievement(a.id));
+                        progressLine.appendChild(btn);
+                    } else {
+                        const progressText = document.createElement('span');
+                        progressText.className = 'achievement-progress-text';
+                        progressText.textContent = progressVal + '/' + a.threshold;
+                        progressLine.appendChild(progressText);
+                    }
                     item.appendChild(progressLine);
 
                     if (achievementsState[a.id] && achievementsState[a.id].claimed) {


### PR DESCRIPTION
## Summary
- tweak achievements display so "RECLAMAR" button replaces progress text when an achievement is reached

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688d26f0be408333b0aa62d8d92b3c35