### PR TITLE
Use progress bar for adventure mode levels

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -512,6 +512,10 @@
             text-align: center;
         }
 
+        #star-progress-wrapper.bar-mode {
+            padding: 0;
+        }
+
         #star-progress-wrapper .value-box {
             background-color: #422E58;
             border-radius: 8px;
@@ -520,6 +524,10 @@
             display: flex;
             justify-content: center;
             align-items: center;
+        }
+
+        #star-progress-wrapper.bar-mode .value-box {
+            padding: 0;
         }
 
         #progress-panel.classification-mode #star-progress-wrapper .value-box {
@@ -583,14 +591,60 @@
         }
 
         #star-progress-container {
+            width: 100%;
+            margin: 0;
+        }
+
+        /* Modo barra de progreso para los niveles de aventura */
+        #star-progress-container.bar-mode {
+            display: flex;
+            gap: 0;
+            width: 100%;
+            height: 100%;
+            padding: 0;
+            overflow: hidden;
+            border-radius: 8px;
+            align-items: stretch;
+        }
+
+        .progress-segment {
+            flex: 1;
+            height: 100%;
+            background-color: #2d1b3d;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .progress-segment:not(:last-child) {
+            border-right: 3px solid #6b46c1;
+        }
+
+        .progress-fill {
+            position: absolute;
+            top: 0;
+            left: 0;
+            height: 100%;
+            width: 0%;
+            background-color: #6b46c1;
+            transition: width 0.5s ease;
+        }
+
+        .progress-segment.full .progress-fill {
+            width: 100%;
+        }
+
+        /* Modo estrellas para laberinto u otros */
+        #star-progress-container.star-mode {
             display: grid;
             grid-template-columns: repeat(5, auto);
             gap: 25px;
             justify-items: center;
             align-items: center;
-            width: 100%;
-            margin: 0;
         }
+
         .progress-star {
             width: 38px;
             height: 38px;
@@ -1958,6 +2012,7 @@
             #current-world-info-group .info-value { font-size: 0.8em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.7em; }
             #star-progress-wrapper { min-height: 28px; padding: 1px 2px; }
+            #star-progress-wrapper.bar-mode { padding: 0; }
             #star-progress-wrapper .value-box {
                 padding: 1px 2px;
                 min-height: 24px;
@@ -1965,12 +2020,14 @@
                 justify-content: center;
                 align-items: center;
             }
+            #star-progress-wrapper.bar-mode .value-box { padding: 0; }
             #progress-lives-info-group .info-group { min-height: 30px; padding: 1px 4px 1px 14px; }
             #progress-lives-info-group .value-box { padding: 1px 6px 1px 14px; }
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
             .progress-star { width: 30px; height: 30px; }
-            #star-progress-container { width: 100%; gap: 19px; }
+            #star-progress-container.star-mode { width: 100%; gap: 19px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; }
 
 
             #d-pad-container {
@@ -2112,6 +2169,7 @@
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.6em; }
             #current-world-info-group { min-width: 60px; min-height: 34px; padding: 2px 4px 2px 20px; cursor: pointer;}
             #star-progress-wrapper { min-height: 30px; padding: 2px 2px; }
+            #star-progress-wrapper.bar-mode { padding: 0; }
             #star-progress-wrapper .value-box {
                 padding: 5px 5px;
                 min-height: 26px;
@@ -2119,12 +2177,14 @@
                 justify-content: center;
                 align-items: center;
             }
+            #star-progress-wrapper.bar-mode .value-box { padding: 0; }
             #progress-lives-info-group .info-group { min-height: 36px; padding: 2px 4px 2px 20px; }
             #progress-lives-info-group .value-box { padding: 2px 5px 2px 20px; }
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }
             .progress-star { width: 24px; height: 24px; }
-            #star-progress-container { width: 100%; gap: 16px; }
+            #star-progress-container.star-mode { width: 100%; gap: 16px; }
+            #star-progress-container.bar-mode .progress-segment { height: 100%; }
 
 
             #d-pad-container {
@@ -3833,6 +3893,7 @@
         const progressLifeTimerValueDisplay = document.getElementById("progressLifeTimerValue");
         const progressLivesInfoGroup = document.getElementById("progress-lives-info-group");
         const starProgressContainer = document.getElementById("star-progress-container");
+        const starProgressWrapper = document.getElementById("star-progress-wrapper");
         const highScoreDisplay = document.getElementById("high-score-display");
         const hsScoreValue = document.getElementById("hs-score-value");
         // Se obtendrá hsSkinValue dentro de la función displayHighScoreInPanel
