### PR TITLE
feat: expand unlockable achievements

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5815,6 +5815,10 @@ function setupSlider(slider, display) {
             foodsUnlocked: 'unlockables',
             skinsUnlocked: 'unlockables',
             scenesUnlocked: 'unlockables',
+            commonUnlocked: 'unlockables',
+            rareUnlocked: 'unlockables',
+            epicUnlocked: 'unlockables',
+            legendaryUnlocked: 'unlockables',
             playersAdded: 'specials'
         };
 
@@ -5874,14 +5878,47 @@ function setupSlider(slider, display) {
             { id: 'legend_1500', type: 'legendaryPoints', threshold: 1500, reward: 3, description: '1.5k puntos en Legendario' },
             { id: 'legend_2000', type: 'legendaryPoints', threshold: 2000, reward: 3, description: '2k puntos en Legendario' },
             { id: 'skins_1', type: 'skinsUnlocked', threshold: 1, reward: 1, description: 'Desbloquea 1 disfraz' },
-            { id: 'skins_2', type: 'skinsUnlocked', threshold: 2, reward: 1, description: 'Desbloquea 2 disfraces' },
+            { id: 'skins_3', type: 'skinsUnlocked', threshold: 3, reward: 1, description: 'Desbloquea 3 disfraces' },
             { id: 'skins_5', type: 'skinsUnlocked', threshold: 5, reward: 3, description: 'Desbloquea 5 disfraces' },
+            { id: 'skins_10', type: 'skinsUnlocked', threshold: 10, reward: 5, description: 'Desbloquea 10 disfraces' },
+            { id: 'skins_25', type: 'skinsUnlocked', threshold: 25, reward: 8, description: 'Desbloquea 25 disfraces' },
+            { id: 'skins_50', type: 'skinsUnlocked', threshold: 50, reward: 15, description: 'Desbloquea 50 disfraces' },
             { id: 'foods_1', type: 'foodsUnlocked', threshold: 1, reward: 1, description: 'Desbloquea 1 comestible' },
-            { id: 'foods_2', type: 'foodsUnlocked', threshold: 2, reward: 1, description: 'Desbloquea 2 comestibles' },
+            { id: 'foods_3', type: 'foodsUnlocked', threshold: 3, reward: 1, description: 'Desbloquea 3 comestibles' },
             { id: 'foods_5', type: 'foodsUnlocked', threshold: 5, reward: 3, description: 'Desbloquea 5 comestibles' },
+            { id: 'foods_10', type: 'foodsUnlocked', threshold: 10, reward: 5, description: 'Desbloquea 10 comestibles' },
+            { id: 'foods_25', type: 'foodsUnlocked', threshold: 25, reward: 8, description: 'Desbloquea 25 comestibles' },
+            { id: 'foods_50', type: 'foodsUnlocked', threshold: 50, reward: 15, description: 'Desbloquea 50 comestibles' },
             { id: 'scenes_1', type: 'scenesUnlocked', threshold: 1, reward: 1, description: 'Desbloquea 1 escenario' },
-            { id: 'scenes_2', type: 'scenesUnlocked', threshold: 2, reward: 1, description: 'Desbloquea 2 escenarios' },
+            { id: 'scenes_3', type: 'scenesUnlocked', threshold: 3, reward: 1, description: 'Desbloquea 3 escenarios' },
             { id: 'scenes_5', type: 'scenesUnlocked', threshold: 5, reward: 3, description: 'Desbloquea 5 escenarios' },
+            { id: 'scenes_10', type: 'scenesUnlocked', threshold: 10, reward: 5, description: 'Desbloquea 10 escenarios' },
+            { id: 'scenes_25', type: 'scenesUnlocked', threshold: 25, reward: 8, description: 'Desbloquea 25 escenarios' },
+            { id: 'scenes_50', type: 'scenesUnlocked', threshold: 50, reward: 15, description: 'Desbloquea 50 escenarios' },
+            { id: 'common_1', type: 'commonUnlocked', threshold: 1, reward: 1, description: 'Consigue 1 elemento común' },
+            { id: 'common_3', type: 'commonUnlocked', threshold: 3, reward: 1, description: 'Consigue 3 elementos comunes' },
+            { id: 'common_5', type: 'commonUnlocked', threshold: 5, reward: 3, description: 'Consigue 5 elementos comunes' },
+            { id: 'common_10', type: 'commonUnlocked', threshold: 10, reward: 5, description: 'Consigue 10 elementos comunes' },
+            { id: 'common_25', type: 'commonUnlocked', threshold: 25, reward: 8, description: 'Consigue 25 elementos comunes' },
+            { id: 'common_50', type: 'commonUnlocked', threshold: 50, reward: 15, description: 'Consigue 50 elementos comunes' },
+            { id: 'rare_1', type: 'rareUnlocked', threshold: 1, reward: 1, description: 'Consigue 1 elemento raro' },
+            { id: 'rare_3', type: 'rareUnlocked', threshold: 3, reward: 1, description: 'Consigue 3 elementos raros' },
+            { id: 'rare_5', type: 'rareUnlocked', threshold: 5, reward: 3, description: 'Consigue 5 elementos raros' },
+            { id: 'rare_10', type: 'rareUnlocked', threshold: 10, reward: 5, description: 'Consigue 10 elementos raros' },
+            { id: 'rare_25', type: 'rareUnlocked', threshold: 25, reward: 8, description: 'Consigue 25 elementos raros' },
+            { id: 'rare_50', type: 'rareUnlocked', threshold: 50, reward: 15, description: 'Consigue 50 elementos raros' },
+            { id: 'epic_1', type: 'epicUnlocked', threshold: 1, reward: 1, description: 'Consigue 1 elemento épico' },
+            { id: 'epic_3', type: 'epicUnlocked', threshold: 3, reward: 1, description: 'Consigue 3 elementos épicos' },
+            { id: 'epic_5', type: 'epicUnlocked', threshold: 5, reward: 3, description: 'Consigue 5 elementos épicos' },
+            { id: 'epic_10', type: 'epicUnlocked', threshold: 10, reward: 5, description: 'Consigue 10 elementos épicos' },
+            { id: 'epic_25', type: 'epicUnlocked', threshold: 25, reward: 8, description: 'Consigue 25 elementos épicos' },
+            { id: 'epic_50', type: 'epicUnlocked', threshold: 50, reward: 15, description: 'Consigue 50 elementos épicos' },
+            { id: 'legendary_1', type: 'legendaryUnlocked', threshold: 1, reward: 1, description: 'Consigue 1 elemento legendario' },
+            { id: 'legendary_3', type: 'legendaryUnlocked', threshold: 3, reward: 1, description: 'Consigue 3 elementos legendarios' },
+            { id: 'legendary_5', type: 'legendaryUnlocked', threshold: 5, reward: 3, description: 'Consigue 5 elementos legendarios' },
+            { id: 'legendary_10', type: 'legendaryUnlocked', threshold: 10, reward: 5, description: 'Consigue 10 elementos legendarios' },
+            { id: 'legendary_25', type: 'legendaryUnlocked', threshold: 25, reward: 8, description: 'Consigue 25 elementos legendarios' },
+            { id: 'legendary_50', type: 'legendaryUnlocked', threshold: 50, reward: 15, description: 'Consigue 50 elementos legendarios' },
             { id: 'players_1', type: 'playersAdded', threshold: 1, reward: 1, description: 'Añade un jugador' }
         ];
 
