### PR TITLE
Reduce store item cost size on mobile

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3278,6 +3278,18 @@
             opacity: 1;
         }
 
+        @media (hover: none) and (pointer: coarse) {
+            .store-item-status {
+                font-size: 0.45rem;
+            }
+            .coin-cost-icon,
+            .gem-cost-icon,
+            .ad-cost-icon {
+                width: 10px;
+                height: 10px;
+            }
+        }
+
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Reduce store item cost text and icon size on mobile devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689359cbecc083338de0ad8648a64ef5