### PR TITLE
Add daily rewards submenu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Open `Snake Github.html` directly in your favorite web browser. You can either d
 - **Audio** – Select between Activado, Sólo Música, Sólo Efectos o Desactivado y ajusta por separado los volúmenes de música y efectos.
 - **Maze Stars** – Each maze level tracks the stars you've earned so you can work toward a perfect 5-star score over multiple attempts.
 - **Coins** – Earn coins at the end of every game. Your total coins accumulate across all game modes and sessions.
+- **Daily Rewards** – Earn randomized prizes by checking in every day. Claim all seven in a row to restart the cycle.
 
 For details on the upcoming Classification mode revamp, see [CLASIFICACION.md](CLASIFICACION.md).
 

--- a/premios_diarios.html
+++ b/premios_diarios.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <title>Premios Diarios</title>
+  <style>
+    #premios {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 10px;
+      max-width: 600px;
+    }
+    .premio {
+      border: 1px solid #333;
+      padding: 20px;
+      text-align: center;
+      cursor: pointer;
+      user-select: none;
+    }
+    .bloqueado {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+    .reclamado {
+      background: #eee;
+      cursor: default;
+    }
+  </style>
+</head>
+<body>
+  <h1>Premios diarios</h1>
+  <div id="premios"></div>
+  <script src="premios_diarios.js"></script>
+</body>
+</html>

--- a/premios_diarios.js
+++ b/premios_diarios.js
@@ -1,0 +1,114 @@
+const STORAGE_KEY = 'premiosDiarios';
+const premios = [
+  { tipo: 'vidas', min: 1, max: 5 },
+  { tipo: 'monedas', min: 100, max: 1000 },
+  { tipo: 'gemas', min: 1, max: 10 },
+  { tipo: 'cofre', rareza: 'común' },
+  { tipo: 'cofre', rareza: 'raro' },
+  { tipo: 'cofre', rareza: 'épico' },
+  { tipo: 'cofre', rareza: 'legendario' }
+];
+
+function hoy() {
+  return new Date().toISOString().split('T')[0];
+}
+
+function cargarEstado() {
+  const datos = localStorage.getItem(STORAGE_KEY);
+  if (!datos) return { ultimaFecha: null, streak: 0 };
+  try {
+    return JSON.parse(datos);
+  } catch (_) {
+    return { ultimaFecha: null, streak: 0 };
+  }
+}
+
+function guardarEstado(estado) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(estado));
+}
+
+function reiniciarEstado() {
+  guardarEstado({ ultimaFecha: null, streak: 0 });
+}
+
+function crearVista() {
+  const contenedor = document.getElementById('premios');
+  premios.forEach((p, i) => {
+    const dia = i + 1;
+    const div = document.createElement('div');
+    div.className = 'premio';
+    div.dataset.dia = dia;
+    div.innerHTML = `<strong>Día ${dia}</strong>`;
+    div.addEventListener('click', () => intentarReclamar(dia));
+    contenedor.appendChild(div);
+  });
+  actualizarVista();
+}
+
+function actualizarVista() {
+  const estado = cargarEstado();
+  const hoyStr = hoy();
+  const premiosEls = document.querySelectorAll('.premio');
+  premiosEls.forEach(el => {
+    const dia = parseInt(el.dataset.dia, 10);
+    el.classList.remove('bloqueado', 'reclamado');
+    if (estado.ultimaFecha === hoyStr && dia <= estado.streak) {
+      el.classList.add('reclamado');
+    } else if (dia > estado.streak + 1) {
+      el.classList.add('bloqueado');
+    }
+  });
+}
+
+function obtenerRecompensa(dia) {
+  const premio = premios[dia - 1];
+  if (premio.tipo === 'cofre') {
+    alert(`¡Has conseguido un cofre ${premio.rareza}!`);
+  } else {
+    const cantidad = Math.floor(Math.random() * (premio.max - premio.min + 1)) + premio.min;
+    alert(`¡Has conseguido ${cantidad} ${premio.tipo}!`);
+  }
+}
+
+function intentarReclamar(dia) {
+  const estado = cargarEstado();
+  const hoyStr = hoy();
+
+  if (estado.ultimaFecha === hoyStr) {
+    if (dia === estado.streak + 1) {
+      alert('Disponible mañana');
+    } else {
+      alert('Todavía no disponible');
+    }
+    return;
+  }
+
+  if (estado.ultimaFecha) {
+    const diff = (new Date(hoyStr) - new Date(estado.ultimaFecha)) / (1000 * 60 * 60 * 24);
+    if (diff > 1 && dia !== 1) {
+      alert('Todavía no disponible');
+      reiniciarEstado();
+      actualizarVista();
+      return;
+    }
+    if (diff > 1 || dia !== estado.streak + 1) {
+      alert('Todavía no disponible');
+      reiniciarEstado();
+      actualizarVista();
+      return;
+    }
+  } else if (dia !== 1) {
+    alert('Todavía no disponible');
+    return;
+  }
+
+  if (confirm('¿Quieres ver un anuncio para conseguir el premio diario?')) {
+    obtenerRecompensa(dia);
+    estado.ultimaFecha = hoyStr;
+    estado.streak = dia % 7;
+    guardarEstado(estado);
+    actualizarVista();
+  }
+}
+
+crearVista();


### PR DESCRIPTION
## Summary
- Add HTML and JS for a seven-day daily rewards system with natural-day tracking
- Update README to document new daily rewards feature

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68972f1f78d48333bec15d8bf9f9c526