### PR TITLE
Animar suma de vidas tras compra

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7694,12 +7694,13 @@ function openPurchaseConfirm(type, key) {
                         success = true;
                     } else if (purchaseInfo.type === 'coinInfinite') {
                         totalCoins -= price;
+                        const prevLives = playerLives;
                         infiniteLivesEnd = Date.now() + 60 * 60 * 1000;
                         playerLives = MAX_LIVES;
                         lifeRestoreQueue = [];
                         saveLives();
-                        updateLivesDisplay();
                         updateLifeTimerDisplay();
+                        animateLifeGain(prevLives, playerLives);
                         success = true;
                     }
                 } else {
@@ -7757,12 +7758,13 @@ function openPurchaseConfirm(type, key) {
                         updateLifeTimerDisplay();
                         animateLifeGain(prevLives, playerLives);
                     } else if (type === 'adInfinite') {
+                        const prevLives = playerLives;
                         infiniteLivesEnd = Date.now() + 60 * 60 * 1000;
                         playerLives = MAX_LIVES;
                         lifeRestoreQueue = [];
                         saveLives();
-                        updateLivesDisplay();
                         updateLifeTimerDisplay();
+                        animateLifeGain(prevLives, playerLives);
                     }
                     adsWatched[type] = 0;
                     adCooldownExpiry[type] = Date.now() + 60 * 60 * 1000;


### PR DESCRIPTION
## Summary
- Añade animación de suma de vidas al comprar "vidas infinitas" con monedas
- Muestra la animación también al desbloquear vidas infinitas mediante anuncios

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6890f15e79588333912601e6bc04472e