### PR TITLE
Alinea altura del panel de progreso con la del título

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -383,8 +383,8 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 8px 10px;
-            min-height: 48px;
+            padding: 0 10px;
+            height: 48px;
             width: 100%;
             margin: 0 auto 5px auto;
             position: relative;
@@ -426,15 +426,19 @@
             margin: 0 auto 5px auto;
             position: relative;
             z-index: 10;
+            height: 48px;
+            overflow: hidden;
         }
 
         #progress-panel .panel-card {
             position: relative;
-            padding: 4px;
+            padding: 0;
             border: 2px solid #2B1D3A;
             border-radius: 10px;
             box-shadow: 0 2px 0 #422E58;
             box-sizing: border-box;
+            height: 100%;
+            overflow: hidden;
         }
 
         #progress-panel .panel-card::before {
@@ -476,13 +480,14 @@
             justify-content: center;
             background-color: #374151;
             border-radius: 8px;
-            padding: 8px 10px;
+            padding: 0 10px;
             grid-column: 1 / 2;
             min-width: 80px;
-            min-height: 55px;
+            height: 100%;
             box-sizing: border-box;
             text-align: center;
             cursor: pointer;
+            overflow: hidden;
         }
          #current-world-info-group .info-label { 
             font-size: 0.65em; 
@@ -506,10 +511,11 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            padding: 8px 10px;
-            min-height: 55px;
+            padding: 0 10px;
+            height: 100%;
             box-sizing: border-box;
             text-align: center;
+            overflow: hidden;
         }
 
         #star-progress-wrapper.bar-mode {
@@ -519,11 +525,14 @@
         #star-progress-wrapper .value-box {
             background-color: #422E58;
             border-radius: 8px;
-            padding: 6px 8px;
+            padding: 0 8px;
             width: 100%;
             display: flex;
             justify-content: center;
             align-items: center;
+            height: 100%;
+            box-sizing: border-box;
+            overflow: hidden;
         }
 
         #star-progress-wrapper.bar-mode .value-box {
@@ -545,19 +554,23 @@
             align-items: center;
             justify-content: flex-start;
             border-radius: 8px;
-            padding: 6px 8px 6px 22px;
+            padding: 0 8px 0 22px;
             min-width: 90px;
-            min-height: 48px;
+            height: 100%;
             box-sizing: border-box;
             width: 100%;
+            overflow: hidden;
         }
 
         #progress-lives-info-group .value-box {
             background-color: #422E58;
             border-radius: 8px;
-            padding: 6px 8px 6px 22px;
+            padding: 0 8px;
             width: 100%;
             text-align: center;
+            height: 100%;
+            box-sizing: border-box;
+            overflow: hidden;
         }
 
         #progress-lives-info-group .info-icon-wrapper {
@@ -652,6 +665,7 @@
             gap: 15px;
             justify-items: center;
             align-items: center;
+            height: 100%;
         }
 
         .progress-star {
@@ -675,8 +689,10 @@
             align-items: center;
             justify-content: flex-start;
             width: 100%;
-            padding: 6px 0 4px 22px;
-            min-height: 48px; /* Igual altura que el temporizador de vidas */
+            padding: 0 0 0 22px;
+            height: 100%;
+            box-sizing: border-box;
+            overflow: hidden;
         }
         #high-score-display .info-icon-wrapper {
             position: absolute;
@@ -703,10 +719,12 @@
         #high-score-display .value-box {
             background-color: #422E58;
             border-radius: 8px;
-            padding: 6px 8px 6px 22px;
-            min-height: 36px; /* Mantener misma altura visual que otros paneles */
+            padding: 0 8px;
             width: 100%;
             text-align: center;
+            height: 100%;
+            box-sizing: border-box;
+            overflow: hidden;
         }
         #hs-values-container {
             display: flex;
@@ -2020,17 +2038,19 @@
                 margin-left: 0;
             }
           
-            #title-panel { min-height: 30px; padding: 6px; }
+            #title-panel { padding: 0 6px; }
             #title-image,
             #settings-title,
             #main-info-title,
             #specific-info-title { font-size: 0.9em; }
 
