### PR TITLE
Standardize shop pricing with gems

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2851,21 +2851,21 @@
           content: '';
           position: absolute;
           inset: 0;
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
+          background-image: url('https://i.imgur.com/n1Fb83c.png');
           background-size: contain;
           background-repeat: no-repeat;
           background-position: center;
           transition: filter 0.05s ease-out;
           pointer-events: none;
-          z-index: 1;
+          z-index: 0;
         }
         .store-item.scene-item::before {
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
-          z-index: 1;
+          background-image: url('https://i.imgur.com/n1Fb83c.png');
+          z-index: 0;
         }
         .store-item.currency-item::before {
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
-          z-index: 1;
+          background-image: url('https://i.imgur.com/n1Fb83c.png');
+          z-index: 0;
         }
         .store-item:hover::before { filter: brightness(0.95); }
         .store-item.icon-button-pressed::before { filter: brightness(0.5); }
@@ -2881,12 +2881,12 @@
           opacity: 0.7;
         }
         .store-item.locked .store-item-status {
-          color: #cccccc;
-          opacity: 0.7;
+          color: #ffffff;
+          opacity: 1;
         }
         .store-item.locked .store-item-status img {
-          filter: grayscale(100%);
-          opacity: 0.7;
+          filter: none;
+          opacity: 1;
         }
         .store-item.purchased {
           pointer-events: none;
@@ -2904,13 +2904,13 @@
           height: 60%;
           object-fit: contain;
           pointer-events: none;
-          z-index: 0;
+          z-index: 1;
         }
         .scene-item .store-item-img {
-          z-index: 0;
+          z-index: 1;
         }
         .currency-item .store-item-img {
-          z-index: 0;
+          z-index: 1;
         }
         .store-item-img.scene-img-full {
           width: 90%;
@@ -4557,15 +4557,15 @@ function setupSlider(slider, display) {
 
         const SKIN_ORDER = ['snake','rubiSnake','aitorSnake','noemiSnake','maraSnake','almuSnake','mimiSnake','blackCat','orangeCat'];
         const SKIN_PRICES = {
-            snake: 0,
-            rubiSnake: 1000,
-            aitorSnake: 1000,
-            noemiSnake: 1000,
-            maraSnake: 1000,
-            almuSnake: 1000,
-            mimiSnake: 1000,
-            blackCat: 1000,
-            orangeCat: 1000
+            snake: 5,
+            rubiSnake: 10,
+            aitorSnake: 10,
+            noemiSnake: 10,
+            maraSnake: 10,
+            almuSnake: 10,
+            mimiSnake: 10,
+            blackCat: 10,
+            orangeCat: 10
         };
 
         const SCENE_DISPLAY_NAMES = {
@@ -4604,36 +4604,36 @@ function setupSlider(slider, display) {
         const SCENE_ORDER = ['classic', 'hierba', 'volcan',
             'aceraGrande','aceraPequena','agua','baldosaColores','caminoPiedra','caminoPiedraMusgo','caminoHierbaPiedra','cebra','halloween','hielo','ladrillo','madera','baldosaBlanca','baldosaBeige','rocas','tejado','tierra','tribal','desierto','playa','espacio','carretera','estrellaNeon','serpientesNeon','formasNeon','cuadradosNeon','xNeon'];
         const SCENE_PRICES = {
-            classic: 0,
-            hierba: 1000,
-            volcan: 1000,
-            aceraGrande: 1000,
-            aceraPequena: 1000,
-            agua: 1000,
-            baldosaColores: 1000,
-            caminoPiedra: 1000,
-            caminoPiedraMusgo: 1000,
-            caminoHierbaPiedra: 1000,
-            cebra: 1000,
-            halloween: 1000,
-            hielo: 1000,
-            ladrillo: 1000,
-            madera: 1000,
-            baldosaBlanca: 1000,
-            baldosaBeige: 1000,
-            rocas: 1000,
-            tejado: 1000,
-            tierra: 1000,
-            tribal: 1000,
-            desierto: 1000,
-            playa: 1000,
-            espacio: 1000,
-            carretera: 1000,
-            estrellaNeon: 1000,
-            serpientesNeon: 1000,
-            formasNeon: 1000,
-            cuadradosNeon: 1000,
-            xNeon: 1000
+            classic: 5,
+            hierba: 10,
+            volcan: 10,
+            aceraGrande: 10,
+            aceraPequena: 10,
+            agua: 10,
+            baldosaColores: 10,
+            caminoPiedra: 10,
+            caminoPiedraMusgo: 10,
+            caminoHierbaPiedra: 10,
+            cebra: 10,
+            halloween: 10,
+            hielo: 10,
+            ladrillo: 10,
+            madera: 10,
+            baldosaBlanca: 10,
+            baldosaBeige: 10,
+            rocas: 10,
+            tejado: 10,
+            tierra: 10,
+            tribal: 10,
+            desierto: 10,
+            playa: 10,
+            espacio: 10,
+            carretera: 10,
+            estrellaNeon: 10,
+            serpientesNeon: 10,
+            formasNeon: 10,
+            cuadradosNeon: 10,
+            xNeon: 10
         };
 
         const SCENES = {
@@ -5443,59 +5443,59 @@ function setupSlider(slider, display) {
 
         // --- Configuración de Comestibles ---
         const FOODS = {
-            apple: { asset: classicFoodImg, url: 'https://i.imgur.com/fOSSwUX.png', scale: 1.25, price: 0 },
-            cereza: { asset: new Image(), url: 'https://i.imgur.com/s3WYriu.png', scale: 1.25, price: 100 },
-            pera: { asset: new Image(), url: 'https://i.imgur.com/QwJzp1k.png', scale: 1.25, price: 100 },
-            platano: { asset: new Image(), url: 'https://i.imgur.com/tYSI90u.png', scale: 1.25, price: 100 },
-            pina: { asset: new Image(), url: 'https://i.imgur.com/udkmLUq.png', scale: 1.25, price: 100 },
-            naranja: { asset: new Image(), url: 'https://i.imgur.com/W1WDTpC.png', scale: 1.25, price: 100 },
-            kiwi: { asset: new Image(), url: 'https://i.imgur.com/ZixdENw.png', scale: 1.25, price: 200 },
-            aguacate: { asset: new Image(), url: 'https://i.imgur.com/yEHqcAz.png', scale: 1.25, price: 200 },
-            fresa: { asset: new Image(), url: 'https://i.imgur.com/I9jGTrT.png', scale: 1.25, price: 200 },
-            sandia: { asset: new Image(), url: 'https://i.imgur.com/gYOUtji.png', scale: 1.25, price: 200 },
-            cafe: { asset: new Image(), url: 'https://i.imgur.com/2iuZzZQ.png', scale: 1.25, price: 300 },
-            batidoFresa: { asset: new Image(), url: 'https://i.imgur.com/AJf2LOK.png', scale: 1.25, price: 300 },
-            soda: { asset: new Image(), url: 'https://i.imgur.com/PoEzKvA.png', scale: 1.25, price: 300 },
-            zumoNaranja: { asset: new Image(), url: 'https://i.imgur.com/D1ZryCw.png', scale: 1.25, price: 300 },
-            batidoChocolate: { asset: new Image(), url: 'https://i.imgur.com/uyBQXKX.png', scale: 1.25, price: 300 },
-            chocolateCaliente: { asset: new Image(), url: 'https://i.imgur.com/QwHWdN9.png', scale: 1.25, price: 300 },
-            cerveza: { asset: new Image(), url: 'https://i.imgur.com/LKcF2tT.png', scale: 1.25, price: 400 },
-            vinoBlanco: { asset: new Image(), url: 'https://i.imgur.com/1S0Qvnn.png', scale: 1.25, price: 400 },
-            vinoTinto: { asset: new Image(), url: 'https://i.imgur.com/FfXlbU8.png', scale: 1.25, price: 400 },
-            kebap: { asset: new Image(), url: 'https://i.imgur.com/NpgCRUg.png', scale: 1.25, price: 500 },
-            burrito: { asset: new Image(), url: 'https://i.imgur.com/dSa3rSL.png', scale: 1.25, price: 500 },
-            patatas: { asset: new Image(), url: 'https://i.imgur.com/SCzeVKi.png', scale: 1.25, price: 500 },
-            polloFrito: { asset: new Image(), url: 'https://i.imgur.com/0kfGi0C.png', scale: 1.25, price: 500 },
-            salchicha: { asset: new Image(), url: 'https://i.imgur.com/wHPKEW4.png', scale: 1.25, price: 500 },
-            huevoFrito: { asset: new Image(), url: 'https://i.imgur.com/UBMaN50.png', scale: 1.25, price: 500 },
-            croqueta: { asset: new Image(), url: 'https://i.imgur.com/4psebHZ.png', scale: 1.25, price: 500 },
-            hamburguesa: { asset: new Image(), url: 'https://i.imgur.com/oQVdXFq.png', scale: 1.25, price: 750 },
-            pizza: { asset: new Image(), url: 'https://i.imgur.com/D7HV0O4.png', scale: 1.25, price: 750 },
-            hotDog: { asset: new Image(), url: 'https://i.imgur.com/v8Tng9s.png', scale: 1.25, price: 750 },
-            lasana: { asset: new Image(), url: 'https://i.imgur.com/uO5z1tZ.png', scale: 1.25, price: 750 },
-            sushi: { asset: new Image(), url: 'https://i.imgur.com/uccnlBy.png', scale: 1.25, price: 750 },
-            caramelo: { asset: new Image(), url: 'https://i.imgur.com/wg4aGv9.png', scale: 1.25, price: 1000 },
-            ensaimada: { asset: new Image(), url: 'https://i.imgur.com/6CxTo6I.png', scale: 1.25, price: 1000 },
-            muffin: { asset: new Image(), url: 'https://i.imgur.com/1qw2SLR.png', scale: 1.25, price: 1000 },
-            croissant: { asset: new Image(), url: 'https://i.imgur.com/rTctItm.png', scale: 1.25, price: 1000 },
-            macarrons: { asset: new Image(), url: 'https://i.imgur.com/eYb36j8.png', scale: 1.25, price: 1000 },
-            heladoFresa: { asset: new Image(), url: 'https://i.imgur.com/DOYtVFR.png', scale: 1.25, price: 1000 },
-            tartaFresa: { asset: new Image(), url: 'https://i.imgur.com/v95HG3r.png', scale: 1.25, price: 1000 },
-            palomitas: { asset: new Image(), url: 'https://i.imgur.com/qiCsIkb.png', scale: 1.25, price: 3000 },
-            algodonAzucar: { asset: new Image(), url: 'https://i.imgur.com/GSov6QD.png', scale: 1.25, price: 3000 },
-            tortitas: { asset: new Image(), url: 'https://i.imgur.com/PGlpQBY.png', scale: 1.25, price: 3000 },
-            helado: { asset: new Image(), url: 'https://i.imgur.com/f7VMyLh.png', scale: 1.25, price: 3000 },
-            tartaFantasia: { asset: new Image(), url: 'https://i.imgur.com/a7uFEuY.png', scale: 1.25, price: 3000 },
-            gofre: { asset: new Image(), url: 'https://i.imgur.com/PD05I19.png', scale: 1.25, price: 3000 },
-            donutsGlaseado: { asset: new Image(), url: 'https://i.imgur.com/ZiGKtUq.png', scale: 1.25, price: 5000 },
-            huevoYoshi: { asset: new Image(), url: 'https://i.imgur.com/Kx68UN2.png', scale: 1.25, price: 5000 },
-            espadaLaser: { asset: new Image(), url: 'https://i.imgur.com/3XIKlOA.png', scale: 1.25, price: 5000 },
-            cuernoUnicornio: { asset: new Image(), url: 'https://i.imgur.com/BFgtJCk.png', scale: 1.25, price: 5000 },
-            cartuchoRetro: { asset: new Image(), url: 'https://i.imgur.com/mSlH5Go.png', scale: 1.25, price: 5000 },
-            setaMario: { asset: new Image(), url: 'https://i.imgur.com/a41hS2U.png', scale: 1.25, price: 5000 },
-            guanteInfinito: { asset: new Image(), url: 'https://i.imgur.com/RD42tWb.png', scale: 1.25, price: 5000 },
-            gorroMagico: { asset: new Image(), url: 'https://i.imgur.com/1Y2w8KB.png', scale: 1.25, price: 5000 },
-            bolaDragon: { asset: new Image(), url: 'https://i.imgur.com/MjDXSXh.png', scale: 1.25, price: 5000 }
+            apple: { asset: classicFoodImg, url: 'https://i.imgur.com/fOSSwUX.png', scale: 1.25, price: 5 },
+            cereza: { asset: new Image(), url: 'https://i.imgur.com/s3WYriu.png', scale: 1.25, price: 5 },
+            pera: { asset: new Image(), url: 'https://i.imgur.com/QwJzp1k.png', scale: 1.25, price: 5 },
+            platano: { asset: new Image(), url: 'https://i.imgur.com/tYSI90u.png', scale: 1.25, price: 5 },
+            pina: { asset: new Image(), url: 'https://i.imgur.com/udkmLUq.png', scale: 1.25, price: 5 },
+            naranja: { asset: new Image(), url: 'https://i.imgur.com/W1WDTpC.png', scale: 1.25, price: 5 },
+            kiwi: { asset: new Image(), url: 'https://i.imgur.com/ZixdENw.png', scale: 1.25, price: 5 },
+            aguacate: { asset: new Image(), url: 'https://i.imgur.com/yEHqcAz.png', scale: 1.25, price: 5 },
+            fresa: { asset: new Image(), url: 'https://i.imgur.com/I9jGTrT.png', scale: 1.25, price: 5 },
+            sandia: { asset: new Image(), url: 'https://i.imgur.com/gYOUtji.png', scale: 1.25, price: 5 },
+            cafe: { asset: new Image(), url: 'https://i.imgur.com/2iuZzZQ.png', scale: 1.25, price: 5 },
+            batidoFresa: { asset: new Image(), url: 'https://i.imgur.com/AJf2LOK.png', scale: 1.25, price: 5 },
+            soda: { asset: new Image(), url: 'https://i.imgur.com/PoEzKvA.png', scale: 1.25, price: 5 },
+            zumoNaranja: { asset: new Image(), url: 'https://i.imgur.com/D1ZryCw.png', scale: 1.25, price: 5 },
+            batidoChocolate: { asset: new Image(), url: 'https://i.imgur.com/uyBQXKX.png', scale: 1.25, price: 5 },
+            chocolateCaliente: { asset: new Image(), url: 'https://i.imgur.com/QwHWdN9.png', scale: 1.25, price: 5 },
+            cerveza: { asset: new Image(), url: 'https://i.imgur.com/LKcF2tT.png', scale: 1.25, price: 5 },
+            vinoBlanco: { asset: new Image(), url: 'https://i.imgur.com/1S0Qvnn.png', scale: 1.25, price: 5 },
+            vinoTinto: { asset: new Image(), url: 'https://i.imgur.com/FfXlbU8.png', scale: 1.25, price: 5 },
+            kebap: { asset: new Image(), url: 'https://i.imgur.com/NpgCRUg.png', scale: 1.25, price: 5 },
+            burrito: { asset: new Image(), url: 'https://i.imgur.com/dSa3rSL.png', scale: 1.25, price: 5 },
+            patatas: { asset: new Image(), url: 'https://i.imgur.com/SCzeVKi.png', scale: 1.25, price: 5 },
+            polloFrito: { asset: new Image(), url: 'https://i.imgur.com/0kfGi0C.png', scale: 1.25, price: 5 },
+            salchicha: { asset: new Image(), url: 'https://i.imgur.com/wHPKEW4.png', scale: 1.25, price: 5 },
+            huevoFrito: { asset: new Image(), url: 'https://i.imgur.com/UBMaN50.png', scale: 1.25, price: 5 },
+            croqueta: { asset: new Image(), url: 'https://i.imgur.com/4psebHZ.png', scale: 1.25, price: 5 },
+            hamburguesa: { asset: new Image(), url: 'https://i.imgur.com/oQVdXFq.png', scale: 1.25, price: 5 },
+            pizza: { asset: new Image(), url: 'https://i.imgur.com/D7HV0O4.png', scale: 1.25, price: 5 },
+            hotDog: { asset: new Image(), url: 'https://i.imgur.com/v8Tng9s.png', scale: 1.25, price: 5 },
+            lasana: { asset: new Image(), url: 'https://i.imgur.com/uO5z1tZ.png', scale: 1.25, price: 5 },
+            sushi: { asset: new Image(), url: 'https://i.imgur.com/uccnlBy.png', scale: 1.25, price: 5 },
+            caramelo: { asset: new Image(), url: 'https://i.imgur.com/wg4aGv9.png', scale: 1.25, price: 10 },
+            ensaimada: { asset: new Image(), url: 'https://i.imgur.com/6CxTo6I.png', scale: 1.25, price: 10 },
+            muffin: { asset: new Image(), url: 'https://i.imgur.com/1qw2SLR.png', scale: 1.25, price: 10 },
+            croissant: { asset: new Image(), url: 'https://i.imgur.com/rTctItm.png', scale: 1.25, price: 10 },
+            macarrons: { asset: new Image(), url: 'https://i.imgur.com/eYb36j8.png', scale: 1.25, price: 10 },
+            heladoFresa: { asset: new Image(), url: 'https://i.imgur.com/DOYtVFR.png', scale: 1.25, price: 10 },
+            tartaFresa: { asset: new Image(), url: 'https://i.imgur.com/v95HG3r.png', scale: 1.25, price: 10 },
+            palomitas: { asset: new Image(), url: 'https://i.imgur.com/qiCsIkb.png', scale: 1.25, price: 30 },
+            algodonAzucar: { asset: new Image(), url: 'https://i.imgur.com/GSov6QD.png', scale: 1.25, price: 30 },
+            tortitas: { asset: new Image(), url: 'https://i.imgur.com/PGlpQBY.png', scale: 1.25, price: 30 },
+            helado: { asset: new Image(), url: 'https://i.imgur.com/f7VMyLh.png', scale: 1.25, price: 30 },
+            tartaFantasia: { asset: new Image(), url: 'https://i.imgur.com/a7uFEuY.png', scale: 1.25, price: 30 },
+            gofre: { asset: new Image(), url: 'https://i.imgur.com/PD05I19.png', scale: 1.25, price: 30 },
+            donutsGlaseado: { asset: new Image(), url: 'https://i.imgur.com/ZiGKtUq.png', scale: 1.25, price: 50 },
+            huevoYoshi: { asset: new Image(), url: 'https://i.imgur.com/Kx68UN2.png', scale: 1.25, price: 50 },
+            espadaLaser: { asset: new Image(), url: 'https://i.imgur.com/3XIKlOA.png', scale: 1.25, price: 50 },
+            cuernoUnicornio: { asset: new Image(), url: 'https://i.imgur.com/BFgtJCk.png', scale: 1.25, price: 50 },
+            cartuchoRetro: { asset: new Image(), url: 'https://i.imgur.com/mSlH5Go.png', scale: 1.25, price: 50 },
+            setaMario: { asset: new Image(), url: 'https://i.imgur.com/a41hS2U.png', scale: 1.25, price: 50 },
+            guanteInfinito: { asset: new Image(), url: 'https://i.imgur.com/RD42tWb.png', scale: 1.25, price: 50 },
+            gorroMagico: { asset: new Image(), url: 'https://i.imgur.com/1Y2w8KB.png', scale: 1.25, price: 50 },
+            bolaDragon: { asset: new Image(), url: 'https://i.imgur.com/MjDXSXh.png', scale: 1.25, price: 50 }
         };
         const FOOD_ORDER = ['apple','cereza','pera','platano','pina','naranja','kiwi','aguacate','fresa','sandia','cafe','batidoFresa','soda','zumoNaranja','batidoChocolate','chocolateCaliente','cerveza','vinoBlanco','vinoTinto','kebap','burrito','patatas','polloFrito','salchicha','huevoFrito','croqueta','hamburguesa','pizza','hotDog','lasana','sushi','caramelo','ensaimada','muffin','croissant','macarrons','heladoFresa','tartaFresa','palomitas','algodonAzucar','tortitas','helado','tartaFantasia','gofre','donutsGlaseado','huevoYoshi','espadaLaser','cuernoUnicornio','cartuchoRetro','setaMario','guanteInfinito','gorroMagico','bolaDragon'];
         const FOOD_DISPLAY_NAMES = {
@@ -7311,11 +7311,11 @@ function setupSlider(slider, display) {
                         const costSpan = document.createElement('span');
                         costSpan.textContent = FOODS[key].price.toString();
                         status.appendChild(costSpan);
-                        const coinImg = document.createElement('img');
-                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
-                        coinImg.alt = 'Moneda';
-                        coinImg.className = 'coin-cost-icon';
-                        status.appendChild(coinImg);
+                        const gemImg = document.createElement('img');
+                        gemImg.src = 'https://i.imgur.com/gPGsaCO.png';
+                        gemImg.alt = 'Gema';
+                        gemImg.className = 'gem-cost-icon';
+                        status.appendChild(gemImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('food', key));
                         addIconPressEvents(item, item);
@@ -7342,11 +7342,11 @@ function setupSlider(slider, display) {
                         const costSpan = document.createElement('span');
                         costSpan.textContent = SKIN_PRICES[key].toString();
                         status.appendChild(costSpan);
-                        const coinImg = document.createElement('img');
-                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
-                        coinImg.alt = 'Moneda';
-                        coinImg.className = 'coin-cost-icon';
-                        status.appendChild(coinImg);
+                        const gemImg = document.createElement('img');
+                        gemImg.src = 'https://i.imgur.com/gPGsaCO.png';
+                        gemImg.alt = 'Gema';
+                        gemImg.className = 'gem-cost-icon';
+                        status.appendChild(gemImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('skin', key));
                         addIconPressEvents(item, item);
@@ -7373,11 +7373,11 @@ function setupSlider(slider, display) {
                         const costSpan = document.createElement('span');
                         costSpan.textContent = SCENE_PRICES[key].toString();
                         status.appendChild(costSpan);
-                        const coinImg = document.createElement('img');
-                        coinImg.src = 'https://i.imgur.com/lnc1Mwu.png';
-                        coinImg.alt = 'Moneda';
-                        coinImg.className = 'coin-cost-icon';
-                        status.appendChild(coinImg);
+                        const gemImg = document.createElement('img');
+                        gemImg.src = 'https://i.imgur.com/gPGsaCO.png';
+                        gemImg.alt = 'Gema';
+                        gemImg.className = 'gem-cost-icon';
+                        status.appendChild(gemImg);
                         item.classList.add('locked');
                         item.addEventListener('click', () => openPurchaseConfirm('scene', key));
                         addIconPressEvents(item, item);
@@ -7561,15 +7561,15 @@ function openPurchaseConfirm(type, key) {
             if (type === 'food') {
                 price = FOODS[key].price;
                 name = FOOD_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
             } else if (type === 'skin') {
                 price = SKIN_PRICES[key];
                 name = SKIN_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
             } else if (type === 'scene') {
                 price = SCENE_PRICES[key];
                 name = SCENE_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
             } else if (type === 'general') {
                 price = key === 'heart' ? HEART_PRICE : GEM_PRICE;
                 name = key === 'heart' ? 'coraz\u00F3n' : 'gema';
@@ -7606,30 +7606,36 @@ function openPurchaseConfirm(type, key) {
             let failureMessage;
             if (purchaseInfo.type === 'food') {
                 price = FOODS[purchaseInfo.key].price;
-                if (totalCoins >= price) {
-                    totalCoins -= price;
+                if (totalGems >= price) {
+                    totalGems -= price;
                     unlockedFoods[purchaseInfo.key] = true;
                     saveUnlockedFoods();
                     updateFoodSelectorAvailability();
                     success = true;
+                } else {
+                    failureMessage = 'Gemas insuficientes';
                 }
             } else if (purchaseInfo.type === 'skin') {
                 price = SKIN_PRICES[purchaseInfo.key];
-                if (totalCoins >= price) {
-                    totalCoins -= price;
+                if (totalGems >= price) {
+                    totalGems -= price;
                     unlockedSkins[purchaseInfo.key] = true;
                     saveUnlockedSkins();
                     updateSkinSelectorAvailability();
                     success = true;
+                } else {
+                    failureMessage = 'Gemas insuficientes';
                 }
             } else if (purchaseInfo.type === 'scene') {
                 price = SCENE_PRICES[purchaseInfo.key];
-                if (totalCoins >= price) {
-                    totalCoins -= price;
+                if (totalGems >= price) {
+                    totalGems -= price;
                     unlockedScenes[purchaseInfo.key] = true;
                     saveUnlockedScenes();
                     updateSceneSelectorAvailability();
                     success = true;
+                } else {
+                    failureMessage = 'Gemas insuficientes';
                 }
             } else if (purchaseInfo.type === 'general') {
                 if (purchaseInfo.key === 'heart') {
@@ -7710,8 +7716,6 @@ function openPurchaseConfirm(type, key) {
                 price = pack.costGems;
                 if (totalGems >= price) {
                     totalGems -= price;
-                    saveGems();
-                    updateGemDisplay();
                     const prev = totalCoins;
                     totalCoins += pack.amount;
                     showEarnedCoinsMessage(pack.amount);
@@ -7774,7 +7778,9 @@ function openPurchaseConfirm(type, key) {
             }
             if (success) {
                 localStorage.setItem('snakeGameCoins', totalCoins.toString());
+                saveGems();
                 updateCoinDisplay();
+                updateGemDisplay();
                 populateStoreItems();
                 closePurchaseConfirm();
             } else {


### PR DESCRIPTION
## Summary
- convert food, skin and scene price tables from coins to gem tiers
- update shop UI and purchase flow to use gems instead of coins
- show prices in color over grayscale items and use a grayscale background until unlocked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68921edc9c188333b2267e9d2fa84229