### PR TITLE
feat: mejorar visualización de precios en la tienda

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1017,6 +1017,13 @@
             margin-right: 4px;
         }
 
+        .coin-cost-icon {
+            width: 16px;
+            height: 16px;
+            position: relative;
+            top: -2px;
+        }
+
         .gem-cost-icon {
             width: 16px;
             height: 16px;
@@ -2971,7 +2978,7 @@
         }
         .store-item-status {
           position: absolute;
-          bottom: 16px;
+          bottom: 8px;
           left: 0;
           right: 0;
           display: flex;
@@ -2979,7 +2986,7 @@
           align-items: center;
           gap: 2px;
           font-size: 0.7rem;
-          color: #C084FC;
+          color: #ffffff;
           text-shadow: 1px 1px 2px black;
           font-family: 'Press Start 2P', sans-serif;
         }
@@ -7196,7 +7203,14 @@ function setupSlider(slider, display) {
                         status.textContent = '';
                         item.classList.add('purchased');
                     } else {
-                        status.textContent = FOODS[key].price.toString();
+                        const costSpan = document.createElement('span');
+                        costSpan.textContent = FOODS[key].price.toString();
+                        status.appendChild(costSpan);
+                        const coinImg = document.createElement('img');
+                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
+                        coinImg.alt = 'Moneda';
+                        coinImg.className = 'coin-cost-icon';
+                        status.appendChild(coinImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('food', key));
                         addIconPressEvents(item, item);
@@ -7220,7 +7234,14 @@ function setupSlider(slider, display) {
                         status.textContent = '';
                         item.classList.add('purchased');
                     } else {
-                        status.textContent = SKIN_PRICES[key].toString();
+                        const costSpan = document.createElement('span');
+                        costSpan.textContent = SKIN_PRICES[key].toString();
+                        status.appendChild(costSpan);
+                        const coinImg = document.createElement('img');
+                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
+                        coinImg.alt = 'Moneda';
+                        coinImg.className = 'coin-cost-icon';
+                        status.appendChild(coinImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('skin', key));
                         addIconPressEvents(item, item);
@@ -7244,7 +7265,14 @@ function setupSlider(slider, display) {
                         status.textContent = '';
                         item.classList.add('purchased');
                     } else {
-                        status.textContent = SCENE_PRICES[key].toString();
+                        const costSpan = document.createElement('span');
+                        costSpan.textContent = SCENE_PRICES[key].toString();
+                        status.appendChild(costSpan);
+                        const coinImg = document.createElement('img');
+                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
+                        coinImg.alt = 'Moneda';
+                        coinImg.className = 'coin-cost-icon';
+                        status.appendChild(coinImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('scene', key));
                         addIconPressEvents(item, item);
@@ -7302,7 +7330,14 @@ function setupSlider(slider, display) {
                     item.appendChild(img);
                     const status = document.createElement('div');
                     status.className = 'store-item-status';
-                    status.textContent = data.price.toString();
+                    const costSpan = document.createElement('span');
+                    costSpan.textContent = data.price.toString();
+                    status.appendChild(costSpan);
+                    const coinImg = document.createElement('img');
+                    coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
+                    coinImg.alt = 'Moneda';
+                    coinImg.className = 'coin-cost-icon';
+                    status.appendChild(coinImg);
                     item.addEventListener('click', () => openPurchaseConfirm('general', data.key));
                     addIconPressEvents(item, item);
                     item.appendChild(status);


### PR DESCRIPTION
## Summary
- Mueve hacia abajo y pone en blanco el valor de compra de cada artículo
- Muestra un icono de moneda junto al precio en los artículos comprables con monedas

## Testing
- `npm test` *(falla: no existe package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68908d2b874483338181df5cd698dc36