### PR TITLE
Reduce chest store spacing

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3164,12 +3164,12 @@
         }
 
         .chest-grid-item {
-          width: 65%;
+          width: 100%;
         }
 
         @media screen and (min-width: 800px) {
           .chest-grid-item {
-            width: 70%;
+            width: 100%;
           }
         }
 
@@ -7418,7 +7418,7 @@ function setupSlider(slider, display) {
         function populateStoreItems() {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
-            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-full justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
+            storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-2/3 mx-auto justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];


### PR DESCRIPTION
## Summary
- Reduce spacing of chest items in the store by narrowing the grid width and centering it
- Ensure chest items occupy full grid cell width for consistent alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68946d3afce48333886491447a5bd289