### PR TITLE
Actualiza logros de puntuación para clasificación

### DIFF
--- a/CLASIFICACION.md
+++ b/CLASIFICACION.md
@@ -38,9 +38,9 @@ Este planteamiento tiene como objetivo proporcionar un reto creciente y diferenc
 
 ## Logros por puntuación
 
-Se han añadido logros específicos que recompensan alcanzar determinadas puntuaciones según la dificultad:
+Se han añadido logros específicos que recompensan alcanzar determinadas puntuaciones según la dificultad. Las puntuaciones deben lograrse en una única partida del modo clasificación, sin acumular resultados de partidas diferentes:
 
-- **Novato**: 500, 750 y 1k puntos.
-- **Explorador**: 500, 750, 1k, 1.5k y 2k puntos.
-- **Veterano**: 500, 750, 1k, 1.5k y 2k puntos.
-- **Legendario**: 500, 750, 1k, 1.5k y 2k puntos.
+- **Novato**: 500, 750, 1k y 1.5k puntos.
+- **Explorador**: 750, 1k, 1.5k, 2k y 2.5k puntos.
+- **Veterano**: 750, 1k, 1.5k, 2k y 2.5k puntos.
+- **Legendario**: 750, 1k, 1.5k, 2k y 2.5k puntos.

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -5862,21 +5862,22 @@ function setupSlider(slider, display) {
             { id: 'novice_500', type: 'novicePoints', threshold: 500, reward: 1, description: '500 puntos en Novato' },
             { id: 'novice_750', type: 'novicePoints', threshold: 750, reward: 3, description: '750 puntos en Novato' },
             { id: 'novice_1000', type: 'novicePoints', threshold: 1000, reward: 5, description: '1k puntos en Novato' },
-            { id: 'explorer_500', type: 'explorerPoints', threshold: 500, reward: 1, description: '500 puntos en Explorador' },
+            { id: 'novice_1500', type: 'novicePoints', threshold: 1500, reward: 7, description: '1.5k puntos en Novato' },
             { id: 'explorer_750', type: 'explorerPoints', threshold: 750, reward: 1, description: '750 puntos en Explorador' },
             { id: 'explorer_1000', type: 'explorerPoints', threshold: 1000, reward: 1, description: '1k puntos en Explorador' },
             { id: 'explorer_1500', type: 'explorerPoints', threshold: 1500, reward: 1, description: '1.5k puntos en Explorador' },
             { id: 'explorer_2000', type: 'explorerPoints', threshold: 2000, reward: 1, description: '2k puntos en Explorador' },
-            { id: 'veteran_500', type: 'veteranPoints', threshold: 500, reward: 2, description: '500 puntos en Veterano' },
+            { id: 'explorer_2500', type: 'explorerPoints', threshold: 2500, reward: 1, description: '2.5k puntos en Explorador' },
             { id: 'veteran_750', type: 'veteranPoints', threshold: 750, reward: 2, description: '750 puntos en Veterano' },
             { id: 'veteran_1000', type: 'veteranPoints', threshold: 1000, reward: 2, description: '1k puntos en Veterano' },
             { id: 'veteran_1500', type: 'veteranPoints', threshold: 1500, reward: 2, description: '1.5k puntos en Veterano' },
             { id: 'veteran_2000', type: 'veteranPoints', threshold: 2000, reward: 2, description: '2k puntos en Veterano' },
-            { id: 'legend_500', type: 'legendaryPoints', threshold: 500, reward: 3, description: '500 puntos en Legendario' },
+            { id: 'veteran_2500', type: 'veteranPoints', threshold: 2500, reward: 2, description: '2.5k puntos en Veterano' },
             { id: 'legend_750', type: 'legendaryPoints', threshold: 750, reward: 3, description: '750 puntos en Legendario' },
             { id: 'legend_1000', type: 'legendaryPoints', threshold: 1000, reward: 3, description: '1k puntos en Legendario' },
             { id: 'legend_1500', type: 'legendaryPoints', threshold: 1500, reward: 3, description: '1.5k puntos en Legendario' },
             { id: 'legend_2000', type: 'legendaryPoints', threshold: 2000, reward: 3, description: '2k puntos en Legendario' },
+            { id: 'legend_2500', type: 'legendaryPoints', threshold: 2500, reward: 3, description: '2.5k puntos en Legendario' },
             { id: 'skins_1', type: 'skinsUnlocked', threshold: 1, reward: 1, description: 'Desbloquea 1 disfraz' },
             { id: 'skins_3', type: 'skinsUnlocked', threshold: 3, reward: 2, description: 'Desbloquea 3 disfraces' },
             { id: 'skins_5', type: 'skinsUnlocked', threshold: 5, reward: 3, description: 'Desbloquea 5 disfraces' },
@@ -10172,11 +10173,13 @@ function openPurchaseConfirm(type, key) {
             achievementsProgress.coins = totalCoins;
             achievementsProgress.points += score;
             if (gameMode === 'freeMode') achievementsProgress.freeGames++;
-            if (gameMode === 'classification') achievementsProgress.classificationGames++;
-            if (difficulty === 'principiante') achievementsProgress.novicePoints += score;
-            else if (difficulty === 'explorador') achievementsProgress.explorerPoints += score;
-            else if (difficulty === 'veterano') achievementsProgress.veteranPoints += score;
-            else if (difficulty === 'legendario') achievementsProgress.legendaryPoints += score;
+            if (gameMode === 'classification') {
+                achievementsProgress.classificationGames++;
+                if (difficulty === 'principiante') achievementsProgress.novicePoints = Math.max(achievementsProgress.novicePoints, score);
+                else if (difficulty === 'explorador') achievementsProgress.explorerPoints = Math.max(achievementsProgress.explorerPoints, score);
+                else if (difficulty === 'veterano') achievementsProgress.veteranPoints = Math.max(achievementsProgress.veteranPoints, score);
+                else if (difficulty === 'legendario') achievementsProgress.legendaryPoints = Math.max(achievementsProgress.legendaryPoints, score);
+            }
             checkAchievements();
             saveAchievementsState();
             updateUIOnGameOver();


### PR DESCRIPTION
## Summary
- Ajusta los objetivos de puntuación para los logros de cada dificultad en clasificación
- Registra solo la mejor puntuación obtenida en una única partida de modo clasificación

## Testing
- `npm test` *(falla: no se encontró package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68966daaedc48333bd5d13adbedfb877