### PR TITLE
Animar incremento de vidas tras compras

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7644,7 +7644,15 @@ function openPurchaseConfirm(type, key) {
                         if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
                         saveLives();
                         updateLifeTimerDisplay();
-                        animateLifeGain(prevLives, playerLives);
+                        const gain = playerLives - prevLives;
+                        if (gain > 0) {
+                            showEarnedLivesMessage(gain);
+                            setTimeout(() => {
+                                animateLifeGain(prevLives, playerLives);
+                            }, COIN_MESSAGE_DISPLAY_TIME);
+                        } else {
+                            updateLivesDisplay();
+                        }
                         success = true;
                     } else if (playerLives >= MAX_LIVES) {
                         failureMessage = 'Vidas al máximo';
@@ -7676,7 +7684,15 @@ function openPurchaseConfirm(type, key) {
                             if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
                             saveLives();
                             updateLifeTimerDisplay();
-                            animateLifeGain(prevLives, playerLives);
+                            const gain = playerLives - prevLives;
+                            if (gain > 0) {
+                                showEarnedLivesMessage(gain);
+                                setTimeout(() => {
+                                    animateLifeGain(prevLives, playerLives);
+                                }, COIN_MESSAGE_DISPLAY_TIME);
+                            } else {
+                                updateLivesDisplay();
+                            }
                             success = true;
                         } else {
                             failureMessage = 'Vidas al máximo';
@@ -7690,7 +7706,14 @@ function openPurchaseConfirm(type, key) {
                         if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
                         saveLives();
                         updateLifeTimerDisplay();
-                        animateLifeGain(prevLives, playerLives);
+                        if (actualGain > 0) {
+                            showEarnedLivesMessage(actualGain);
+                            setTimeout(() => {
+                                animateLifeGain(prevLives, playerLives);
+                            }, COIN_MESSAGE_DISPLAY_TIME);
+                        } else {
+                            updateLivesDisplay();
+                        }
                         success = true;
                     } else if (purchaseInfo.type === 'coinInfinite') {
                         totalCoins -= price;
@@ -7736,31 +7759,46 @@ function openPurchaseConfirm(type, key) {
                 adsWatched[type] = Math.min(adsWatched[type] + 1, AD_ITEMS[type].ads);
                 saveAdProgress();
                 updateAdStatuses();
-                if (adsWatched[type] >= AD_ITEMS[type].ads) {
-                    if (type === 'adLife') {
-                        const prevLives = playerLives;
-                        if (playerLives < MAX_LIVES) {
-                            playerLives++;
-                            if (lifeRestoreQueue.length > 0) lifeRestoreQueue.pop();
-                            if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
-                            saveLives();
-                            updateLifeTimerDisplay();
-                            animateLifeGain(prevLives, playerLives);
-                        }
-                    } else if (type === 'adChest') {
-                        const gain = Math.floor(Math.random() * 5) + 1;
-                        const prevLives = playerLives;
-                        playerLives = Math.min(MAX_LIVES, playerLives + gain);
-                        const actualGain = playerLives - prevLives;
-                        if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
-                        saveLives();
-                        updateLifeTimerDisplay();
-                        animateLifeGain(prevLives, playerLives);
-                    } else if (type === 'adInfinite') {
-                        infiniteLivesEnd = Date.now() + 60 * 60 * 1000;
-                        playerLives = MAX_LIVES;
-                        lifeRestoreQueue = [];
-                        saveLives();
+                        if (adsWatched[type] >= AD_ITEMS[type].ads) {
+                            if (type === 'adLife') {
+                                const prevLives = playerLives;
+                                if (playerLives < MAX_LIVES) {
+                                    playerLives++;
+                                    if (lifeRestoreQueue.length > 0) lifeRestoreQueue.pop();
+                                    if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
+                                    saveLives();
+                                    updateLifeTimerDisplay();
+                                    const gain = playerLives - prevLives;
+                                    if (gain > 0) {
+                                        showEarnedLivesMessage(gain);
+                                        setTimeout(() => {
+                                            animateLifeGain(prevLives, playerLives);
+                                        }, COIN_MESSAGE_DISPLAY_TIME);
+                                    } else {
+                                        updateLivesDisplay();
+                                    }
+                                }
+                            } else if (type === 'adChest') {
+                                const gain = Math.floor(Math.random() * 5) + 1;
+                                const prevLives = playerLives;
+                                playerLives = Math.min(MAX_LIVES, playerLives + gain);
+                                const actualGain = playerLives - prevLives;
+                                if (playerLives >= MAX_LIVES) lifeRestoreQueue = [];
+                                saveLives();
+                                updateLifeTimerDisplay();
+                                if (actualGain > 0) {
+                                    showEarnedLivesMessage(actualGain);
+                                    setTimeout(() => {
+                                        animateLifeGain(prevLives, playerLives);
+                                    }, COIN_MESSAGE_DISPLAY_TIME);
+                                } else {
+                                    updateLivesDisplay();
+                                }
+                            } else if (type === 'adInfinite') {
+                                infiniteLivesEnd = Date.now() + 60 * 60 * 1000;
+                                playerLives = MAX_LIVES;
+                                lifeRestoreQueue = [];
+                                saveLives();
                         updateLivesDisplay();
                         updateLifeTimerDisplay();
                     }
@@ -10934,7 +10972,6 @@ function openPurchaseConfirm(type, key) {
                 updateLivesDisplay();
                 return;
             }
-            showEarnedLivesMessage(diff);
             const duration = Math.min(2000, diff * 60);
             const start = performance.now();
             if (areSfxEnabled) playSound('coinAdd', duration / 1000);


### PR DESCRIPTION
## Summary
- Animación de incremento de vidas tras comprar corazones, cofres y anuncios con mensaje verde y desplazamiento.
- Ajustada función `animateLifeGain` para sólo animar el contador tras mostrar el mensaje.

## Testing
- `npm test` *(falló: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890f15e79588333912601e6bc04472e