### PR TITLE
Ampliar vista previa de compra en PC

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3136,6 +3136,13 @@
           height: 140px;
         }
 
+        @media screen and (min-width: 800px) {
+          #purchase-item-preview.store-item {
+            width: 200px;
+            height: 200px;
+          }
+        }
+
         #mazeLevelButtonsContainer.disabled {
           pointer-events: none;
           opacity: 0.7;


### PR DESCRIPTION
## Summary
- Amplía a 200px el tamaño de la vista previa del artículo en la confirmación de compra para pantallas de escritorio.
- Mantiene el tamaño original en dispositivos móviles.

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68936846c7c88333b48e2f0c10cd6c70