@@ -4869,6 +4930,7 @@ function setupSlider(slider, display) {
         let currentLevelInWorld = 1;
         let maxUnlockedWorld = 1;
         let levelsProgress = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+        let levelFillAnimated = Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
         let worldCurrentLevels = Array(TOTAL_WORLDS).fill(1);
 
         // --- Variables de visualización para UI ---
@@ -5122,6 +5184,7 @@ function setupSlider(slider, display) {
             currentLevelInWorld = profile.currentLevelInWorld || 1;
             maxUnlockedWorld = profile.maxUnlockedWorld || 1;
             levelsProgress = Array.isArray(profile.levelsProgress) ? profile.levelsProgress : Array(TOTAL_WORLDS * LEVELS_PER_WORLD).fill(false);
+            levelFillAnimated = levelsProgress.slice();
             worldCurrentLevels = Array.isArray(profile.worldCurrentLevels) ? profile.worldCurrentLevels : Array(TOTAL_WORLDS).fill(1);
             currentMazeLevel = profile.currentMazeLevel || 1;
             mazeLevelStars = Array.isArray(profile.mazeLevelStars) ? profile.mazeLevelStars : Array(MAZE_LEVEL_COUNT).fill(0);
@@ -10485,7 +10548,7 @@ function setupSlider(slider, display) {
         }
         
         function updateGameModeUI() {
-
+            if (starProgressWrapper) starProgressWrapper.classList.remove('bar-mode');
             if (selectorInfoBar) selectorInfoBar.classList.toggle('hidden', !showModeSelect);
             topInfoBar.classList.toggle('hidden', showModeSelect);
 
@@ -10564,6 +10627,7 @@ function setupSlider(slider, display) {
                 titlePanel.classList.add('hidden');
                 progressPanel.classList.remove('hidden');
                 starProgressContainer.classList.remove('hidden');
+                if (starProgressWrapper) starProgressWrapper.classList.add('bar-mode');
                 highScoreDisplay.classList.add('hidden');
                 progressPanelLeftLabel.textContent = "Mundo:";
                 progressPanelLeftValue.textContent = `${displayWorld}.${displayLevelInWorld}`;
@@ -10920,7 +10984,12 @@ function populateMazeLevelButtons() {
 
         function drawStarProgress() {
             starProgressContainer.innerHTML = '';
+            starProgressContainer.classList.remove('bar-mode', 'star-mode');
+            if (starProgressWrapper) starProgressWrapper.classList.remove('bar-mode');
+
             if (gameMode === 'levels') {
+                starProgressContainer.classList.add('bar-mode');
+                if (starProgressWrapper) starProgressWrapper.classList.add('bar-mode');
                 const worldToDisplayStarsFor = (screenState.showCoverForWorld > 0 && !screenState.gameActuallyStarted)
                     ? displayWorld
                     : (gameOver ? displayWorld : currentWorld);
@@ -10928,11 +10997,29 @@ function populateMazeLevelButtons() {
                 for (let i = 0; i < LEVELS_PER_WORLD; i++) {
                     const levelIndexInTotal = worldLevelStartIndex + i;
                     const isCompleted = levelsProgress[levelIndexInTotal];
-                    const star = document.createElement('div');
-                    star.className = 'progress-star ' + (isCompleted ? 'full' : 'empty');
-                    starProgressContainer.appendChild(star);
+                    const segment = document.createElement('div');
+                    segment.className = 'progress-segment';
+                    const fill = document.createElement('div');
+                    fill.className = 'progress-fill';
+                    segment.appendChild(fill);
+                    starProgressContainer.appendChild(segment);
+
+                    if (isCompleted) {
+                        if (levelFillAnimated[levelIndexInTotal]) {
+                            segment.classList.add('full');
+                        } else {
+                            requestAnimationFrame(() => {
+                                void fill.offsetWidth;
+                                requestAnimationFrame(() => {
+                                    segment.classList.add('full');
+                                    levelFillAnimated[levelIndexInTotal] = true;
+                                });
+                            });
+                        }
+                    }
                 }
             } else if (gameMode === 'maze') {
+                starProgressContainer.classList.add('star-mode');
                 for (let i = 0; i < MAZE_STAR_TARGETS.length; i++) {
                     const isEarned = i < mazeStarsEarned;
                     const star = document.createElement('div');


### PR DESCRIPTION
## Summary
- Use a contiguous adventure-mode progress bar with segments that fill and animate without level-number labels
- Keep maze mode's star-based progress display intact while matching segment divider color to the bar fill

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688e24a2f65883338035f92fca7bb735