### PR TITLE
feat: add arcade-style spin button

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3418,9 +3418,43 @@
             border: none;
             border-radius: 50%;
         }
+        .spin-button-wrapper {
+            position: relative;
+            width: 120px;
+            height: 120px;
+        }
+        .arcade-ring {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+        }
+        #spin-button {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+            padding: 0;
+            background: none;
+            cursor: pointer;
+        }
+        #spin-button img {
+            width: 100%;
+            height: 100%;
+            transition: transform 0.1s;
+        }
+        #spin-button:active img {
+            transform: translateY(4px);
+        }
         #spin-button:disabled {
-            opacity: 0.5;
             cursor: not-allowed;
+        }
+        #spin-button:disabled img {
+            opacity: 0.5;
         }
         #wheel-overlay {
             position: absolute;
@@ -3876,7 +3910,12 @@
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
                         </div>
                         <div class="flex items-center justify-center gap-4">
-                            <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
+                            <div class="spin-button-wrapper">
+                                <img src="https://i.imgur.com/9lVaEyu.png" alt="" class="arcade-ring">
+                                <button id="spin-button" aria-label="Girar">
+                                    <img src="https://i.imgur.com/kVwIN0b.png" alt="">
+                                </button>
+                            </div>
                             <div id="prize-display" class="flex items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>


### PR DESCRIPTION
## Summary
- replace text spin button with arcade-style button overlay and ring
- add CSS for arcade button layout and press animation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c85fc238483339f176f532c44d664