### PR TITLE
Mantiene portada del canvas al crear jugador

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -11737,6 +11737,25 @@ async function startGame(isRestart = false) {
                 newPlayerNameInput.value = '';
                 const keepDifficulty = difficultySelector.value;
                 applyProfile(playerProfiles[currentPlayerName]);
+
+                if (!gameIntervalId) {
+                    if (gameMode === 'freeMode') {
+                        screenState.showFreeModeCover = true;
+                    } else if (gameMode === 'levels') {
+                        screenState.showCoverForWorld = currentWorld;
+                        screenState.showWorldCompleteCover = 0;
+                        screenState.showLevelCompleteCover = 0;
+                        screenState.showDefeatCoverForWorld = 0;
+                        screenState.showTimeoutCover = false;
+                        drawStarProgress();
+                    } else if (gameMode === 'classification') {
+                        screenState.showClassificationCover = true;
+                    } else if (gameMode === 'maze') {
+                        screenState.showMazeCover = true;
+                        screenState.mazeResultType = '';
+                    }
+                }
+
                 if (gameMode === 'classification') {
                     difficultySelector.value = keepDifficulty;
                     classificationDifficultyIndex = CLASSIFICATION_DIFFICULTY_ORDER.indexOf(keepDifficulty);


### PR DESCRIPTION
## Resumen
- Restaura la imagen de portada del canvas al registrar un nuevo jugador.
- Ajusta `screenState` según el modo de juego para que la portada vuelva a mostrarse y actualiza el progreso de estrellas cuando corresponde.

## Testing
- `npm test` *(falla: package.json no encontrado)*


------
https://chatgpt.com/codex/tasks/task_b_688f360d73a48333aa2ca7647d8c5700