### PR TITLE
feat: show notifications for unclaimed achievements

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1546,6 +1546,19 @@
         .menu-option-button:hover { filter: brightness(0.95); }
         .menu-option-button:disabled { filter: brightness(0.6); cursor: not-allowed; }
         .menu-option-button.icon-button-pressed { filter: brightness(0.5); }
+        .has-notification {
+            position: relative;
+        }
+        .has-notification::after {
+            content: '';
+            position: absolute;
+            top: -4px;
+            right: -4px;
+            width: 12px;
+            height: 12px;
+            background-color: #FF0000;
+            border-radius: 50%;
+        }
         .config-svg,
         .info-svg {
             height: 100%;
@@ -10247,6 +10260,12 @@ function setupSlider(slider, display) {
             }
         }
 
+        function updateAchievementNotifications() {
+            const pending = Object.values(achievementsState).some(s => s.achieved && !s.claimed);
+            if (configButton) configButton.classList.toggle('has-notification', pending);
+            if (achievementsMenuButton) achievementsMenuButton.classList.toggle('has-notification', pending);
+        }
+
         function checkAchievements() {
             ACHIEVEMENTS.forEach(a => {
                 const progressVal = achievementsProgress[a.type] || 0;
@@ -10254,6 +10273,7 @@ function setupSlider(slider, display) {
                 if (!state.achieved && progressVal >= a.threshold) state.achieved = true;
                 achievementsState[a.id] = state;
             });
+            updateAchievementNotifications();
         }
 
         function claimAchievement(id) {
@@ -10272,6 +10292,7 @@ function setupSlider(slider, display) {
                 achievementsState[id] = state;
                 saveAchievementsState();
                 populateAchievements();
+                updateAchievementNotifications();
             }
         }
 
@@ -12585,6 +12606,8 @@ async function startGame(isRestart = false) {
             updateGameModeUI(); // This will use the newly set display variables
             updateCoinDisplay();
             updateGemDisplay();
+            checkAchievements();
+            saveAchievementsState();
         }
 
 


### PR DESCRIPTION
## Summary
- display red notification dot on main menu and achievements buttons when achievements remain unclaimed
- update notifications on startup and after claiming achievements
- check and save achievements during game settings load

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_b_688f239fa5ac8333a3b8c14b7dd5d1a8