### PR TITLE
Use progress bar for adventure mode levels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -583,14 +583,55 @@
         }
 
         #star-progress-container {
+            width: 100%;
+            margin: 0;
+        }
+
+        /* Modo barra de progreso para los niveles de aventura */
+        #star-progress-container.bar-mode {
+            display: flex;
+            gap: 0;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            overflow: hidden;
+            border-radius: 8px;
+            align-items: stretch;
+        }
+
+        .progress-segment {
+            flex: 1;
+            height: 100%;
+            background-color: #2d1b3d;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-family: 'Press Start 2P', sans-serif;
+            font-size: 0.65em;
+            color: #f5f5f5;
+        }
+
+        .progress-segment:not(:last-child) {
+            border-right: 2px solid #6b46c1;
+        }
+
+        .progress-segment.full {
+            background-color: #6b46c1;
+        }
+
+        .progress-segment.empty {
+            background-color: #2d1b3d;
+        }
+
+        /* Modo estrellas para laberinto u otros */
+        #star-progress-container.star-mode {
             display: grid;
             grid-template-columns: repeat(5, auto);
             gap: 25px;
             justify-items: center;
             align-items: center;
-            width: 100%;
-            margin: 0;
         }
+
         .progress-star {
             width: 38px;
             height: 38px;
@@ -1970,7 +2011,8 @@
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { width: 100%; gap: 19px; }
+            #star-progress-container.star-mode { width: 100%; gap: 19px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; font-size: 0.55em; }
 
 
             #d-pad-container {
@@ -2124,7 +2166,8 @@
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { width: 100%; gap: 16px; }
+            #star-progress-container.star-mode { width: 100%; gap: 16px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; font-size: 0.5em; }
 
 
             #d-pad-container {
@@ -10920,7 +10963,10 @@ function populateMazeLevelButtons() {
 
         function drawStarProgress() {
             starProgressContainer.innerHTML = '';
+            starProgressContainer.classList.remove('bar-mode', 'star-mode');
+
             if (gameMode === 'levels') {
+                starProgressContainer.classList.add('bar-mode');
                 const worldToDisplayStarsFor = (screenState.showCoverForWorld > 0 && !screenState.gameActuallyStarted)
                     ? displayWorld
                     : (gameOver ? displayWorld : currentWorld);
@@ -10928,11 +10974,15 @@ function populateMazeLevelButtons() {
                 for (let i = 0; i < LEVELS_PER_WORLD; i++) {
                     const levelIndexInTotal = worldLevelStartIndex + i;
                     const isCompleted = levelsProgress[levelIndexInTotal];
-                    const star = document.createElement('div');
-                    star.className = 'progress-star ' + (isCompleted ? 'full' : 'empty');
-                    starProgressContainer.appendChild(star);
+                    const segment = document.createElement('div');
+                    segment.className = 'progress-segment ' + (isCompleted ? 'full' : 'empty');
+                    const label = document.createElement('span');
+                    label.textContent = `${worldToDisplayStarsFor}.${i + 1}`;
+                    segment.appendChild(label);
+                    starProgressContainer.appendChild(segment);
                 }
             } else if (gameMode === 'maze') {
+                starProgressContainer.classList.add('star-mode');
                 for (let i = 0; i < MAZE_STAR_TARGETS.length; i++) {
                     const isEarned = i < mazeStarsEarned;
                     const star = document.createElement('div');


### PR DESCRIPTION
## Summary
- Style adventure progress bar segments to fill the entire container without gaps
- Add purple vertical separators between segments and keep responsive sizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e24a2f65883338035f92fca7bb735