### PR TITLE
Add daily prize wheel

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3390,6 +3390,39 @@
             }
         }
 
+        #wheel-wrapper {
+            position: relative;
+        }
+        #wheel-pointer {
+            position: absolute;
+            top: -10px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 0;
+            height: 0;
+            border-left: 15px solid transparent;
+            border-right: 15px solid transparent;
+            border-bottom: 30px solid red;
+            z-index: 10;
+        }
+        #wheel-canvas {
+            transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
+        }
+        #spin-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        #wheel-overlay {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background-color: rgba(0, 0, 0, 0.5);
+            color: white;
+            font-size: 1.2rem;
+        }
+
     </style>
 </head>
 <body>
@@ -3819,7 +3852,21 @@
                     </button>
                 </div>
                 <div class="panel-content">
-                    <p>Contenido no disponible todavía</p>
+                    <div id="wheel-container" class="flex flex-col items-center gap-4">
+                        <div id="wheel-area" class="flex items-center justify-center">
+                            <div id="wheel-wrapper">
+                                <canvas id="wheel-canvas" width="300" height="300"></canvas>
+                                <div id="wheel-pointer"></div>
+                                <div id="wheel-overlay" class="hidden">BLOQUEADO</div>
+                            </div>
+                            <div id="chest-content" class="hidden flex flex-col items-center"></div>
+                        </div>
+                        <div class="flex items-center gap-4">
+                            <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
+                            <div id="prize-display" class="flex items-center gap-2 min-w-[160px] min-h-[48px] justify-center text-center"></div>
+                        </div>
+                        <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>
+                    </div>
                 </div>
             </div>
 <div id="profile-panel" class="profile-panel-hidden">
@@ -4293,6 +4340,14 @@
         const dailyPanel = document.getElementById("daily-panel");
         const closeDailyPanelButton = document.getElementById("close-daily-panel");
         const dailyRewardsContainer = document.getElementById("daily-rewards-container");
+        const wheelCanvas = document.getElementById("wheel-canvas");
+        const wheelCtx = wheelCanvas ? wheelCanvas.getContext("2d") : null;
+        const spinButton = document.getElementById("spin-button");
+        const prizeDisplay = document.getElementById("prize-display");
+        const actionButton = document.getElementById("action-button");
+        const wheelOverlay = document.getElementById("wheel-overlay");
+        const wheelWrapper = document.getElementById("wheel-wrapper");
+        const chestContent = document.getElementById("chest-content");
         const storeItemsContainer = document.getElementById("store-items-container");
         const storeTabButtons = document.querySelectorAll('#store-tabs .store-tab');
         const closeStorePanelButton = document.getElementById("close-store-panel");
