### PR TITLE
Display four chest items in single row

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2949,10 +2949,18 @@
           object-fit: cover;
         }
         .store-item-img.currency-img {
-          width: 70%;
-          height: 70%;
+          width: 65%;
+          height: 65%;
           top: 38%;
         }
+
+        @media screen and (min-width: 800px) {
+          .store-item-img.currency-img {
+            width: 70%;
+            height: 70%;
+          }
+        }
+
         .store-item-img.lives-img {
           width: 70%;
           height: 70%;
@@ -3902,7 +3910,7 @@
                             <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
                         </button>
                     </div>
-                <div id="store-items-container" class="grid grid-cols-2 gap-2 w-full max-w-xs mx-auto"></div>
+                <div id="store-items-container" class="grid grid-cols-4 gap-2 w-full"></div>
                 </div>
             </div>
             <div id="achievements-panel" class="achievements-panel-hidden">
@@ -7419,7 +7427,7 @@ function setupSlider(slider, display) {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
             storeItemsContainer.className = storeTab === 'cofres'
-                ? 'grid grid-cols-2 gap-2 w-full max-w-xs mx-auto'
+                ? 'grid grid-cols-4 gap-2 w-full'
                 : 'grid grid-cols-3 gap-2 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3164,12 +3164,12 @@
         }
 
         .chest-grid-item {
-          width: 65%;
+          width: 100%;
         }
 
         @media screen and (min-width: 800px) {
           .chest-grid-item {
-            width: 70%;
+            width: 100%;
           }
         }
 
@@ -7418,7 +7418,7 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-4 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
+            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-4 gap-2 w-full' : 'grid grid-cols-3 gap-2 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7418,7 +7418,7 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
+            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-4 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3902,7 +3902,7 @@
                             <img src="https://i.imgur.com/DPBCWp1.png" alt="Escenarios">
                         </button>
                     </div>
-                <div id="store-items-container" class="grid grid-cols-3 gap-4 w-full"></div>
+                <div id="store-items-container" class="grid grid-cols-2 gap-2 w-full max-w-xs mx-auto"></div>
                 </div>
             </div>
             <div id="achievements-panel" class="achievements-panel-hidden">
@@ -7418,7 +7418,9 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-4 gap-2 w-full' : 'grid grid-cols-3 gap-2 w-full';
+            storeItemsContainer.className = storeTab === 'cofres'
+                ? 'grid grid-cols-2 gap-2 w-full max-w-xs mx-auto'
+                : 'grid grid-cols-3 gap-2 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];


### PR DESCRIPTION
## Summary
- Show four chest sale items on a single row by using a four-column grid layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894626d3bd88333adf3d03090c5e582