### PR TITLE
Apply item backgrounds per store element

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7887,9 +7887,13 @@ function openPurchaseConfirm(type, key) {
         if (type === 'chest') chestInfoButton.classList.remove('hidden');
         else chestInfoButton.classList.add('hidden');
     }
-            if (purchaseItemPreview) {
-                purchaseItemPreview.innerHTML = '';
-                if (type === 'chest') {
+              if (purchaseItemPreview) {
+                  purchaseItemPreview.innerHTML = '';
+                  purchaseItemPreview.style.backgroundImage = '';
+                  purchaseItemPreview.style.backgroundSize = '';
+                  purchaseItemPreview.style.backgroundPosition = '';
+                  purchaseItemPreview.style.backgroundRepeat = '';
+                  if (type === 'chest') {
                     purchaseItemPreview.className = '';
                     const img = document.createElement('img');
                     img.className = 'chest-preview-img';
@@ -7906,27 +7910,46 @@ function openPurchaseConfirm(type, key) {
                                 : ((type === 'coinPack' || type === 'gemPack')
                                     ? ` currency-item ${rarityClass}`
                                     : ` ${rarityClass}`))));
-                    const img = document.createElement('img');
-                    img.className = 'store-item-img';
-                    if (type === 'food') {
-                        img.src = FOODS[key]?.asset?.src || '';
-                    } else if (type === 'skin') {
-                        img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
-                    } else if (type === 'scene') {
-                        img.classList.add('scene-img-full');
-                        img.src = SCENES[key]?.icon || '';
-                    } else if (type === 'coinPack') {
-                        img.classList.add('currency-img');
-                        img.src = COIN_PACKS[key]?.img || '';
-                    } else if (type === 'gemPack') {
-                        img.classList.add('currency-img');
-                        img.src = GEM_PACKS[key]?.img || '';
-                    } else if (type === 'adLife' || type === 'adChest' || type === 'adInfinite') {
-                        img.src = AD_ITEMS[type]?.img || '';
-                    } else if (type === 'coinLife' || type === 'coinChest' || type === 'coinInfinite') {
-                        img.src = COIN_LIFE_ITEMS[type]?.img || '';
-                    }
-                    purchaseItemPreview.appendChild(img);
+                      const img = document.createElement('img');
+                      img.className = 'store-item-img';
+                      if (type === 'food') {
+                          img.src = FOODS[key]?.asset?.src || '';
+                      } else if (type === 'skin') {
+                          img.src = SKINS[key]?.snakeHeadAsset?.upDown?.src || '';
+                      } else if (type === 'scene') {
+                          img.classList.add('scene-img-full');
+                          img.src = SCENES[key]?.icon || '';
+                      } else if (type === 'coinPack') {
+                          img.classList.add('currency-img');
+                          img.src = COIN_PACKS[key]?.img || '';
+                      } else if (type === 'gemPack') {
+                          img.classList.add('currency-img');
+                          img.src = GEM_PACKS[key]?.img || '';
+                      } else if (type === 'adLife' || type === 'adChest' || type === 'adInfinite') {
+                          img.classList.add('lives-img');
+                          img.src = AD_ITEMS[type]?.img || '';
+                      } else if (type === 'coinLife' || type === 'coinChest' || type === 'coinInfinite') {
+                          img.classList.add('lives-img');
+                          img.src = COIN_LIFE_ITEMS[type]?.img || '';
+                      }
+                      purchaseItemPreview.appendChild(img);
+                      const bgMap = {
+                          coinPack: "url('https://i.imgur.com/kOHjgb7.png')",
+                          gemPack: "url('https://i.imgur.com/kOHjgb7.png')",
+                          adLife: "url('https://i.imgur.com/fxOqXOM.png')",
+                          adChest: "url('https://i.imgur.com/fxOqXOM.png')",
+                          adInfinite: "url('https://i.imgur.com/fxOqXOM.png')",
+                          coinLife: "url('https://i.imgur.com/fxOqXOM.png')",
+                          coinChest: "url('https://i.imgur.com/fxOqXOM.png')",
+                          coinInfinite: "url('https://i.imgur.com/fxOqXOM.png')"
+                      };
+                      const bg = bgMap[type];
+                      if (bg) {
+                          purchaseItemPreview.style.backgroundImage = bg;
+                          purchaseItemPreview.style.backgroundSize = '80% 80%';
+                          purchaseItemPreview.style.backgroundPosition = 'center';
+                          purchaseItemPreview.style.backgroundRepeat = 'no-repeat';
+                      }
             }
         }
             let price = 0;

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7490,7 +7490,7 @@ function setupSlider(slider, display) {
                     item.className = 'store-item currency-item rarity-default chest-grid-item';
                     if (bg) {
                         item.style.backgroundImage = bg;
-                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundSize = '80% 80%';
                         item.style.backgroundPosition = 'center';
                         item.style.backgroundRepeat = 'no-repeat';
                     }
@@ -7623,7 +7623,7 @@ function setupSlider(slider, display) {
                     item.className = 'store-item currency-item rarity-default';
                     if (bg) {
                         item.style.backgroundImage = bg;
-                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundSize = '80% 80%';
                         item.style.backgroundPosition = 'center';
                         item.style.backgroundRepeat = 'no-repeat';
                     }
@@ -7663,7 +7663,7 @@ function setupSlider(slider, display) {
                     item.className = 'store-item rarity-default';
                     if (bg) {
                         item.style.backgroundImage = bg;
-                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundSize = '80% 80%';
                         item.style.backgroundPosition = 'center';
                         item.style.backgroundRepeat = 'no-repeat';
                     }
@@ -7703,7 +7703,7 @@ function setupSlider(slider, display) {
                     item.className = 'store-item rarity-default';
                     if (bg) {
                         item.style.backgroundImage = bg;
-                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundSize = '80% 80%';
                         item.style.backgroundPosition = 'center';
                         item.style.backgroundRepeat = 'no-repeat';
                     }

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1657,11 +1657,6 @@
         #store-panel .panel-content {
             padding-right: 10px;
         }
-        #store-items-container {
-            background-size: cover;
-            background-position: center;
-            background-repeat: no-repeat;
-        }
         #achievements-panel {
             max-height: 90vh;
             box-sizing: border-box;
@@ -7488,12 +7483,17 @@ function setupSlider(slider, display) {
                 divisas: "url('https://i.imgur.com/kOHjgb7.png')"
             };
             const bg = backgrounds[storeTab] || '';
-            storeItemsContainer.style.backgroundImage = bg;
             if (storeTab === 'cofres') {
                 CHEST_ORDER.forEach(key => {
                     const chest = CHESTS[key];
                     const item = document.createElement('div');
                     item.className = 'store-item currency-item rarity-default chest-grid-item';
+                    if (bg) {
+                        item.style.backgroundImage = bg;
+                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundPosition = 'center';
+                        item.style.backgroundRepeat = 'no-repeat';
+                    }
                     const img = document.createElement('img');
                     img.className = 'store-item-img currency-img';
                     img.src = chest.img;
@@ -7621,6 +7621,12 @@ function setupSlider(slider, display) {
                 items.forEach(({ key, pack, type }) => {
                     const item = document.createElement('div');
                     item.className = 'store-item currency-item rarity-default';
+                    if (bg) {
+                        item.style.backgroundImage = bg;
+                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundPosition = 'center';
+                        item.style.backgroundRepeat = 'no-repeat';
+                    }
                     const img = document.createElement('img');
                     img.className = 'store-item-img currency-img';
                     img.src = pack.img;
@@ -7655,6 +7661,12 @@ function setupSlider(slider, display) {
                     const item = document.createElement('div');
                     item.id = `store-item-${type}`;
                     item.className = 'store-item rarity-default';
+                    if (bg) {
+                        item.style.backgroundImage = bg;
+                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundPosition = 'center';
+                        item.style.backgroundRepeat = 'no-repeat';
+                    }
                     const imgEl = document.createElement('img');
                     imgEl.className = 'store-item-img lives-img';
                     imgEl.src = img;
@@ -7689,6 +7701,12 @@ function setupSlider(slider, display) {
                     const item = document.createElement('div');
                     item.id = `store-item-${type}`;
                     item.className = 'store-item rarity-default';
+                    if (bg) {
+                        item.style.backgroundImage = bg;
+                        item.style.backgroundSize = 'cover';
+                        item.style.backgroundPosition = 'center';
+                        item.style.backgroundRepeat = 'no-repeat';
+                    }
                     const imgEl = document.createElement('img');
                     imgEl.className = 'store-item-img lives-img';
                     imgEl.src = data.img;


### PR DESCRIPTION
## Summary
- Remove grid-level background for store tabs
- Apply background images to each store item in chests, currencies and lives tabs

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895b51034888333b038552bf4952138