@@ -7600,6 +7655,7 @@ function setupSlider(slider, display) {
             const isConfigMenuVisible = !configMenuPanel.classList.contains('config-menu-panel-hidden') && configMenuPanel.classList.contains('panel-visible');
             genericMenuPanel.classList.remove('centered-panel');
             togglePanel(genericMenuPanel, genericMenuPanel.querySelector('.panel-content'), true);
+            if (title === 'Ruleta de premios') checkWheelCooldown();
             if (isConfigMenuVisible) {
                 matchPanelSizeWithElement(configMenuPanel, genericMenuPanel);
             }
@@ -14378,6 +14434,190 @@ async function startGame(isRestart = false) {
             updateGameModeUI(); // Refresh UI based on potentially new screenState
 
         }
+
+        // --- Daily Wheel Logic ---
+        const wheelPrizes = [
+            { label: 'Tirar de nuevo', prob: 0.1, type: 'reroll', image: 'https://i.imgur.com/i4m4tSV.png' },
+            { label: 'Vida', prob: 0.25, type: 'life', min: 1, max: 5, image: 'https://i.imgur.com/WrI2XXx.png' },
+            { label: 'Monedas (10-100)', prob: 0.2, type: 'coins', min: 10, max: 100, image: 'https://i.imgur.com/lnc1Mwu.png' },
+            { label: 'Monedas (100-1000)', prob: 0.1, type: 'coins', min: 100, max: 1000, image: 'https://i.imgur.com/lnc1Mwu.png' },
+            { label: 'Gemas (1-5)', prob: 0.1, type: 'gems', min: 1, max: 5, image: 'https://i.imgur.com/gPGsaCO.png' },
+            { label: 'Gemas (5-10)', prob: 0.05, type: 'gems', min: 5, max: 10, image: 'https://i.imgur.com/gPGsaCO.png' },
+            { label: 'Cofre común', prob: 0.1, type: 'chest', chestType: 'common', image: 'https://i.imgur.com/j8UD4hK.png' },
+            { label: 'Cofre raro', prob: 0.06, type: 'chest', chestType: 'rare', image: 'https://i.imgur.com/1BBQ2DK.png' },
+            { label: 'Cofre épico', prob: 0.03, type: 'chest', chestType: 'epic', image: 'https://i.imgur.com/6U6QE3X.png' },
+            { label: 'Cofre legendario', prob: 0.01, type: 'chest', chestType: 'legendary', image: 'https://i.imgur.com/4kOPIdx.png' }
+        ];
+
+        const wheelAngles = [];
+        (function computeAngles() {
+            let start = 0;
+            wheelPrizes.forEach(p => {
+                const angle = p.prob * 2 * Math.PI;
+                wheelAngles.push({ start, end: start + angle, prize: p });
+                start += angle;
+            });
+        })();
+
+        function drawWheel() {
+            if (!wheelCtx) return;
+            let start = 0;
+            wheelPrizes.forEach((p, i) => {
+                const angle = p.prob * 2 * Math.PI;
+                wheelCtx.beginPath();
+                wheelCtx.moveTo(150, 150);
+                wheelCtx.arc(150, 150, 150, start, start + angle);
+                wheelCtx.closePath();
+                wheelCtx.fillStyle = `hsl(${i * 36},70%,50%)`;
+                wheelCtx.fill();
+                wheelCtx.save();
+                wheelCtx.translate(150, 150);
+                wheelCtx.rotate(start + angle / 2);
+                wheelCtx.textAlign = 'right';
+                wheelCtx.fillStyle = '#fff';
+                wheelCtx.font = '12px sans-serif';
+                wheelCtx.fillText(p.label, 140, 5);
+                wheelCtx.restore();
+                start += angle;
+            });
+        }
+
+        function selectPrize() {
+            const r = Math.random();
+            let acc = 0;
+            for (const p of wheelPrizes) {
+                acc += p.prob;
+                if (r <= acc) return p;
+            }
+            return wheelPrizes[wheelPrizes.length - 1];
+        }
+
+        let wheelSpinning = false;
+        function spinWheel() {
+            if (wheelSpinning) return;
+            const cooldown = getWheelCooldown();
+            if (Date.now() < cooldown) return;
+            wheelSpinning = true;
+            if (spinButton) spinButton.disabled = true;
+            const prize = selectPrize();
+            const seg = wheelAngles.find(a => a.prize === prize);
+            const center = (seg.start + seg.end) / 2;
+            const extra = 2 * Math.PI * 5;
+            const finalAngle = extra + (Math.PI * 1.5 - center);
+            if (wheelCanvas) {
+                wheelCanvas.style.transition = 'transform 4s cubic-bezier(0.33,1,0.68,1)';
+                wheelCanvas.style.transform = `rotate(${finalAngle}rad)`;
+            }
+            setTimeout(() => { wheelSpinning = false; showPrize(prize); }, 4000);
+        }
+
+        function showPrize(prize) {
+            if (!prizeDisplay) return;
+            let text = prize.label;
+            if (prize.type === 'life' || prize.type === 'coins' || prize.type === 'gems') {
+                const amount = Math.floor(Math.random() * (prize.max - prize.min + 1)) + prize.min;
+                text = `${prize.type === 'life' ? 'Vida' : prize.type === 'coins' ? 'Monedas' : 'Gemas'} x${amount}`;
+            }
+            prizeDisplay.innerHTML = `<img src="${prize.image}" alt="premio" class="w-8 h-8"><span>${text}</span>`;
+            if (prize.type === 'reroll') {
+                if (spinButton) spinButton.disabled = false;
+                return;
+            }
+            if (prize.type === 'chest') {
+                if (actionButton) {
+                    actionButton.textContent = 'Abrir';
+                    actionButton.classList.remove('hidden');
+                    actionButton.onclick = () => openChest(prize.chestType);
+                }
+            } else {
+                if (actionButton) {
+                    actionButton.textContent = 'Recoger';
+                    actionButton.classList.remove('hidden');
+                    actionButton.onclick = collectPrize;
+                }
+            }
+        }
+
+        function openChest(type) {
+            if (!chestContent || !wheelWrapper) return;
+            const rewards = {
+                common: '50 monedas',
+                rare: '100 monedas y 1 gema',
+                epic: '200 monedas y 3 gemas',
+                legendary: '500 monedas y 5 gemas'
+            };
+            chestContent.textContent = `Has recibido ${rewards[type] || ''}.`;
+            chestContent.classList.remove('hidden');
+            wheelWrapper.classList.add('hidden');
+            if (actionButton) {
+                actionButton.textContent = 'Recoger';
+                actionButton.onclick = collectPrize;
+            }
+        }
+
+        function collectPrize() {
+            if (actionButton) actionButton.classList.add('hidden');
+            if (prizeDisplay) prizeDisplay.innerHTML = '';
+            if (chestContent) chestContent.classList.add('hidden');
+            if (wheelWrapper) wheelWrapper.classList.remove('hidden');
+            if (wheelCanvas) {
+                wheelCanvas.style.transition = 'none';
+                wheelCanvas.style.transform = 'rotate(0deg)';
+            }
+            startWheelCooldown();
+        }
+
+        const WHEEL_COOLDOWN_MS = 4 * 60 * 60 * 1000;
+
+        function startWheelCooldown() {
+            const end = Date.now() + WHEEL_COOLDOWN_MS;
+            localStorage.setItem('snakeWheelCooldown', end.toString());
+            checkWheelCooldown();
+        }
+
+        function getWheelCooldown() {
+            return parseInt(localStorage.getItem('snakeWheelCooldown') || '0', 10);
+        }
+
+        function updateCooldownDisplay() {
+            const end = getWheelCooldown();
+            const now = Date.now();
+            if (now >= end) {
+                if (prizeDisplay) prizeDisplay.textContent = '';
+                if (spinButton) spinButton.disabled = false;
+                if (wheelOverlay) wheelOverlay.classList.add('hidden');
+                return;
+            }
+            if (spinButton) spinButton.disabled = true;
+            if (wheelOverlay) wheelOverlay.classList.remove('hidden');
+            const diff = end - now;
+            const h = String(Math.floor(diff / 3600000)).padStart(2, '0');
+            const m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
+            const s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
+            if (prizeDisplay) prizeDisplay.textContent = `Disponible en ${h}:${m}:${s}`;
+            setTimeout(updateCooldownDisplay, 1000);
+        }
+
+        function checkWheelCooldown() {
+            if (chestContent) chestContent.classList.add('hidden');
+            if (wheelWrapper) wheelWrapper.classList.remove('hidden');
+            if (actionButton) actionButton.classList.add('hidden');
+            drawWheel();
+            const end = getWheelCooldown();
+            if (Date.now() < end) {
+                updateCooldownDisplay();
+            } else {
+                if (prizeDisplay) prizeDisplay.textContent = '';
+                if (wheelOverlay) wheelOverlay.classList.add('hidden');
+                if (spinButton) spinButton.disabled = false;
+                if (wheelCanvas) {
+                    wheelCanvas.style.transition = 'none';
+                    wheelCanvas.style.transform = 'rotate(0deg)';
+                }
+            }
+        }
+
+        if (spinButton) spinButton.addEventListener('click', spinWheel);
 
         window.onload = () => {
             loadSkinImages();

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3398,7 +3398,7 @@
         #wheel-wrapper {
             position: relative;
             border-radius: 50%;
-            box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
+            box-shadow: 0 0 15px rgba(128, 0, 128, 0.5);
         }
         #wheel-pointer {
             position: absolute;
@@ -3409,7 +3409,7 @@
             height: 0;
             border-top: 15px solid transparent;
             border-bottom: 15px solid transparent;
-            border-right: 30px solid red;
+            border-right: 30px solid #8e44ad;
             z-index: 10;
         }
         #wheel-canvas {
