### PR TITLE
Replace spin button with arcade arcade style

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3418,9 +3418,38 @@
             border: none;
             border-radius: 50%;
         }
+        #spin-button-container {
+            position: relative;
+            width: 80px;
+            height: 80px;
+        }
+        #spin-button-container .arcade-ring {
+            width: 100%;
+            height: 100%;
+            display: block;
+            pointer-events: none;
+        }
+        #spin-button {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 60%;
+            height: 60%;
+            transform: translate(-50%, -50%);
+            background: url('https://i.imgur.com/kVwIN0b.png') center/contain no-repeat;
+            border: none;
+            padding: 0;
+            border-radius: 50%;
+            cursor: pointer;
+            transition: transform 0.1s;
+        }
         #spin-button:disabled {
             opacity: 0.5;
             cursor: not-allowed;
+        }
+        #spin-button:active:not(:disabled),
+        #spin-button.icon-button-pressed {
+            transform: translate(-50%, -50%) scale(0.90);
         }
         #wheel-overlay {
             position: absolute;
@@ -3876,7 +3905,10 @@
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
                         </div>
                         <div class="flex items-center justify-center gap-4">
-                            <button id="spin-button" class="bg-red-600 text-white px-4 py-2 rounded">Girar</button>
+                            <div id="spin-button-container">
+                                <img src="https://i.imgur.com/9lVaEyu.png" alt="" class="arcade-ring">
+                                <button id="spin-button" aria-label="Girar"></button>
+                            </div>
                             <div id="prize-display" class="flex items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>
@@ -14133,8 +14165,9 @@ async function startGame(isRestart = false) {
         addIconPressEvents(closeAchievementsPanelButton, closeAchievementsPanelButton);
         addIconPressEvents(closeOutOfLivesPanelButton, closeOutOfLivesPanelButton);
         addIconPressEvents(getLivesStoreButton, getLivesStoreButton);
+        addIconPressEvents(spinButton, spinButton);
 
-        // Original click listeners for D-Pad 
+        // Original click listeners for D-Pad
         upButton.addEventListener("click", () => changeDirection("up"));
         downButton.addEventListener("click", () => changeDirection("down"));
         leftButton.addEventListener("click", () => changeDirection("left"));


### PR DESCRIPTION
## Summary
- Add arcade-style spin button using provided images and proper overlay
- Implement press animation and integrate with existing event handler

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689c85fc238483339f176f532c44d664