### PR TITLE
feat: add arcade-style spin button

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3418,6 +3418,35 @@
             border: none;
             border-radius: 50%;
         }
+        #spin-button-container {
+            position: relative;
+            display: inline-block;
+        }
+        #spin-button-container > img {
+            display: block;
+            pointer-events: none;
+            user-select: none;
+        }
+        #spin-button {
+            position: absolute;
+            inset: 0;
+            background: none;
+            border: none;
+            padding: 0;
+            cursor: pointer;
+            transition: transform 0.05s ease-out, filter 0.05s ease-out;
+        }
+        #spin-button img {
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+            user-select: none;
+            display: block;
+        }
+        #spin-button:active {
+            transform: scale(0.9);
+            filter: brightness(0.8);
+        }
         #spin-button:disabled {
             opacity: 0.5;
             cursor: not-allowed;
@@ -3876,7 +3905,12 @@
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
                         </div>
                         <div class="flex items-center justify-center gap-4">
-                            <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
+                            <div id="spin-button-container">
+                                <img src="https://i.imgur.com/9lVaEyu.png" alt="">
+                                <button id="spin-button" aria-label="Girar">
+                                    <img src="https://i.imgur.com/kVwIN0b.png" alt="Girar">
+                                </button>
+                            </div>
                             <div id="prize-display" class="flex items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>


### PR DESCRIPTION
## Summary
- Replace the text-based spin button with an arcade-style button superimposed on a ring
- Add press animation and disable state styling for the new button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c85fc238483339f176f532c44d664