@@ -3430,7 +3430,7 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            background-color: rgba(0, 0, 0, 0.5);
+            background-color: rgba(142, 68, 173, 0.5);
             color: white;
             font-size: 1.2rem;
             border-radius: 50%;
@@ -14497,12 +14497,12 @@ async function startGame(isRestart = false) {
                 wheelCtx.moveTo(150, 150);
                 wheelCtx.arc(150, 150, 150, start, start + angle);
                 wheelCtx.closePath();
-                wheelCtx.fillStyle = `hsl(${i * 36},60%,80%)`;
+                wheelCtx.fillStyle = `hsl(${260 + i * 5},60%,80%)`;
                 wheelCtx.fill();
 
                 // thin beveled separator between segments
                 wheelCtx.lineWidth = 3;
-                wheelCtx.strokeStyle = '#222';
+                wheelCtx.strokeStyle = '#4c1a70';
                 wheelCtx.stroke();
                 wheelCtx.lineWidth = 1;
                 wheelCtx.strokeStyle = 'rgba(255,255,255,0.6)';
@@ -14535,7 +14535,7 @@ async function startGame(isRestart = false) {
             wheelCtx.beginPath();
             wheelCtx.arc(150, 150, 150, 0, 2 * Math.PI);
             wheelCtx.lineWidth = 10;
-            wheelCtx.strokeStyle = '#222';
+            wheelCtx.strokeStyle = '#4c1a70';
             wheelCtx.stroke();
             wheelCtx.beginPath();
             wheelCtx.arc(150, 150, 145, 0, 2 * Math.PI);

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3401,7 +3401,7 @@
         #wheel-pointer {
             position: absolute;
             top: 50%;
-            right: -30px;
+            right: -15px;
             transform: translateY(-50%);
             width: 0;
             height: 0;
@@ -14491,17 +14491,23 @@ async function startGame(isRestart = false) {
                 wheelCtx.closePath();
                 wheelCtx.fillStyle = `hsl(${i * 36},70%,50%)`;
                 wheelCtx.fill();
+
+                const mid = start + angle / 2;
+                const r = 120;
+                const x = 150 + r * Math.cos(mid);
+                const y = 150 + r * Math.sin(mid);
+
                 wheelCtx.save();
-                wheelCtx.translate(150, 150);
-                wheelCtx.rotate(start + angle / 2);
+                wheelCtx.translate(x, y);
+                wheelCtx.rotate(mid + Math.PI / 2);
                 if (p.img && p.img.complete) {
-                    wheelCtx.drawImage(p.img, 110, -15, 30, 30);
+                    wheelCtx.drawImage(p.img, -15, -30, 30, 30);
                     if (p.type === 'life' || p.type === 'coins' || p.type === 'gems') {
                         wheelCtx.fillStyle = '#fff';
                         wheelCtx.font = '12px sans-serif';
-                        wheelCtx.textAlign = 'right';
-                        wheelCtx.textBaseline = 'middle';
-                        wheelCtx.fillText(`${p.min}-${p.max}`, 105, 0);
+                        wheelCtx.textAlign = 'center';
+                        wheelCtx.textBaseline = 'top';
+                        wheelCtx.fillText(`${p.min}-${p.max}`, 0, 2);
                     }
                 }
                 wheelCtx.restore();

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -14459,7 +14459,7 @@ async function startGame(isRestart = false) {
             { label: 'Tirar de nuevo', prob: 0.1, type: 'reroll', image: 'https://i.imgur.com/i4m4tSV.png' },
             { label: 'Vida', prob: 0.25, type: 'life', min: 1, max: 5, image: 'https://i.imgur.com/WrI2XXx.png' },
             { label: 'Monedas (10-100)', prob: 0.2, type: 'coins', min: 10, max: 100, image: 'https://i.imgur.com/lnc1Mwu.png' },
-            { label: 'Monedas (100-1000)', prob: 0.1, type: 'coins', min: 100, max: 1000, image: 'https://i.imgur.com/lnc1Mwu.png' },
+            { label: 'Monedas (100-1k)', prob: 0.1, type: 'coins', min: 100, max: 1000, image: 'https://i.imgur.com/lnc1Mwu.png' },
             { label: 'Gemas (1-5)', prob: 0.1, type: 'gems', min: 1, max: 5, image: 'https://i.imgur.com/gPGsaCO.png' },
             { label: 'Gemas (5-10)', prob: 0.05, type: 'gems', min: 5, max: 10, image: 'https://i.imgur.com/gPGsaCO.png' },
             { label: 'Cofre común', prob: 0.1, type: 'chest', chestType: 'common', image: 'https://i.imgur.com/j8UD4hK.png' },
@@ -14497,7 +14497,7 @@ async function startGame(isRestart = false) {
                 wheelCtx.fill();
 
                 const mid = start + angle / 2;
-                const r = 120;
+                const r = 100;
                 const x = 150 + r * Math.cos(mid);
                 const y = 150 + r * Math.sin(mid);
 
@@ -14505,13 +14505,14 @@ async function startGame(isRestart = false) {
                 wheelCtx.translate(x, y);
                 wheelCtx.rotate(mid + Math.PI / 2);
                 if (p.img && p.img.complete) {
-                    wheelCtx.drawImage(p.img, -15, -30, 30, 30);
+                    wheelCtx.drawImage(p.img, -20, -40, 40, 40);
                     if (p.type === 'life' || p.type === 'coins' || p.type === 'gems') {
                         wheelCtx.fillStyle = '#fff';
                         wheelCtx.font = '12px sans-serif';
-                        wheelCtx.textAlign = 'center';
-                        wheelCtx.textBaseline = 'top';
-                        wheelCtx.fillText(`${p.min}-${p.max}`, 0, 2);
+                        wheelCtx.textAlign = 'right';
+                        wheelCtx.textBaseline = 'middle';
+                        const rangeText = `${p.min}-${p.max >= 1000 ? '1k' : p.max}`;
+                        wheelCtx.fillText(rangeText, -25, -20);
                     }
                 }
                 wheelCtx.restore();

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3390,6 +3390,10 @@
             }
         }
 
+        #wheel-area {
+            background: none;
+            border: none;
+        }
         #wheel-wrapper {
             position: relative;
         }
@@ -3407,6 +3411,8 @@
         }
         #wheel-canvas {
             transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
+            background: none;
+            border: none;
         }
         #spin-button:disabled {
             opacity: 0.5;
