### PR TITLE
Alinear marco de barra de progreso con contenedor de estrellas

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -512,10 +512,6 @@
             text-align: center;
         }
 
-        #star-progress-wrapper.bar-mode {
-            padding: 0;
-        }
-
         #star-progress-wrapper .value-box {
             background-color: #422E58;
             border-radius: 8px;
@@ -524,10 +520,6 @@
             display: flex;
             justify-content: center;
             align-items: center;
-        }
-
-        #star-progress-wrapper.bar-mode .value-box {
-            padding: 0;
         }
 
         #progress-panel.classification-mode #star-progress-wrapper .value-box {
@@ -601,7 +593,6 @@
             gap: 0;
             width: 100%;
             height: 100%;
-            padding: 0;
             overflow: hidden;
             border-radius: 8px;
             align-items: stretch;


### PR DESCRIPTION
## Summary
- Restaurar el padding original del `star-progress-wrapper` para que la barra de progreso conserve el mismo marco que las estrellas del laberinto.
- Eliminar la anulación de padding en `#star-progress-container.bar-mode`, permitiendo que se muestre el borde común.

## Testing
- `npm test` *(falla: package.json no encontrado)*

------
https://chatgpt.com/codex/tasks/task_b_688e865ebf3083338983df722539747e