### PR TITLE
Move achievements notification dot to button corner

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1481,6 +1481,15 @@
             border-radius: 50%;
             display: none;
         }
+        #achievements-menu-button {
+            overflow: visible;
+        }
+
+        #achievements-menu-button .notification-dot {
+            top: 0;
+            right: 0;
+            transform: translate(50%, -50%);
+        }
         .icon-button-pressed {
             transform: scale(0.90) translateY(2px);
             filter: brightness(0.7);


### PR DESCRIPTION
## Summary
- Allow achievements button to render notifications outside the button
- Position achievements notification dot at the top-right corner

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_b_688f4a357f648333a0ebf0b90a624722