### PR TITLE
feat: update tab icon and round scene images

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2829,6 +2829,7 @@
           left: 50%;
           transform: translate(-50%, -50%);
           object-fit: cover;
+          border-radius: 10px;
         }
         .achievement-item {
           display: flex;
@@ -3583,7 +3584,7 @@
                 <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
             </button>
             <button data-tab="disfraces" id="profile-tab-disfraces" class="store-tab menu-option-button">
-                <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+                <img src="images/disfraces-icon.svg" alt="Disfraces">
             </button>
             <button data-tab="escenarios" id="profile-tab-escenarios" class="store-tab menu-option-button">
                 <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
@@ -3694,7 +3695,7 @@
                             <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
                         </button>
                         <button data-tab="disfraces" id="store-tab-disfraces" class="store-tab menu-option-button">
-                            <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+                            <img src="images/disfraces-icon.svg" alt="Disfraces">
                         </button>
                         <button data-tab="escenarios" id="store-tab-escenarios" class="store-tab menu-option-button">
                             <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">

--- a/images/disfraces-icon.svg
+++ b/images/disfraces-icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <path d="M8 24c0 12 8 20 24 20s24-8 24-20S48 4 32 4 8 12 8 24z" fill="#8C64AF" stroke="#2B1D3A" stroke-width="4"/>
+  <circle cx="24" cy="24" r="6" fill="#02030D"/>
+  <circle cx="40" cy="24" r="6" fill="#02030D"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace snake icon in profile and store tabs with new costume icon
- round scenario images inside store items

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f616c71f0833392cec5d6f37ebaa5