@@ -5900,6 +5937,10 @@ function setupSlider(slider, display) {
             skinsUnlocked: 0,
             foodsUnlocked: 0,
             scenesUnlocked: 0,
+            commonUnlocked: 0,
+            rareUnlocked: 0,
+            epicUnlocked: 0,
+            legendaryUnlocked: 0,
             playersAdded: 0
         };
 
@@ -13262,9 +13303,32 @@ async function startGame(isRestart = false) {
             btn.addEventListener('touchcancel', removePressed);
         }
 
+        function updateUnlockableAchievementProgress() {
+            achievementsProgress.foodsUnlocked = Math.max(Object.keys(unlockedFoods).length - DEFAULT_FOOD_COUNT, 0);
+            achievementsProgress.skinsUnlocked = Math.max(Object.keys(unlockedSkins).length - DEFAULT_SKIN_COUNT, 0);
+            achievementsProgress.scenesUnlocked = Math.max(Object.keys(unlockedScenes).length - DEFAULT_SCENE_COUNT, 0);
+
+            const rarityCounts = { common: 0, rare: 0, epic: 0, legendary: 0 };
+            const accumulate = (type, items, defaultKey) => {
+                for (const key of Object.keys(items)) {
+                    if (key === defaultKey) continue;
+                    const rarity = getRarityClass(type, key).replace('rarity-', '');
+                    if (rarityCounts[rarity] !== undefined) rarityCounts[rarity]++;
+                }
+            };
+            accumulate('food', unlockedFoods, 'apple');
+            accumulate('skin', unlockedSkins, 'snake');
+            accumulate('scene', unlockedScenes, 'classic');
+
+            achievementsProgress.commonUnlocked = rarityCounts.common;
+            achievementsProgress.rareUnlocked = rarityCounts.rare;
+            achievementsProgress.epicUnlocked = rarityCounts.epic;
+            achievementsProgress.legendaryUnlocked = rarityCounts.legendary;
+        }
+
         function saveUnlockedFoods() {
             localStorage.setItem('snakeGameUnlockedFoods', JSON.stringify(unlockedFoods));
-            achievementsProgress.foodsUnlocked = Math.max(Object.keys(unlockedFoods).length - DEFAULT_FOOD_COUNT, 0);
+            updateUnlockableAchievementProgress();
             checkAchievements();
             saveAchievementsState();
         }
