### PR TITLE
Center store chests and tighten tab spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3164,12 +3164,12 @@
         }
 
         .chest-grid-item {
-          width: 65%;
+          width: 150px;
         }
 
         @media screen and (min-width: 800px) {
           .chest-grid-item {
-            width: 70%;
+            width: 200px;
           }
         }
 
@@ -3882,7 +3882,7 @@
                     </button>
                 </div>
                 <div class="panel-content">
-                    <div id="store-tabs" class="flex gap-2 mb-2">
+                    <div id="store-tabs" class="flex gap-1 mb-2">
                         <button data-tab="cofres" id="store-tab-cofres" class="store-tab menu-option-button active">
                             <img src="https://i.imgur.com/QND7wuI.png" alt="Cofres">
                         </button>
@@ -7418,7 +7418,9 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-4 w-full';
+            storeItemsContainer.className = storeTab === 'cofres'
+                ? 'grid grid-cols-2 gap-2 w-fit mx-auto justify-items-center'
+                : 'grid grid-cols-3 gap-4 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];


### PR DESCRIPTION
## Summary
- Reduce gap between store tabs for a more compact layout
- Center chest items in the store and size them consistently for a tighter grouping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6893c9bc4c748333acde04869519d5aa