### PR TITLE
feat: show item value in purchase confirmation

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3168,11 +3168,17 @@
           width: 140px;
           height: 140px;
         }
+        #purchase-item-preview.store-item .store-item-status {
+          font-size: 0.7rem;
+        }
 
         @media screen and (min-width: 800px) {
           #purchase-item-preview.store-item {
             width: 200px;
             height: 200px;
+          }
+          #purchase-item-preview.store-item .store-item-status {
+            font-size: 1rem;
           }
         }
 
@@ -7891,22 +7897,38 @@ function openPurchaseConfirm(type, key) {
                         img.src = COIN_LIFE_ITEMS[type]?.img || '';
                     }
                     purchaseItemPreview.appendChild(img);
-                }
             }
+        }
             let price = 0;
             let name = '';
+            let statusNeeded = false;
+            let iconSrc = '';
+            let iconAlt = '';
+            let iconClass = '';
             if (type === 'food') {
                 price = FOODS[key].price;
                 name = FOOD_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
+                statusNeeded = true;
+                iconSrc = 'https://i.imgur.com/gPGsaCO.png';
+                iconAlt = 'Gema';
+                iconClass = 'gem-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
             } else if (type === 'skin') {
                 price = SKIN_PRICES[key];
                 name = SKIN_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
+                statusNeeded = true;
+                iconSrc = 'https://i.imgur.com/gPGsaCO.png';
+                iconAlt = 'Gema';
+                iconClass = 'gem-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
             } else if (type === 'scene') {
                 price = SCENE_PRICES[key];
                 name = SCENE_DISPLAY_NAMES[key];
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
+                statusNeeded = true;
+                iconSrc = 'https://i.imgur.com/gPGsaCO.png';
+                iconAlt = 'Gema';
+                iconClass = 'gem-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
             } else if (type === 'chest') {
                 price = CHESTS[key].cost;
                 name = CHEST_DISPLAY_NAMES[key];
@@ -7914,22 +7936,53 @@ function openPurchaseConfirm(type, key) {
             } else if (type === 'coinPack') {
                 price = COIN_PACKS[key].costGems;
                 name = `${COIN_PACKS[key].amount} monedas`;
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> gemas?`;
+                statusNeeded = true;
+                iconSrc = 'https://i.imgur.com/gPGsaCO.png';
+                iconAlt = 'Gema';
+                iconClass = 'gem-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
             } else if (type === 'gemPack') {
                 price = GEM_PACKS[key].price;
                 name = `${GEM_PACKS[key].amount} gemas`;
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong>?`;
+                statusNeeded = true;
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
             } else if (type === 'adLife' || type === 'adChest' || type === 'adInfinite') {
                 const config = AD_ITEMS[type];
                 name = config.label;
-                const nAds = config.ads;
-                const plural = nAds === 1 ? '' : 's';
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Ver ${nAds} anuncio${plural} para obtener ${name}?`;
+                statusNeeded = true;
+                price = `${adsWatched[type]}/${config.ads}`;
+                iconSrc = 'https://i.imgur.com/9BfNTJh.png';
+                iconAlt = 'Anuncio';
+                iconClass = 'ad-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Ver anuncios para obtener ${name}?`;
             } else if (type === 'coinLife' || type === 'coinChest' || type === 'coinInfinite') {
                 const config = COIN_LIFE_ITEMS[type];
                 price = config.cost;
                 name = config.label;
-                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name} por <strong>${price}</strong> monedas?`;
+                statusNeeded = true;
+                iconSrc = 'https://i.imgur.com/lnc1Mwu.png';
+                iconAlt = 'Moneda';
+                iconClass = 'coin-cost-icon';
+                if (purchaseConfirmationText) purchaseConfirmationText.innerHTML = `¿Comprar ${name}?`;
+            }
+            if (statusNeeded && purchaseItemPreview) {
+                const status = document.createElement('div');
+                status.className = 'store-item-status';
+                if (typeof price === 'string' && !iconSrc) {
+                    status.textContent = price;
+                } else {
+                    const costSpan = document.createElement('span');
+                    costSpan.textContent = price.toString();
+                    status.appendChild(costSpan);
+                    if (iconSrc) {
+                        const icon = document.createElement('img');
+                        icon.src = iconSrc;
+                        icon.alt = iconAlt;
+                        icon.className = iconClass;
+                        status.appendChild(icon);
+                    }
+                }
+                purchaseItemPreview.appendChild(status);
             }
             purchaseConfirmationPanel.classList.remove('centered-panel');
             togglePanel(purchaseConfirmationPanel, purchaseConfirmationPanel.querySelector('.panel-content'), true);


### PR DESCRIPTION
## Summary
- show cost indicators above items in purchase confirmation panels
- scale cost labels with preview size
- remove cost from confirmation prompt
- display ad progress for life rewards in confirmation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689513916b388333a320ada18ff3e43a