-            #current-world-info-group { min-height: 30px; padding: 1px 4px 1px 14px; min-width: 70px; cursor: pointer;}
+            #progress-panel .panel-card { padding: 0; }
+
+            #current-world-info-group { min-height: 30px; padding: 6px 4px 6px 14px; min-width: 70px; cursor: pointer; overflow: hidden; }
             #current-world-info-group .info-label { font-size: 0.6em; }
             #current-world-info-group .info-value { font-size: 0.8em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.7em; }
-            #star-progress-wrapper { min-height: 28px; padding: 1px 2px; }
+            #star-progress-wrapper { min-height: 30px; padding: 6px 2px; overflow: hidden; }
             #star-progress-wrapper.bar-mode { padding: 0; }
             #star-progress-wrapper .value-box {
                 padding: 1px 2px;
@@ -2038,9 +2058,10 @@
                 display: flex;
                 justify-content: center;
                 align-items: center;
+                height: 100%;
             }
             #star-progress-wrapper.bar-mode .value-box { padding: 0; }
-            #progress-lives-info-group .info-group { min-height: 30px; padding: 1px 4px 1px 14px; }
+            #progress-lives-info-group .info-group { min-height: 30px; padding: 6px 4px 6px 14px; overflow: hidden; }
             #progress-lives-info-group .value-box { padding: 1px 6px 1px 14px; }
             #progress-lives-info-group .info-value { font-size: 0.8em; }
             #progress-lives-info-group .info-icon-wrapper { width: 26px; height: 26px; transform: translate(10%, -50%); }
@@ -2154,7 +2175,7 @@
                 transform: translateX(-60px) translateY(-40%);
             }
 
-            #title-panel { min-height: 36px; padding: 6px; }
+            #title-panel { padding: 0 6px; }
             #title-image,
             #settings-title,
             #main-info-title,
@@ -2186,8 +2207,8 @@
             #current-world-info-group .info-label { font-size: 0.55em; }
             #current-world-info-group .info-value { font-size: 0.7em; }
             #progress-panel.classification-mode #current-world-info-group .info-value { font-size: 0.6em; }
-            #current-world-info-group { min-width: 60px; min-height: 34px; padding: 2px 4px 2px 20px; cursor: pointer;}
-            #star-progress-wrapper { min-height: 30px; padding: 2px 2px; }
+            #current-world-info-group { min-width: 60px; min-height: 32px; padding: 4px 4px 4px 20px; cursor: pointer; overflow: hidden;}
+            #star-progress-wrapper { min-height: 32px; padding: 4px 2px; overflow: hidden; }
             #star-progress-wrapper.bar-mode { padding: 0; }
             #star-progress-wrapper .value-box {
                 padding: 5px 5px;
@@ -2195,9 +2216,10 @@
                 display: flex;
                 justify-content: center;
                 align-items: center;
+                height: 100%;
             }
             #star-progress-wrapper.bar-mode .value-box { padding: 0; }
-            #progress-lives-info-group .info-group { min-height: 36px; padding: 2px 4px 2px 20px; }
+            #progress-lives-info-group .info-group { min-height: 36px; padding: 2px 4px 2px 20px; overflow: hidden; }
             #progress-lives-info-group .value-box { padding: 2px 5px 2px 20px; }
             #progress-lives-info-group .info-value { font-size: 0.7em; }
             #progress-lives-info-group .info-icon-wrapper { width: 32px; height: 32px; transform: translate(12%, -50%); }


### PR DESCRIPTION
## Summary
- Fijada altura de 48px tanto para el panel del título como el de progreso para eliminar saltos visuales
- Reducidos rellenos y ajustados contenedores internos del panel de progreso, incluyendo vidas y estrellas, para que no excedan su altura
- Simplificado el bloque de récords para que se adapte al nuevo alto sin desbordar

## Testing
- `npm test` *(falla: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_688f35f33a3c833384ad77bd95814f66