### PR TITLE
Estilo unificado para pestañas de tienda y perfil

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2967,15 +2967,19 @@
           font-family: 'Press Start 2P', sans-serif;
           font-size: 0.7rem;
           padding: 4px 6px;
-          border: 2px solid #8f66af;
-          border-radius: 6px;
-          background-color: #1F2937;
-          color: #C084FC;
+          width: auto;
+          height: auto;
         }
 
         .store-tab.active {
-          background-color: #8f66af;
-          color: #1F2937;
+          filter: brightness(0.5);
+          transform: translateY(2px);
+        }
+
+        .store-tab img {
+          height: 40px;
+          width: auto;
+          pointer-events: none;
         }
 
         #purchase-item-preview {
@@ -3572,10 +3576,16 @@
     </div>
     <div class="panel-content">
         <div id="profile-tabs" class="flex justify-center gap-2 mb-2">
-            <button data-tab="general" id="profile-tab-general" class="store-tab active">PERFIL</button>
-            <button data-tab="comida" id="profile-tab-comida" class="store-tab">COMIDA</button>
-            <button data-tab="disfraces" id="profile-tab-disfraces" class="store-tab">DISFRACES</button>
-            <button data-tab="escenarios" id="profile-tab-escenarios" class="store-tab">ESCENARIOS</button>
+            <button data-tab="general" id="profile-tab-general" class="store-tab menu-option-button active">PERFIL</button>
+            <button data-tab="comida" id="profile-tab-comida" class="store-tab menu-option-button">
+                <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
+            </button>
+            <button data-tab="disfraces" id="profile-tab-disfraces" class="store-tab menu-option-button">
+                <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+            </button>
+            <button data-tab="escenarios" id="profile-tab-escenarios" class="store-tab menu-option-button">
+                <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
+            </button>
         </div>
 
         <div id="profile-general-content">
@@ -3677,10 +3687,16 @@
                 </div>
                 <div class="panel-content">
                     <div id="store-tabs" class="flex justify-center gap-2 mb-2">
-                        <button data-tab="general" id="store-tab-general" class="store-tab active">GENERAL</button>
-                        <button data-tab="comida" id="store-tab-comida" class="store-tab">COMIDA</button>
-                        <button data-tab="disfraces" id="store-tab-disfraces" class="store-tab">DISFRACES</button>
-                        <button data-tab="escenarios" id="store-tab-escenarios" class="store-tab">ESCENARIOS</button>
+                        <button data-tab="general" id="store-tab-general" class="store-tab menu-option-button active">GENERAL</button>
+                        <button data-tab="comida" id="store-tab-comida" class="store-tab menu-option-button">
+                            <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
+                        </button>
+                        <button data-tab="disfraces" id="store-tab-disfraces" class="store-tab menu-option-button">
+                            <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+                        </button>
+                        <button data-tab="escenarios" id="store-tab-escenarios" class="store-tab menu-option-button">
+                            <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
+                        </button>
                     </div>
                 <div id="store-items-container" class="grid grid-cols-3 gap-4 w-full"></div>
                 </div>


### PR DESCRIPTION
## Summary
- Las pestañas de comida, disfraces y escenarios en el perfil y la tienda muestran iconos de manzana, serpiente y hierba
- Se añadió estilo para dimensionar correctamente los iconos de pestañas

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f4feb62308333b312aa979a76abc1