@@ -14451,9 +14457,9 @@ async function startGame(isRestart = false) {
 
         const wheelAngles = [];
         (function computeAngles() {
+            const angle = (2 * Math.PI) / wheelPrizes.length;
             let start = 0;
             wheelPrizes.forEach(p => {
-                const angle = p.prob * 2 * Math.PI;
                 wheelAngles.push({ start, end: start + angle, prize: p });
                 start += angle;
             });
@@ -14461,9 +14467,9 @@ async function startGame(isRestart = false) {
 
         function drawWheel() {
             if (!wheelCtx) return;
+            const angle = (2 * Math.PI) / wheelPrizes.length;
             let start = 0;
             wheelPrizes.forEach((p, i) => {
-                const angle = p.prob * 2 * Math.PI;
                 wheelCtx.beginPath();
                 wheelCtx.moveTo(150, 150);
                 wheelCtx.arc(150, 150, 150, start, start + angle);

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -7658,7 +7658,15 @@ function setupSlider(slider, display) {
         }
 
         function openGenericMenuPanel(title) {
-            if (genericMenuTitle) genericMenuTitle.textContent = (title || '').toUpperCase();
+            if (genericMenuTitle) {
+                if (title === 'Ruleta de premios') {
+                    genericMenuTitle.classList.add('hidden');
+                    genericMenuTitle.textContent = '';
+                } else {
+                    genericMenuTitle.classList.remove('hidden');
+                    genericMenuTitle.textContent = (title || '').toUpperCase();
+                }
+            }
             const isConfigMenuVisible = !configMenuPanel.classList.contains('config-menu-panel-hidden') && configMenuPanel.classList.contains('panel-visible');
             genericMenuPanel.classList.remove('centered-panel');
             togglePanel(genericMenuPanel, genericMenuPanel.querySelector('.panel-content'), true);
@@ -14532,12 +14540,12 @@ async function startGame(isRestart = false) {
 
         function showPrize(prize) {
             if (!prizeDisplay) return;
-            let text = prize.label;
             if (prize.type === 'life' || prize.type === 'coins' || prize.type === 'gems') {
                 const amount = Math.floor(Math.random() * (prize.max - prize.min + 1)) + prize.min;
-                text = `${prize.type === 'life' ? 'Vida' : prize.type === 'coins' ? 'Monedas' : 'Gemas'} x${amount}`;
+                prizeDisplay.innerHTML = `<span>${amount}</span><img src="${prize.image}" alt="premio" class="w-8 h-8">`;
+            } else {
+                prizeDisplay.innerHTML = `<img src="${prize.image}" alt="premio" class="w-8 h-8"><span>${prize.label}</span>`;
             }
-            prizeDisplay.innerHTML = `<img src="${prize.image}" alt="premio" class="w-8 h-8"><span>${text}</span>`;
             if (prize.type === 'reroll') {
                 if (spinButton) spinButton.disabled = false;
                 return;

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -14486,6 +14486,7 @@ async function startGame(isRestart = false) {
 
         function drawWheel() {
             if (!wheelCtx) return;
+            wheelCtx.clearRect(0, 0, 300, 300);
             const angle = (2 * Math.PI) / wheelPrizes.length;
             let start = 0;
             wheelPrizes.forEach((p, i) => {
@@ -14495,6 +14496,14 @@ async function startGame(isRestart = false) {
                 wheelCtx.closePath();
                 wheelCtx.fillStyle = `hsl(${i * 36},70%,50%)`;
                 wheelCtx.fill();
+
+                // thin beveled separator between segments
+                wheelCtx.lineWidth = 3;
+                wheelCtx.strokeStyle = '#222';
+                wheelCtx.stroke();
+                wheelCtx.lineWidth = 1;
+                wheelCtx.strokeStyle = 'rgba(255,255,255,0.6)';
+                wheelCtx.stroke();
 
                 const mid = start + angle / 2;
                 const r = 100;
@@ -14518,6 +14527,18 @@ async function startGame(isRestart = false) {
                 wheelCtx.restore();
                 start += angle;
             });
+
+            // outer beveled border
+            wheelCtx.beginPath();
+            wheelCtx.arc(150, 150, 150, 0, 2 * Math.PI);
+            wheelCtx.lineWidth = 10;
+            wheelCtx.strokeStyle = '#222';
+            wheelCtx.stroke();
+            wheelCtx.beginPath();
+            wheelCtx.arc(150, 150, 145, 0, 2 * Math.PI);
+            wheelCtx.lineWidth = 5;
+            wheelCtx.strokeStyle = 'rgba(255,255,255,0.6)';
+            wheelCtx.stroke();
         }
 
         function selectPrize() {

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3866,11 +3866,11 @@
                                 <div id="wheel-pointer"></div>
                                 <div id="wheel-overlay" class="hidden">BLOQUEADO</div>
                             </div>
-                            <div id="prize-display" class="flex flex-col items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
                         </div>
-                        <div class="flex items-center justify-center">
+                        <div class="flex items-center justify-center gap-4">
                             <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
+                            <div id="prize-display" class="flex items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>
                     </div>
@@ -14491,8 +14491,9 @@ async function startGame(isRestart = false) {
                     if (p.type === 'life' || p.type === 'coins' || p.type === 'gems') {
                         wheelCtx.fillStyle = '#fff';
                         wheelCtx.font = '12px sans-serif';
-                        wheelCtx.textAlign = 'center';
-                        wheelCtx.fillText(`${p.min}-${p.max}`, 125, 25);
+                        wheelCtx.textAlign = 'right';
+                        wheelCtx.textBaseline = 'middle';
+                        wheelCtx.fillText(`${p.min}-${p.max}`, 105, 0);
                     }
                 }
                 wheelCtx.restore();

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -14509,10 +14509,10 @@ async function startGame(isRestart = false) {
                     if (p.type === 'life' || p.type === 'coins' || p.type === 'gems') {
                         wheelCtx.fillStyle = '#fff';
                         wheelCtx.font = '12px sans-serif';
-                        wheelCtx.textAlign = 'right';
-                        wheelCtx.textBaseline = 'middle';
+                        wheelCtx.textAlign = 'center';
+                        wheelCtx.textBaseline = 'top';
                         const rangeText = `${p.min}-${p.max >= 1000 ? '1k' : p.max}`;
-                        wheelCtx.fillText(rangeText, -25, -20);
+                        wheelCtx.fillText(rangeText, 0, 5);
                     }
                 }
                 wheelCtx.restore();

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3397,6 +3397,8 @@
         }
         #wheel-wrapper {
             position: relative;
+            border-radius: 50%;
+            box-shadow: 0 0 15px rgba(0, 0, 0, 0.5);
         }
         #wheel-pointer {
             position: absolute;
@@ -3414,6 +3416,7 @@
             transition: transform 4s cubic-bezier(0.33, 1, 0.68, 1);
             background: none;
             border: none;
+            border-radius: 50%;
         }
         #spin-button:disabled {
             opacity: 0.5;
@@ -14494,7 +14497,7 @@ async function startGame(isRestart = false) {
                 wheelCtx.moveTo(150, 150);
                 wheelCtx.arc(150, 150, 150, start, start + angle);
                 wheelCtx.closePath();
-                wheelCtx.fillStyle = `hsl(${i * 36},70%,50%)`;
+                wheelCtx.fillStyle = `hsl(${i * 36},60%,80%)`;
                 wheelCtx.fill();
 
                 // thin beveled separator between segments

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3393,20 +3393,21 @@
         #wheel-area {
             background: none;
             border: none;
+            gap: 1rem;
         }
         #wheel-wrapper {
             position: relative;
         }
         #wheel-pointer {
             position: absolute;
-            top: -10px;
-            left: 50%;
-            transform: translateX(-50%);
+            top: 50%;
+            right: -30px;
+            transform: translateY(-50%);
             width: 0;
             height: 0;
-            border-left: 15px solid transparent;
-            border-right: 15px solid transparent;
-            border-bottom: 30px solid red;
+            border-top: 15px solid transparent;
+            border-bottom: 15px solid transparent;
+            border-right: 30px solid red;
             z-index: 10;
         }
         #wheel-canvas {
@@ -3859,17 +3860,17 @@
                 </div>
                 <div class="panel-content">
                     <div id="wheel-container" class="flex flex-col items-center gap-4">
-                        <div id="wheel-area" class="flex items-center justify-center">
+                        <div id="wheel-area" class="flex items-center justify-center gap-4">
                             <div id="wheel-wrapper">
                                 <canvas id="wheel-canvas" width="300" height="300"></canvas>
                                 <div id="wheel-pointer"></div>
                                 <div id="wheel-overlay" class="hidden">BLOQUEADO</div>
                             </div>
+                            <div id="prize-display" class="flex flex-col items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
                         </div>
-                        <div class="flex items-center gap-4">
+                        <div class="flex items-center justify-center">
                             <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
-                            <div id="prize-display" class="flex items-center gap-2 min-w-[160px] min-h-[48px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>
                     </div>
@@ -14455,6 +14456,12 @@ async function startGame(isRestart = false) {
             { label: 'Cofre legendario', prob: 0.01, type: 'chest', chestType: 'legendary', image: 'https://i.imgur.com/4kOPIdx.png' }
         ];
 
+        wheelPrizes.forEach(p => {
+            const img = new Image();
+            img.src = p.image;
+            p.img = img;
+        });
+
         const wheelAngles = [];
         (function computeAngles() {
             const angle = (2 * Math.PI) / wheelPrizes.length;
@@ -14479,10 +14486,15 @@ async function startGame(isRestart = false) {
                 wheelCtx.save();
                 wheelCtx.translate(150, 150);
                 wheelCtx.rotate(start + angle / 2);
-                wheelCtx.textAlign = 'right';
-                wheelCtx.fillStyle = '#fff';
-                wheelCtx.font = '12px sans-serif';
-                wheelCtx.fillText(p.label, 140, 5);
+                if (p.img && p.img.complete) {
+                    wheelCtx.drawImage(p.img, 110, -15, 30, 30);
+                    if (p.type === 'life' || p.type === 'coins' || p.type === 'gems') {
+                        wheelCtx.fillStyle = '#fff';
+                        wheelCtx.font = '12px sans-serif';
+                        wheelCtx.textAlign = 'center';
+                        wheelCtx.fillText(`${p.min}-${p.max}`, 125, 25);
+                    }
+                }
                 wheelCtx.restore();
                 start += angle;
             });
@@ -14509,7 +14521,7 @@ async function startGame(isRestart = false) {
             const seg = wheelAngles.find(a => a.prize === prize);
             const center = (seg.start + seg.end) / 2;
             const extra = 2 * Math.PI * 5;
-            const finalAngle = extra + (Math.PI * 1.5 - center);
+            const finalAngle = extra - center;
             if (wheelCanvas) {
                 wheelCanvas.style.transition = 'transform 4s cubic-bezier(0.33,1,0.68,1)';
                 wheelCanvas.style.transform = `rotate(${finalAngle}rad)`;
@@ -14555,6 +14567,7 @@ async function startGame(isRestart = false) {
             chestContent.textContent = `Has recibido ${rewards[type] || ''}.`;
             chestContent.classList.remove('hidden');
             wheelWrapper.classList.add('hidden');
+            if (prizeDisplay) prizeDisplay.classList.add('hidden');
             if (actionButton) {
                 actionButton.textContent = 'Recoger';
                 actionButton.onclick = collectPrize;
@@ -14563,7 +14576,10 @@ async function startGame(isRestart = false) {
 
         function collectPrize() {
             if (actionButton) actionButton.classList.add('hidden');
-            if (prizeDisplay) prizeDisplay.innerHTML = '';
+            if (prizeDisplay) {
+                prizeDisplay.innerHTML = '';
+                prizeDisplay.classList.remove('hidden');
+            }
             if (chestContent) chestContent.classList.add('hidden');
             if (wheelWrapper) wheelWrapper.classList.remove('hidden');
             if (wheelCanvas) {
@@ -14613,7 +14629,10 @@ async function startGame(isRestart = false) {
             if (Date.now() < end) {
                 updateCooldownDisplay();
             } else {
-                if (prizeDisplay) prizeDisplay.textContent = '';
+                if (prizeDisplay) {
+                    prizeDisplay.textContent = '';
+                    prizeDisplay.classList.remove('hidden');
+                }
                 if (wheelOverlay) wheelOverlay.classList.add('hidden');
                 if (spinButton) spinButton.disabled = false;
                 if (wheelCanvas) {

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3422,12 +3422,16 @@
         #wheel-overlay {
             position: absolute;
             inset: 0;
+            width: 100%;
+            height: 100%;
             display: flex;
             align-items: center;
             justify-content: center;
             background-color: rgba(0, 0, 0, 0.5);
             color: white;
             font-size: 1.2rem;
+            border-radius: 50%;
+            pointer-events: none;
         }
 
     </style>
@@ -14622,7 +14626,10 @@ async function startGame(isRestart = false) {
             if (now >= end) {
                 if (prizeDisplay) prizeDisplay.textContent = '';
                 if (spinButton) spinButton.disabled = false;
-                if (wheelOverlay) wheelOverlay.classList.add('hidden');
+                if (wheelOverlay) {
+                    wheelOverlay.classList.add('hidden');
+                    wheelOverlay.textContent = 'BLOQUEADO';
+                }
                 return;
             }
             if (spinButton) spinButton.disabled = true;
@@ -14631,7 +14638,8 @@ async function startGame(isRestart = false) {
             const h = String(Math.floor(diff / 3600000)).padStart(2, '0');
             const m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
             const s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
-            if (prizeDisplay) prizeDisplay.textContent = `Disponible en ${h}:${m}:${s}`;
+            if (prizeDisplay) prizeDisplay.textContent = '';
+            if (wheelOverlay) wheelOverlay.textContent = `Disponible en ${h}:${m}:${s}`;
             setTimeout(updateCooldownDisplay, 1000);
         }
 
@@ -14648,7 +14656,10 @@ async function startGame(isRestart = false) {
                     prizeDisplay.textContent = '';
                     prizeDisplay.classList.remove('hidden');
                 }
-                if (wheelOverlay) wheelOverlay.classList.add('hidden');
+                if (wheelOverlay) {
+                    wheelOverlay.classList.add('hidden');
+                    wheelOverlay.textContent = 'BLOQUEADO';
+                }
                 if (spinButton) spinButton.disabled = false;
                 if (wheelCanvas) {
                     wheelCanvas.style.transition = 'none';


### PR DESCRIPTION
## Summary
- integrate a daily prize wheel submenu with spin button and prize display
- style wheel, pointer, and overlay within the main game HTML
- implement weighted rewards, chest handling, and 4‑hour cooldown persistence

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689b22f6597c8333b4fd90d83a2ca7b2