### PR TITLE
Reduce spacing in daily reward confirmation windows

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2405,7 +2405,7 @@
         #profile-panel { z-index: 2101; }
         #achievements-panel { z-index: 2101; }
         #daily-panel { z-index: 2101; }
-        #purchase-confirmation-panel { z-index: 2103; }
+        #purchase-confirmation-panel { z-index: 2103; gap: 4px; }
         #chest-info-panel { z-index: 2103; }
         #delete-confirmation-panel { z-index: 2103; }
         #select-confirmation-panel { z-index: 2103; }
@@ -2454,7 +2454,7 @@
 
         #reset-confirmation-panel p { text-align: center; margin: 0 0 10px 0; }
         #purchase-confirmation-panel p { text-align: center; margin: 0 0 2px 0; font-size: 0.8em; }
-        #purchase-confirmation-panel.chest-purchase .reset-header { margin-bottom: 0; }
+        #purchase-confirmation-panel .reset-header { margin-bottom: 0; }
         #chest-info-panel p { text-align: left; margin: 8px 0 10px 10px; font-size: 0.8em; }
         #chest-info-panel .reset-header { margin-bottom: 0; }
         #chest-info-button { background-color: transparent; border-radius: 0; top: 0; right: 0; transform: none; height: 100%; }


### PR DESCRIPTION
## Summary
- Shrink vertical gap between title and content in daily reward confirmation panel
- Remove extra margin below the panel header to keep reward dialog compact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689766e452a48333811b8df1cd1da67f