### PR TITLE
Aumenta tamaño del título en selector de juegos

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -384,7 +384,7 @@
             justify-content: center;
             align-items: center;
             padding: 8px 10px;
-            min-height: 48px;
+            min-height: 55px;
             width: 100%;
             margin: 0 auto 5px auto;
             position: relative;
@@ -407,7 +407,7 @@
             text-overflow: ellipsis;
         }
         #title-image {
-            max-height: 48px;
+            max-height: 55px;
             width: auto;
             max-width: 90%;
         }
@@ -2025,6 +2025,7 @@
             #settings-title,
             #main-info-title,
             #specific-info-title { font-size: 0.9em; }
+            #title-image { max-height: 30px; }
 
             #current-world-info-group { min-height: 30px; padding: 1px 4px 1px 14px; min-width: 70px; cursor: pointer;}
             #current-world-info-group .info-label { font-size: 0.6em; }
@@ -2159,6 +2160,7 @@
             #settings-title,
             #main-info-title,
             #specific-info-title { font-size: 1em; }
+            #title-image { max-height: 36px; }
 
 
              #top-info-bar .info-label { font-size: 0.55em; }


### PR DESCRIPTION
## Summary
- Amplía la altura del panel de título y de la imagen para igualar el tamaño de los paneles de otros modos.
- Ajusta estilos responsivos para mantener proporciones en pantallas pequeñas.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f3a60a2b883338400f1d3a7cb2125