@@ -13280,7 +13344,7 @@ async function startGame(isRestart = false) {
 
         function saveUnlockedSkins() {
             localStorage.setItem('snakeGameUnlockedSkins', JSON.stringify(unlockedSkins));
-            achievementsProgress.skinsUnlocked = Math.max(Object.keys(unlockedSkins).length - DEFAULT_SKIN_COUNT, 0);
+            updateUnlockableAchievementProgress();
             checkAchievements();
             saveAchievementsState();
         }
@@ -13296,7 +13360,7 @@ async function startGame(isRestart = false) {
 
         function saveUnlockedScenes() {
             localStorage.setItem('snakeGameUnlockedScenes', JSON.stringify(unlockedScenes));
-            achievementsProgress.scenesUnlocked = Math.max(Object.keys(unlockedScenes).length - DEFAULT_SCENE_COUNT, 0);
+            updateUnlockableAchievementProgress();
             checkAchievements();
             saveAchievementsState();
         }
@@ -13741,6 +13805,9 @@ async function startGame(isRestart = false) {
             loadUnlockedSkins();
             loadUnlockedScenes();
             loadAchievementsState();
+            updateUnlockableAchievementProgress();
+            checkAchievements();
+            saveAchievementsState();
             updateFoodSelectorOptions(playerProfiles[currentPlayerName]?.food || 'apple');
             updateSceneSelectorOptions(playerProfiles[currentPlayerName]?.scene || 'classic');
             updatePlayerNameSelectors(currentPlayerName);


### PR DESCRIPTION
## Summary
- expand unlockable achievements for skins, foods and scenes up to 50 items
- add achievements for unlocking items by rarity
- track and update new rarity-based progress counters

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_689664afb91083338ab566f28888d656