### PR TITLE
Reduce achievement description text size

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2776,6 +2776,9 @@
           position: relative;
           top: -1px;
         }
+        .achievement-desc {
+          font-size: 0.65rem;
+        }
         .achievement-top-line {
           display: flex;
           justify-content: space-between;
@@ -10131,6 +10134,7 @@ function setupSlider(slider, display) {
                     const top = document.createElement('div');
                     top.className = 'achievement-top-line';
                     const desc = document.createElement('span');
+                    desc.className = 'achievement-desc';
                     desc.textContent = a.description;
                     top.appendChild(desc);
 


### PR DESCRIPTION
## Summary
- decrease the font size for achievement description text
- add `achievement-desc` CSS class and apply it when creating achievements

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688d2d24e7448333879a61a4a06f1f8e