### PR TITLE
Reduce espaciado en confirmación de compra

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2436,6 +2436,11 @@
         .reset-panel-hidden { display: none !important; }
 
         #reset-confirmation-panel p { text-align: center; margin: 0 0 10px 0; }
+        #purchase-confirmation-panel p {
+            text-align: center;
+            margin: 0;
+        }
+        #purchase-confirmation-panel .panel-content { gap: 10px; }
         #reset-confirmation-panel .reset-buttons,
         #purchase-confirmation-panel .reset-buttons,
         #delete-confirmation-panel .reset-buttons {
@@ -3129,7 +3134,7 @@
         }
 
         #purchase-item-preview {
-          margin: 0 auto 8px;
+          margin: 0 auto;
         }
         #purchase-item-preview.store-item {
           width: 140px;


### PR DESCRIPTION
## Summary
- Ajusta estilos de la ventana de confirmación de compra para reducir el espacio entre la previsualización y el texto

## Testing
- `npm test` *(falla: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6893642751f88333827d4eea06050a1a