### PR TITLE
Reduce purchase confirmation menu text size

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1051,7 +1051,7 @@
             left: 100%;
             transform: translateX(-20px) translateY(-50%);
             color: #4ade80;
-            font-size: 1em;
+            font-size: 0.8em;
             white-space: nowrap;
             opacity: 0;
             transition: opacity 0.3s, transform 0.5s;
@@ -2436,6 +2436,7 @@
         .reset-panel-hidden { display: none !important; }
 
         #reset-confirmation-panel p { text-align: center; margin: 0 0 10px 0; }
+        #purchase-confirmation-panel p { text-align: center; margin: 0 0 10px 0; font-size: 0.8em; }
         #reset-confirmation-panel .reset-buttons,
         #purchase-confirmation-panel .reset-buttons,
         #delete-confirmation-panel .reset-buttons {
@@ -2536,7 +2537,7 @@
             min-width: 130px;
             position: relative;
             padding: 0 6px;
-            font-size: 1em;
+            font-size: 0.8em;
             border: 2px solid #2B1D3A;
             border-radius: 10px;
             box-shadow: 0 2px 0 #422E58;


### PR DESCRIPTION
## Summary
- Shrink text within the purchase confirmation panel for better readability.
- Decrease font size of purchase confirmation buttons.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68936b7ed09c8333a5a0595c3207ab31