### PR TITLE
Use progress bar for adventure mode levels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -506,7 +506,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 8px 10px;
+            padding: 0;
             min-height: 55px;
             box-sizing: border-box;
             text-align: center;
@@ -515,7 +515,7 @@
         #star-progress-wrapper .value-box {
             background-color: #422E58;
             border-radius: 8px;
-            padding: 6px 8px;
+            padding: 0;
             width: 100%;
             display: flex;
             justify-content: center;
@@ -583,14 +583,68 @@
         }
 
         #star-progress-container {
+            width: 100%;
+            margin: 0;
+        }
+
+        /* Modo barra de progreso para los niveles de aventura */
+        #star-progress-container.bar-mode {
+            display: flex;
+            gap: 0;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            overflow: hidden;
+            border-radius: 8px;
+            align-items: stretch;
+        }
+
+        .progress-segment {
+            flex: 1;
+            height: 100%;
+            background-color: #2d1b3d;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-family: 'Press Start 2P', sans-serif;
+            font-size: 0.65em;
+            color: #f5f5f5;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .progress-segment:not(:last-child) {
+            border-right: 3px solid #7E529F;
+        }
+
+        .progress-fill {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 0%;
+            background-color: #6b46c1;
+            transition: width 0.5s ease;
+        }
+
+        .progress-segment.full .progress-fill {
+            width: 100%;
+        }
+
+        .progress-segment span {
+            position: relative;
+            z-index: 1;
+        }
+
+        /* Modo estrellas para laberinto u otros */
+        #star-progress-container.star-mode {
             display: grid;
             grid-template-columns: repeat(5, auto);
             gap: 25px;
             justify-items: center;
             align-items: center;
-            width: 100%;
-            margin: 0;
         }
+
         .progress-star {
             width: 38px;
             height: 38px;
@@ -1957,9 +2011,9 @@
             #current-world-info-group .info-label { font-size: 0.6em; }
             #current-world-info-group .info-value { font-size: 0.8em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.7em; }
-            #star-progress-wrapper { min-height: 28px; padding: 1px 2px; }
+            #star-progress-wrapper { min-height: 28px; padding: 0; }
             #star-progress-wrapper .value-box {
-                padding: 1px 2px;
+                padding: 0;
                 min-height: 24px;
                 display: flex;
                 justify-content: center;
@@ -1970,7 +2024,8 @@
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { width: 100%; gap: 19px; }
+            #star-progress-container.star-mode { width: 100%; gap: 19px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; font-size: 0.55em; }
 
 
             #d-pad-container {
@@ -2111,9 +2166,9 @@
             #current-world-info-group .info-value { font-size: 0.7em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.6em; }
             #current-world-info-group { min-width: 60px; min-height: 34px; padding: 2px 4px 2px 20px; cursor: pointer;}
-            #star-progress-wrapper { min-height: 30px; padding: 2px 2px; }
+            #star-progress-wrapper { min-height: 30px; padding: 0; }
             #star-progress-wrapper .value-box {
-                padding: 5px 5px;
+                padding: 0;
                 min-height: 26px;
                 display: flex;
                 justify-content: center;
@@ -2124,7 +2179,8 @@
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { width: 100%; gap: 16px; }
+            #star-progress-container.star-mode { width: 100%; gap: 16px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; font-size: 0.5em; }
 
 
             #d-pad-container {
@@ -4869,6 +4925,7 @@ function setupSlider(slider, display) {
         let currentLevelInWorld = 1;
         let maxUnlockedWorld = 1;
         let levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+        let levelFillAnimated = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
         let worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
 
         // --- Variables de visualización para UI ---
@@ -5122,6 +5179,7 @@ function setupSlider(slider, display) {
             currentLevelInWorld = profile.currentLevelInWorld || 1;
             maxUnlockedWorld = profile.maxUnlockedWorld || 1;
             levelsProgress = Array.isArray(profile.levelsProgress) ? profile.levelsProgress : Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+            levelFillAnimated = levelsProgress.slice();
             worldCurrentLevels = Array.isArray(profile.worldCurrentLevels) ? profile.worldCurrentLevels : Array(TOTAL_WORLDS).fill(1);
             currentMazeLevel = profile.currentMazeLevel || 1;
             mazeLevelStars = Array.isArray(profile.mazeLevelStars) ? profile.mazeLevelStars : Array(MAZE_LEVEL_COUNT).fill(0);
@@ -10920,7 +10978,10 @@ function populateMazeLevelButtons() {
 
         function drawStarProgress() {
             starProgressContainer.innerHTML = '';
+            starProgressContainer.classList.remove('bar-mode', 'star-mode');
+
             if (gameMode === 'levels') {
+                starProgressContainer.classList.add('bar-mode');
                 const worldToDisplayStarsFor = (screenState.showCoverForWorld > 0 && !screenState.gameActuallyStarted)
                     ? displayWorld
                     : (gameOver ? displayWorld : currentWorld);
@@ -10928,11 +10989,32 @@ function populateMazeLevelButtons() {
                 for (let i = 0; i < LEVELS_PER_WORLD; i++) {
                     const levelIndexInTotal = worldLevelStartIndex + i;
                     const isCompleted = levelsProgress[levelIndexInTotal];
-                    const star = document.createElement('div');
-                    star.className = 'progress-star ' + (isCompleted ? 'full' : 'empty');
-                    starProgressContainer.appendChild(star);
+                    const segment = document.createElement('div');
+                    segment.className = 'progress-segment';
+                    const fill = document.createElement('div');
+                    fill.className = 'progress-fill';
+                    segment.appendChild(fill);
+                    const label = document.createElement('span');
+                    label.textContent = `${worldToDisplayStarsFor}.${i + 1}`;
+                    segment.appendChild(label);
+                    starProgressContainer.appendChild(segment);
+
+                    if (isCompleted) {
+                        if (levelFillAnimated[levelIndexInTotal]) {
+                            segment.classList.add('full');
+                        } else {
+                            requestAnimationFrame(() => {
+                                void fill.offsetWidth;
+                                requestAnimationFrame(() => {
+                                    segment.classList.add('full');
+                                    levelFillAnimated[levelIndexInTotal] = true;
+                                });
+                            });
+                        }
+                    }
                 }
             } else if (gameMode === 'maze') {
+                starProgressContainer.classList.add('star-mode');
                 for (let i = 0; i < MAZE_STAR_TARGETS.length; i++) {
                     const isEarned = i < mazeStarsEarned;
                     const star = document.createElement('div');


### PR DESCRIPTION
## Summary
- Animate adventure-mode progress bar segments as levels are completed
- Show 3px #7E529F dividers between segments for clear level boundaries
- Remove padding around adventure progress bar so it fills its container on mobile
- Force a reflow before applying the "full" class so segment fill animations also play on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e24a2f65883338035f92fca7bb735