### PR TITLE
Añadir rarezas para artículos de la tienda

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2852,7 +2852,6 @@
           content: '';
           position: absolute;
           inset: 0;
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
           background-size: contain;
           background-repeat: no-repeat;
           background-position: center;
@@ -2860,14 +2859,11 @@
           pointer-events: none;
           z-index: 2;
         }
-        .store-item.scene-item::before {
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
-          z-index: 2;
-        }
-        .store-item.currency-item::before {
-          background-image: url('https://i.imgur.com/YKjPhxX.png');
-          z-index: 2;
-        }
+        .store-item.rarity-default::before { background-image: url('https://i.imgur.com/UwsZ1z5.png'); }
+        .store-item.rarity-common::before { background-image: url('https://i.imgur.com/a1HIP4u.png'); }
+        .store-item.rarity-rare::before { background-image: url('https://i.imgur.com/rUCQC5y.png'); }
+        .store-item.rarity-epic::before { background-image: url('https://i.imgur.com/EUXBiO4.png'); }
+        .store-item.rarity-legendary::before { background-image: url('https://i.imgur.com/ThkZoci.png'); }
 
         .store-item.highlight-bg::after {
           content: '';
@@ -3744,9 +3740,9 @@
             </div>
         </div>
         <div id="selected-items-row" class="grid grid-cols-3 gap-2 mb-2 mt-2 w-full">
-            <div id="selected-skin-item" class="store-item highlight-bg"></div>
-            <div id="selected-food-item" class="store-item highlight-bg"></div>
-            <div id="selected-scene-item" class="store-item scene-item highlight-bg"></div>
+            <div id="selected-skin-item" class="store-item highlight-bg rarity-default"></div>
+            <div id="selected-food-item" class="store-item highlight-bg rarity-default"></div>
+            <div id="selected-scene-item" class="store-item scene-item highlight-bg rarity-default"></div>
         </div>
 
         <div class="control-group hidden" id="skin-control-group">
@@ -3856,7 +3852,7 @@
                     <h2>CONFIRMAR COMPRA</h2>
                 </div>
                 <div class="panel-content">
-                    <div id="purchase-item-preview" class="store-item locked"></div>
+                    <div id="purchase-item-preview" class="store-item locked rarity-default"></div>
                     <p id="purchase-confirmation-text">¿Comprar por <strong>0</strong> monedas?</p>
                     <div class="reset-buttons">
                         <button id="confirmPurchaseYes">SI</button>
@@ -5602,6 +5598,31 @@ function setupSlider(slider, display) {
         };
         let storeTab = 'general';
         let profileTab = 'general';
+        function getRarityClass(type, key) {
+            if (type === 'skin') {
+                if (key === 'snake') return 'rarity-default';
+                const price = SKIN_PRICES[key] || 0;
+                if (price >= 100) return 'rarity-legendary';
+                if (price >= 50) return 'rarity-epic';
+                if (price >= 30) return 'rarity-rare';
+                if (price >= 10) return 'rarity-common';
+            } else if (type === 'scene') {
+                if (key === 'classic') return 'rarity-default';
+                const price = SCENE_PRICES[key] || 0;
+                if (price >= 50) return 'rarity-legendary';
+                if (price >= 30) return 'rarity-epic';
+                if (price >= 10) return 'rarity-rare';
+                if (price >= 5) return 'rarity-common';
+            } else if (type === 'food') {
+                if (key === 'apple') return 'rarity-default';
+                const price = FOODS[key]?.price || 0;
+                if (price >= 50) return 'rarity-legendary';
+                if (price >= 30) return 'rarity-epic';
+                if (price >= 10) return 'rarity-rare';
+                if (price >= 5) return 'rarity-common';
+            }
+            return 'rarity-default';
+        }
         // --- Fin Configuración de Comestibles ---
 
         const ACHIEVEMENT_CATEGORY_NAMES = {
@@ -7311,7 +7332,8 @@ function setupSlider(slider, display) {
             if (storeTab === 'comida') {
                 FOOD_ORDER.forEach(key => {
                     const item = document.createElement('div');
-                    item.className = 'store-item highlight-bg';
+                    const rarityClass = getRarityClass('food', key);
+                    item.className = `store-item highlight-bg ${rarityClass}`;
 
                     const img = document.createElement('img');
                     img.className = 'store-item-img';
@@ -7342,7 +7364,8 @@ function setupSlider(slider, display) {
             } else if (storeTab === 'disfraces') {
                 SKIN_ORDER.forEach(key => {
                     const item = document.createElement('div');
-                    item.className = 'store-item highlight-bg';
+                    const rarityClass = getRarityClass('skin', key);
+                    item.className = `store-item highlight-bg ${rarityClass}`;
 
                     const img = document.createElement('img');
                     img.className = 'store-item-img';
@@ -7373,7 +7396,8 @@ function setupSlider(slider, display) {
             } else if (storeTab === 'escenarios') {
                 SCENE_ORDER.forEach(key => {
                     const item = document.createElement('div');
-                    item.className = 'store-item scene-item highlight-bg';
+                    const rarityClass = getRarityClass('scene', key);
+                    item.className = `store-item scene-item highlight-bg ${rarityClass}`;
 
                     const img = document.createElement('img');
                     img.className = 'store-item-img scene-img-full';
@@ -7412,7 +7436,7 @@ function setupSlider(slider, display) {
                 ];
                 items.forEach(({ key, pack, type }) => {
                     const item = document.createElement('div');
-                    item.className = 'store-item currency-item';
+                    item.className = 'store-item currency-item rarity-default';
                     const img = document.createElement('img');
                     img.className = 'store-item-img currency-img';
                     img.src = pack.img;
@@ -7446,7 +7470,7 @@ function setupSlider(slider, display) {
                 items.forEach(({ type, img }) => {
                     const item = document.createElement('div');
                     item.id = `store-item-${type}`;
-                    item.className = 'store-item';
+                    item.className = 'store-item rarity-default';
                     const imgEl = document.createElement('img');
                     imgEl.className = 'store-item-img lives-img';
                     imgEl.src = img;
@@ -7480,7 +7504,7 @@ function setupSlider(slider, display) {
                 coinItems.forEach(({ type, data }) => {
                     const item = document.createElement('div');
                     item.id = `store-item-${type}`;
-                    item.className = 'store-item';
+                    item.className = 'store-item rarity-default';
                     const imgEl = document.createElement('img');
                     imgEl.className = 'store-item-img lives-img';
                     imgEl.src = data.img;
@@ -7547,7 +7571,14 @@ function openPurchaseConfirm(type, key) {
     purchaseInfo = { type, key };
             if (purchaseItemPreview) {
                 purchaseItemPreview.innerHTML = '';
-                purchaseItemPreview.className = 'store-item' + (type === 'scene' ? ' scene-item highlight-bg' : ((type === 'food' || type === 'skin') ? ' highlight-bg' : ((type === 'coinPack' || type === 'gemPack') ? ' currency-item' : '')));
+                const rarityClass = getRarityClass(type, key);
+                purchaseItemPreview.className = 'store-item' + (type === 'scene'
+                    ? ` scene-item highlight-bg ${rarityClass}`
+                    : ((type === 'food' || type === 'skin')
+                        ? ` highlight-bg ${rarityClass}`
+                        : ((type === 'coinPack' || type === 'gemPack')
+                            ? ` currency-item ${rarityClass}`
+                            : ` ${rarityClass}`)));
                 const img = document.createElement('img');
                 img.className = 'store-item-img';
                 if (type === 'food') {
@@ -12827,7 +12858,7 @@ async function startGame(isRestart = false) {
         function updateProfileSelectedItems() {
             if (profileSelectedSkin) {
                 profileSelectedSkin.innerHTML = '';
-                profileSelectedSkin.className = 'store-item purchased profile-clickable highlight-bg';
+                profileSelectedSkin.className = 'store-item purchased profile-clickable highlight-bg ' + getRarityClass('skin', getSelectedSkin());
                 const img = document.createElement('img');
                 img.className = 'store-item-img';
                 img.src = SKINS[getSelectedSkin()]?.snakeHeadAsset?.upDown?.src || '';
@@ -12835,7 +12866,7 @@ async function startGame(isRestart = false) {
             }
             if (profileSelectedFood) {
                 profileSelectedFood.innerHTML = '';
-                profileSelectedFood.className = 'store-item purchased profile-clickable highlight-bg';
+                profileSelectedFood.className = 'store-item purchased profile-clickable highlight-bg ' + getRarityClass('food', getSelectedFood());
                 const img = document.createElement('img');
                 img.className = 'store-item-img';
                 img.src = FOODS[getSelectedFood()]?.asset?.src || '';
@@ -12843,7 +12874,7 @@ async function startGame(isRestart = false) {
             }
             if (profileSelectedScene) {
                 profileSelectedScene.innerHTML = '';
-                profileSelectedScene.className = 'store-item purchased profile-clickable scene-item highlight-bg';
+                profileSelectedScene.className = 'store-item purchased profile-clickable scene-item highlight-bg ' + getRarityClass('scene', getSelectedScene());
                 const img = document.createElement('img');
                 img.className = 'store-item-img scene-img-full';
                 img.src = SCENES[getSelectedScene()]?.icon || '';
@@ -12857,7 +12888,8 @@ async function startGame(isRestart = false) {
             profileFoodLocked.innerHTML = '';
             FOOD_ORDER.forEach(key => {
                 const item = document.createElement('div');
-                item.className = 'store-item highlight-bg';
+                const rarityClass = getRarityClass('food', key);
+                item.className = `store-item highlight-bg ${rarityClass}`;
                 const img = document.createElement('img');
                 img.className = 'store-item-img';
                 img.src = FOODS[key]?.asset?.src || '';
@@ -12880,7 +12912,8 @@ async function startGame(isRestart = false) {
             profileSkinLocked.innerHTML = '';
             SKIN_ORDER.forEach(key => {
                 const item = document.createElement('div');
-                item.className = 'store-item highlight-bg';
+                const rarityClass = getRarityClass('skin', key);
+                item.className = `store-item highlight-bg ${rarityClass}`;
                 const img = document.createElement('img');
                 img.className = 'store-item-img';
                 img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
@@ -12903,7 +12936,8 @@ async function startGame(isRestart = false) {
             profileSceneLocked.innerHTML = '';
             SCENE_ORDER.forEach(key => {
                 const item = document.createElement('div');
-                item.className = 'store-item scene-item highlight-bg';
+                const rarityClass = getRarityClass('scene', key);
+                item.className = `store-item scene-item highlight-bg ${rarityClass}`;
                 const img = document.createElement('img');
                 img.className = 'store-item-img scene-img-full';
                 img.src = SCENES[key]?.icon || '';


### PR DESCRIPTION
## Summary
- Clasificar comestibles, disfraces y escenarios por rareza según su coste.
- Añadir función que determina la rareza y aplica el marco correspondiente en la tienda y perfiles.
- Sustituir el marco de la tienda por variantes para cada rareza.

## Testing
- `npm test` *(falla: npm no está instalado)*

------
https://chatgpt.com/codex/tasks/task_b_6892fc43b1c883339a37a0a2e084bfe6