### PR TITLE
Refine chest purchase UI and store layout

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3144,6 +3144,35 @@
           }
         }
 
+        #purchase-item-preview .chest-preview-img {
+          width: 140px;
+          height: 140px;
+          display: block;
+          margin: 0 auto;
+        }
+
+        @media screen and (min-width: 800px) {
+          #purchase-item-preview .chest-preview-img {
+            width: 200px;
+            height: 200px;
+          }
+        }
+
+        #purchase-confirmation-panel .panel-content {
+          justify-content: center;
+          align-items: center;
+        }
+
+        .chest-grid-item {
+          width: 60%;
+        }
+
+        @media screen and (min-width: 800px) {
+          .chest-grid-item {
+            width: 50%;
+          }
+        }
+
         #mazeLevelButtonsContainer.disabled {
           pointer-events: none;
           opacity: 0.7;
@@ -7389,12 +7418,12 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-4 w-full' : 'grid grid-cols-3 gap-4 w-full';
+            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-4 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];
                     const item = document.createElement('div');
-                    item.className = 'store-item currency-item rarity-default';
+                    item.className = 'store-item currency-item rarity-default chest-grid-item';
                     const img = document.createElement('img');
                     img.className = 'store-item-img currency-img';
                     img.src = chest.img;
@@ -7767,40 +7796,45 @@ function openPurchaseConfirm(type, key) {
     if (collectPurchaseRewardButton) collectPurchaseRewardButton.classList.add('hidden');
             if (purchaseItemPreview) {
                 purchaseItemPreview.innerHTML = '';
-                const rarityClass = getRarityClass(type, key);
-                purchaseItemPreview.className = 'store-item' + (type === 'scene'
-                    ? ` scene-item highlight-bg ${rarityClass}`
-                    : (type === 'food'
-                        ? ` food-item highlight-bg ${rarityClass}`
-                        : (type === 'skin'
-                            ? ` skin-item highlight-bg ${rarityClass}`
-                            : ((type === 'coinPack' || type === 'gemPack' || type === 'chest')
-                                ? ` currency-item ${rarityClass}`
-                                : ` ${rarityClass}`))));
-                const img = document.createElement('img');
-                img.className = 'store-item-img';
-                if (type === 'food') {
-                    img.src = FOODS[key]?.asset?.src || '';
-                } else if (type === 'skin') {
-                    img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
-                } else if (type === 'scene') {
-                    img.classList.add('scene-img-full');
-                    img.src = SCENES[key]?.icon || '';
-                } else if (type === 'chest') {
-                    img.classList.add('currency-img');
+                if (type === 'chest') {
+                    purchaseItemPreview.className = '';
+                    const img = document.createElement('img');
+                    img.className = 'chest-preview-img';
                     img.src = CHESTS[key]?.img || '';
-                } else if (type === 'coinPack') {
-                    img.classList.add('currency-img');
-                    img.src = COIN_PACKS[key]?.img || '';
-                } else if (type === 'gemPack') {
-                    img.classList.add('currency-img');
-                    img.src = GEM_PACKS[key]?.img || '';
-                } else if (type === 'adLife' || type === 'adChest' || type === 'adInfinite') {
-                    img.src = AD_ITEMS[type]?.img || '';
-                } else if (type === 'coinLife' || type === 'coinChest' || type === 'coinInfinite') {
-                    img.src = COIN_LIFE_ITEMS[type]?.img || '';
+                    purchaseItemPreview.appendChild(img);
+                } else {
+                    const rarityClass = getRarityClass(type, key);
+                    purchaseItemPreview.className = 'store-item' + (type === 'scene'
+                        ? ` scene-item highlight-bg ${rarityClass}`
+                        : (type === 'food'
+                            ? ` food-item highlight-bg ${rarityClass}`
+                            : (type === 'skin'
+                                ? ` skin-item highlight-bg ${rarityClass}`
+                                : ((type === 'coinPack' || type === 'gemPack')
+                                    ? ` currency-item ${rarityClass}`
+                                    : ` ${rarityClass}`))));
+                    const img = document.createElement('img');
+                    img.className = 'store-item-img';
+                    if (type === 'food') {
+                        img.src = FOODS[key]?.asset?.src || '';
+                    } else if (type === 'skin') {
+                        img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
+                    } else if (type === 'scene') {
+                        img.classList.add('scene-img-full');
+                        img.src = SCENES[key]?.icon || '';
+                    } else if (type === 'coinPack') {
+                        img.classList.add('currency-img');
+                        img.src = COIN_PACKS[key]?.img || '';
+                    } else if (type === 'gemPack') {
+                        img.classList.add('currency-img');
+                        img.src = GEM_PACKS[key]?.img || '';
+                    } else if (type === 'adLife' || type === 'adChest' || type === 'adInfinite') {
+                        img.src = AD_ITEMS[type]?.img || '';
+                    } else if (type === 'coinLife' || type === 'coinChest' || type === 'coinInfinite') {
+                        img.src = COIN_LIFE_ITEMS[type]?.img || '';
+                    }
+                    purchaseItemPreview.appendChild(img);
                 }
-                purchaseItemPreview.appendChild(img);
             }
             let price = 0;
             let name = '';


### PR DESCRIPTION
## Summary
- Show chest images without frames in purchase confirmation and vertically center reward screen
- Reduce chest size and center chest items in store tab to avoid scrolling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6893c09fa4d4833383fbfda673287382