### PR TITLE
Add currency purchase tab

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1017,6 +1017,13 @@
             margin-right: 4px;
         }
 
+        .gem-cost-icon {
+            width: 16px;
+            height: 16px;
+            margin-left: 4px;
+            vertical-align: middle;
+        }
+
 
         #earnedCoinsMessage {
             position: absolute;
@@ -3690,6 +3697,9 @@
                 <div class="panel-content">
                     <div id="store-tabs" class="flex gap-2 mb-2">
                         <button data-tab="general" id="store-tab-general" class="store-tab menu-option-button active">GENERAL</button>
+                        <button data-tab="divisas" id="store-tab-divisas" class="store-tab menu-option-button">
+                            <img src="https://i.imgur.com/WDpRCFy.png" alt="Divisas">
+                        </button>
                         <button data-tab="comida" id="store-tab-comida" class="store-tab menu-option-button">
                             <img src="https://i.imgur.com/fOSSwUX.png" alt="Comida">
                         </button>
@@ -5442,6 +5452,16 @@ function setupSlider(slider, display) {
         let totalGems = 0;
         const HEART_PRICE = 100;
         const GEM_PRICE = 1000;
+        const COIN_PACKS = {
+            coin1000: { img: 'https://i.imgur.com/walqd0H.png', costGems: 1, amount: 1000, name: 'Monedas' },
+            coin7500: { img: 'https://i.imgur.com/iGzWFgy.png', costGems: 5, amount: 7500, name: 'Bolsa de Monedas' },
+            coin20000: { img: 'https://i.imgur.com/FNDmDcR.png', costGems: 10, amount: 20000, name: 'Cofre de Monedas' }
+        };
+        const GEM_PACKS = {
+            gem10: { img: 'https://i.imgur.com/Qoo648i.png', price: '0.99€', amount: 10, name: 'Gemas' },
+            gem50: { img: 'https://i.imgur.com/Sk6SMrC.png', price: '2.99€', amount: 50, name: 'Bolsa de Gemas' },
+            gem100: { img: 'https://i.imgur.com/w15V6yf.png', price: '4.99€', amount: 100, name: 'Cofre de Gemas' }
+        };
         let storeTab = 'general';
         let profileTab = 'general';
         // --- Fin Configuración de Comestibles ---
@@ -7218,6 +7238,39 @@ function setupSlider(slider, display) {
                     item.appendChild(status);
                     storeItemsContainer.appendChild(item);
                 });
+            } else if (storeTab === 'divisas') {
+                const items = [
+                    { key: 'coin1000', pack: COIN_PACKS.coin1000, type: 'coinPack' },
+                    { key: 'coin7500', pack: COIN_PACKS.coin7500, type: 'coinPack' },
+                    { key: 'coin20000', pack: COIN_PACKS.coin20000, type: 'coinPack' },
+                    { key: 'gem10', pack: GEM_PACKS.gem10, type: 'gemPack' },
+                    { key: 'gem50', pack: GEM_PACKS.gem50, type: 'gemPack' },
+                    { key: 'gem100', pack: GEM_PACKS.gem100, type: 'gemPack' }
+                ];
+                items.forEach(({ key, pack, type }) => {
+                    const item = document.createElement('div');
+                    item.className = 'store-item';
+                    const img = document.createElement('img');
+                    img.className = 'store-item-img';
+                    img.src = pack.img;
+                    item.appendChild(img);
+                    const status = document.createElement('div');
+                    status.className = 'store-item-status';
+                    if (type === 'coinPack') {
+                        status.textContent = pack.costGems.toString();
+                        const gemImg = document.createElement('img');
+                        gemImg.src = GEM_PACKS.gem10.img;
+                        gemImg.className = 'gem-cost-icon';
+                        status.appendChild(gemImg);
+                        item.addEventListener('click', () => openPurchaseConfirm('coinPack', key));
+                    } else {
+                        status.textContent = pack.price;
+                        item.addEventListener('click', () => openPurchaseConfirm('gemPack', key));
+                    }
+                    addIconPressEvents(item, item);
+                    item.appendChild(status);
+                    storeItemsContainer.appendChild(item);
+                });
             } else {
                 const generalItems = [
                     { key: 'heart', price: HEART_PRICE, img: 'https://i.imgur.com/WrI2XXx.png' },
@@ -7258,6 +7311,10 @@ function setupSlider(slider, display) {
                     img.src = SCENES[key]?.icon || '';
                 } else if (type === 'general') {
                     img.src = key === 'heart' ? 'https://i.imgur.com/WrI2XXx.png' : 'https://i.imgur.com/gPGsaCO.png';
+                } else if (type === 'coinPack') {
+                    img.src = COIN_PACKS[key]?.img || '';
+                } else if (type === 'gemPack') {
+                    img.src = GEM_PACKS[key]?.img || '';
                 }
                 purchaseItemPreview.appendChild(img);
             }
@@ -7266,17 +7323,28 @@ function setupSlider(slider, display) {
             if (type === 'food') {
                 price = FOODS[key].price;
                 name = FOOD_DISPLAY_NAMES[key];
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
             } else if (type === 'skin') {
                 price = SKIN_PRICES[key];
                 name = SKIN_DISPLAY_NAMES[key];
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
             } else if (type === 'scene') {
                 price = SCENE_PRICES[key];
                 name = SCENE_DISPLAY_NAMES[key];
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
             } else if (type === 'general') {
                 price = key === 'heart' ? HEART_PRICE : GEM_PRICE;
                 name = key === 'heart' ? 'coraz\u00F3n' : 'gema';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
+            } else if (type === 'coinPack') {
+                price = COIN_PACKS[key].costGems;
+                name = `${COIN_PACKS[key].amount} monedas`;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
+            } else if (type === 'gemPack') {
+                price = GEM_PACKS[key].price;
+                name = `${GEM_PACKS[key].amount} gemas`;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong>?`;
             }
-            if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
             purchaseConfirmationPanel.classList.add('centered-panel');
             togglePanel(purchaseConfirmationPanel, purchaseConfirmationPanel.querySelector('.panel-content'), true);
             if (modalOverlay) modalOverlay.classList.remove('hidden');
@@ -7345,6 +7413,25 @@ function setupSlider(slider, display) {
                         success = true;
                     }
                 }
+            } else if (purchaseInfo.type === 'coinPack') {
+                const pack = COIN_PACKS[purchaseInfo.key];
+                price = pack.costGems;
+                if (totalGems >= price) {
+                    totalGems -= price;
+                    saveGems();
+                    updateGemDisplay();
+                    const prev = totalCoins;
+                    totalCoins += pack.amount;
+                    showEarnedCoinsMessage(pack.amount);
+                    animateCoinGain(prev, totalCoins);
+                    success = true;
+                } else {
+                    failureMessage = 'Gemas insuficientes';
+                }
+            } else if (purchaseInfo.type === 'gemPack') {
+                closePurchaseConfirm();
+                showInsufficientFundsToast('Función no disponible');
+                return;
             }
             if (success) {
                 localStorage.setItem('snakeGameCoins', totalCoins.toString());


### PR DESCRIPTION
## Summary
- add new currency tab to store for coin and gem purchases
- implement coin pack purchases with gems and placeholder real-money gem packs
- style gem cost icon for currency items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68905f390c808333bb502dc9590cb0b2