### PR TITLE
Ajusta estilo del botón de recompensa

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2475,6 +2475,16 @@
             height: 50px;
             box-sizing: border-box;
         }
+
+        #purchase-confirmation-panel #collectPurchaseReward {
+            color: #4E3967;
+            text-shadow:
+                0px 0px 1px #422E58,
+                -1px -1px 0 #D0B5E2,
+                1px -1px 0 #D0B5E2,
+                -1px  1px 0 #D0B5E2,
+                1px  1px 0 #D0B5E2;
+        }
         #confirmResetYes::before,
         #confirmResetNo::before {
             content: '';


### PR DESCRIPTION
## Summary
- Igualar el color y el sombreado del texto del botón de recogida de recompensas con el estilo de los botones del menú principal.

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6894e64caaf083339031bce2a23af468