### PR TITLE
Add new store images and backgrounds

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1657,6 +1657,11 @@
         #store-panel .panel-content {
             padding-right: 10px;
         }
+        #store-items-container {
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;
+        }
         #achievements-panel {
             max-height: 90vh;
             box-sizing: border-box;
@@ -5701,19 +5706,19 @@ function setupSlider(slider, display) {
         const HEART_PRICE = 100;
         const GEM_PRICE = 1000;
         const COIN_PACKS = {
-            coin500: { img: 'https://i.imgur.com/fMa30Nl.png', costGems: 1, amount: 500, name: 'Monedas' },
-            coin4000: { img: 'https://i.imgur.com/KnP5MXr.png', costGems: 5, amount: 4000, name: 'Bolsa de Monedas' },
-            coin10000: { img: 'https://i.imgur.com/3tiAqwx.png', costGems: 10, amount: 10000, name: 'Cofre de Monedas' }
+            coin500: { img: 'https://i.imgur.com/FKGwR3v.png', costGems: 1, amount: 500, name: 'Monedas' },
+            coin4000: { img: 'https://i.imgur.com/H1IFDGv.png', costGems: 5, amount: 4000, name: 'Bolsa de Monedas' },
+            coin10000: { img: 'https://i.imgur.com/uiFWFQW.png', costGems: 10, amount: 10000, name: 'Cofre de Monedas' }
         };
         const GEM_PACKS = {
-            gem10: { img: 'https://i.imgur.com/K5ntwBh.png', price: '0.99€', amount: 10, name: 'Gemas' },
-            gem50: { img: 'https://i.imgur.com/vhkvsPO.png', price: '2.99€', amount: 50, name: 'Bolsa de Gemas' },
-            gem100: { img: 'https://i.imgur.com/P59q9kH.png', price: '4.99€', amount: 100, name: 'Cofre de Gemas' }
+            gem10: { img: 'https://i.imgur.com/lTkdIwE.png', price: '0.99€', amount: 10, name: 'Gemas' },
+            gem50: { img: 'https://i.imgur.com/ovwNq8q.png', price: '2.99€', amount: 50, name: 'Bolsa de Gemas' },
+            gem100: { img: 'https://i.imgur.com/HJSyKZS.png', price: '4.99€', amount: 100, name: 'Cofre de Gemas' }
         };
         const AD_ITEMS = {
-            adLife: { img: 'https://i.imgur.com/bYgWlew.png', ads: 1, label: 'una vida' },
-            adChest: { img: 'https://i.imgur.com/Q5hONzD.png', ads: 2, label: 'un cofre de vidas' },
-            adInfinite: { img: 'https://i.imgur.com/QUXDBHx.png', ads: 3, label: 'vidas infinitas durante 1 hora' }
+            adLife: { img: 'https://i.imgur.com/QUrli9c.png', ads: 1, label: 'una vida' },
+            adChest: { img: 'https://i.imgur.com/FaevCFi.png', ads: 2, label: 'un cofre de vidas' },
+            adInfinite: { img: 'https://i.imgur.com/7l5zi5a.png', ads: 3, label: 'vidas infinitas durante 1 hora' }
         };
         const COIN_LIFE_ITEMS = {
             coinLife: { img: AD_ITEMS.adLife.img, cost: HEART_PRICE, label: 'una vida' },
@@ -5729,10 +5734,10 @@ function setupSlider(slider, display) {
         const ITEM_TYPE_DISPLAY = { food: 'comestible', scene: 'escenario', skin: 'disfraz' };
         const RARITY_DISPLAY_NAMES = { common: 'Común', rare: 'Raro', epic: 'Épico', legendary: 'Legendario' };
         const CHESTS = {
-            common: { img: 'https://i.imgur.com/CVheg4k.png', cost: 1000, coinRange: [10, 100], gemChance: 0.5, gemRange: [1, 1], rarity: { common: 70, rare: 20, epic: 9, legendary: 1 } },
-            rare: { img: 'https://i.imgur.com/ldTAquf.png', cost: 2500, coinRange: [100, 250], gemChance: 1, gemRange: [1, 3], rarity: { common: 10, rare: 70, epic: 15, legendary: 5 } },
-            epic: { img: 'https://i.imgur.com/4iQctwM.png', cost: 5000, coinRange: [250, 500], gemChance: 1, gemRange: [3, 5], rarity: { common: 5, rare: 10, epic: 70, legendary: 15 } },
-            legendary: { img: 'https://i.imgur.com/QND7wuI.png', cost: 10000, coinRange: [500, 1000], gemChance: 1, gemRange: [5, 10], rarity: { common: 5, rare: 10, epic: 15, legendary: 70 } }
+            common: { img: 'https://i.imgur.com/9npPWMV.png', cost: 1000, coinRange: [10, 100], gemChance: 0.5, gemRange: [1, 1], rarity: { common: 70, rare: 20, epic: 9, legendary: 1 } },
+            rare: { img: 'https://i.imgur.com/o6dPrib.png', cost: 2500, coinRange: [100, 250], gemChance: 1, gemRange: [1, 3], rarity: { common: 10, rare: 70, epic: 15, legendary: 5 } },
+            epic: { img: 'https://i.imgur.com/2n1fOZK.png', cost: 5000, coinRange: [250, 500], gemChance: 1, gemRange: [3, 5], rarity: { common: 5, rare: 10, epic: 70, legendary: 15 } },
+            legendary: { img: 'https://i.imgur.com/qF71FNE.png', cost: 10000, coinRange: [500, 1000], gemChance: 1, gemRange: [5, 10], rarity: { common: 5, rare: 10, epic: 15, legendary: 70 } }
         };
         const CHEST_ORDER = ['common', 'rare', 'epic', 'legendary'];
         let storeTab = 'cofres';
@@ -7477,6 +7482,13 @@ function setupSlider(slider, display) {
             if (!storeItemsContainer) return;
             storeItemsContainer.innerHTML = '';
             storeItemsContainer.className = storeTab === 'cofres' ? 'grid grid-cols-2 gap-2 w-2/3 mx-auto justify-items-center' : 'grid grid-cols-3 gap-2 w-full';
+            const backgrounds = {
+                cofres: "url('https://i.imgur.com/ovDIW0W.png')",
+                vidas: "url('https://i.imgur.com/fxOqXOM.png')",
+                divisas: "url('https://i.imgur.com/kOHjgb7.png')"
+            };
+            const bg = backgrounds[storeTab] || '';
+            storeItemsContainer.style.backgroundImage = bg;
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];


### PR DESCRIPTION
## Summary
- Add background support for store tabs with images for chests, lives, and currency
- Update chest, life, coin, and gem item art to new assets
- Apply dynamic backgrounds when switching store tabs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895a2f30c248333bf3541ab8423110d