### PR TITLE
Use downward snake icon for profile and store tabs

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3583,7 +3583,7 @@
                 <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
             </button>
             <button data-tab="disfraces" id="profile-tab-disfraces" class="store-tab menu-option-button">
-                <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+                <img src="https://i.imgur.com/kCgKrBZ.png" alt="Disfraces">
             </button>
             <button data-tab="escenarios" id="profile-tab-escenarios" class="store-tab menu-option-button">
                 <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
@@ -3694,7 +3694,7 @@
                             <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
                         </button>
                         <button data-tab="disfraces" id="store-tab-disfraces" class="store-tab menu-option-button">
-                            <img src="https://i.imgur.com/fcZoVkW.png" alt="Disfraces">
+                            <img src="https://i.imgur.com/kCgKrBZ.png" alt="Disfraces">
                         </button>
                         <button data-tab="escenarios" id="store-tab-escenarios" class="store-tab menu-option-button">
                             <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">


### PR DESCRIPTION
## Summary
- Replace snake icon in profile tab button with downward-moving head asset
- Replace snake icon in store tab button with downward-moving head asset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688f638b03a083339f633d950b62ff1f