### PR TITLE
Unifica estilo de barra de scroll en logros

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1826,6 +1826,7 @@
         #free-settings-panel .panel-content::-webkit-scrollbar,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar,
         #store-panel .panel-content::-webkit-scrollbar,
+        #achievements-panel .panel-content::-webkit-scrollbar,
         #profile-panel .panel-content::-webkit-scrollbar {
             width: 8px;
         }
@@ -1837,6 +1838,7 @@
         #free-settings-panel .panel-content::-webkit-scrollbar-track,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar-track,
         #store-panel .panel-content::-webkit-scrollbar-track,
+        #achievements-panel .panel-content::-webkit-scrollbar-track,
         #profile-panel .panel-content::-webkit-scrollbar-track {
             background: #2d1d3a;
             border-radius: 4px;
@@ -1849,6 +1851,7 @@
         #free-settings-panel .panel-content::-webkit-scrollbar-thumb,
         #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb,
         #store-panel .panel-content::-webkit-scrollbar-thumb,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb,
         #profile-panel .panel-content::-webkit-scrollbar-thumb {
             background: #442F58;
             border-radius: 4px;
@@ -1869,6 +1872,8 @@
         #reset-confirmation-panel .panel-content::-webkit-scrollbar-thumb:active,
         #store-panel .panel-content::-webkit-scrollbar-thumb:hover,
         #store-panel .panel-content::-webkit-scrollbar-thumb:active,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb:hover,
+        #achievements-panel .panel-content::-webkit-scrollbar-thumb:active,
         #profile-panel .panel-content::-webkit-scrollbar-thumb:hover,
         #profile-panel .panel-content::-webkit-scrollbar-thumb:active {
             background: #8f66af;


### PR DESCRIPTION
## Resumen
- Extiende los estilos de scrollbar unificados al panel de logros para igualarlo con el resto de menús.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688dd327a8208333945e022a5ab6f4d8