### PR TITLE
Scale cost icons with store item size

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1023,24 +1023,24 @@
         }
 
         .coin-cost-icon {
-            width: 12px;
-            height: 12px;
+            width: 1.5em;
+            height: 1.5em;
             position: relative;
-            top: -1px;
+            top: -0.1em;
         }
 
         .gem-cost-icon {
-            width: 12px;
-            height: 12px;
+            width: 1.5em;
+            height: 1.5em;
             position: relative;
-            top: -1px;
+            top: -0.1em;
         }
 
         .ad-cost-icon {
-            width: 12px;
-            height: 12px;
+            width: 1.5em;
+            height: 1.5em;
             position: relative;
-            top: -2px;
+            top: -0.25em;
         }
 
 
@@ -3364,8 +3364,8 @@
             .coin-cost-icon,
             .gem-cost-icon,
             .ad-cost-icon {
-                width: 10px;
-                height: 10px;
+                width: 1.5em;
+                height: 1.5em;
             }
         }
 


### PR DESCRIPTION
## Summary
- make gem, coin, and ad icons scale proportionally with item size in purchase confirmation
- ensure responsive CSS uses relative sizing for these icons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895ae769494833381e8c89eb83c411f