### PR TITLE
Add central wheel button and prize overlay

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3420,38 +3420,54 @@
         }
         #spin-button {
             position: absolute;
-            bottom: -50px;
-            left: -50px;
+            top: 50%;
+            left: 50%;
             width: 90px;
             height: 90px;
             border: none;
             padding: 0;
             background: none;
             cursor: pointer;
+            transform: translate(-50%, -50%);
+            transition: transform 0.05s ease-out, filter 0.05s ease-out;
         }
         #spin-button img {
-            position: absolute;
-            top: 0;
-            left: 0;
             width: 100%;
             height: 100%;
             pointer-events: none;
         }
-        #spin-button .button-face {
-            width: 80%;
-            height: 80%;
-            top: 10%;
-            left: 10%;
-            z-index: 1;
-            transition: transform 0.1s;
-            transform-origin: center;
-        }
-        #spin-button:active .button-face {
-            transform: scale(0.95);
+        #spin-button.icon-button-pressed {
+            filter: brightness(0.5);
+            transform: translate(-50%, -50%) scale(0.95);
         }
         #spin-button:disabled {
             opacity: 0.5;
             cursor: not-allowed;
+        }
+        #prize-star {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135px;
+            height: 135px;
+            transform: translate(-50%, -50%);
+            pointer-events: none;
+            z-index: 20;
+        }
+        #prize-display {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 135px;
+            height: 135px;
+            transform: translate(-50%, -50%);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            pointer-events: none;
+            z-index: 21;
         }
         #wheel-overlay {
             position: absolute;
@@ -3903,15 +3919,13 @@
                                 <canvas id="wheel-canvas" width="300" height="300"></canvas>
                                 <div id="wheel-pointer"></div>
                                 <button id="spin-button" aria-label="Girar">
-                                    <img src="https://i.imgur.com/9lVaEyu.png" alt="" onerror="this.src='https://placehold.co/90x90/000000/FFFFFF?text=Aro'; console.error('Error loading spin-button ring');" />
-                                    <img src="https://i.imgur.com/kVwIN0b.png" alt="" class="button-face" onerror="this.src='https://placehold.co/72x72/000000/FFFFFF?text=Boton'; console.error('Error loading spin-button face');" />
+                                    <img src="https://i.imgur.com/Iv0kEE6.png" alt="Girar" onerror="this.src='https://placehold.co/90x90/000000/FFFFFF?text=Spin'; console.error('Error loading spin button');" />
                                 </button>
+                                <img id="prize-star" src="https://i.imgur.com/MGECRJe.png" alt="" class="hidden" onerror="this.src='https://placehold.co/135x135/000000/FFFFFF?text=Premio'; console.error('Error loading prize star');" />
+                                <div id="prize-display" class="hidden"></div>
                                 <div id="wheel-overlay" class="hidden">BLOQUEADO</div>
                             </div>
                             <div id="chest-content" class="hidden flex flex-col items-center"></div>
-                        </div>
-                        <div class="flex items-center justify-center gap-4">
-                            <div id="prize-display" class="flex items-center gap-2 min-w-[120px] min-h-[60px] justify-center text-center"></div>
                         </div>
                         <button id="action-button" class="bg-blue-600 text-white px-4 py-2 rounded hidden"></button>
                     </div>
@@ -4392,6 +4406,7 @@
         const wheelCtx = wheelCanvas ? wheelCanvas.getContext("2d") : null;
         const spinButton = document.getElementById("spin-button");
         const prizeDisplay = document.getElementById("prize-display");
+        const prizeStar = document.getElementById("prize-star");
         const actionButton = document.getElementById("action-button");
         const wheelOverlay = document.getElementById("wheel-overlay");
         const wheelWrapper = document.getElementById("wheel-wrapper");
@@ -14149,6 +14164,7 @@ async function startGame(isRestart = false) {
         addIconPressEvents(chestInfoButton, chestInfoButton);
         addIconPressEvents(chestInfoCloseButton, chestInfoCloseButton);
         addIconPressEvents(collectPurchaseRewardButton, collectPurchaseRewardButton);
+        addIconPressEvents(spinButton, spinButton);
         addIconPressEvents(confirmDeleteYesButton, confirmDeleteYesButton);
         addIconPressEvents(confirmDeleteNoButton, confirmDeleteNoButton);
         addIconPressEvents(confirmSelectYesButton, confirmSelectYesButton);
@@ -14595,6 +14611,11 @@ async function startGame(isRestart = false) {
             if (wheelSpinning) return;
             const cooldown = getWheelCooldown();
             if (Date.now() < cooldown) return;
+            if (prizeDisplay) {
+                prizeDisplay.classList.add('hidden');
+                prizeDisplay.innerHTML = '';
+            }
+            if (prizeStar) prizeStar.classList.add('hidden');
             wheelSpinning = true;
             if (spinButton) spinButton.disabled = true;
             const prize = selectPrize();
@@ -14611,6 +14632,8 @@ async function startGame(isRestart = false) {
 
         function showPrize(prize) {
             if (!prizeDisplay) return;
+            prizeDisplay.classList.remove('hidden');
+            if (prizeStar) prizeStar.classList.remove('hidden');
             if (prize.type === 'life' || prize.type === 'coins' || prize.type === 'gems') {
                 const amount = Math.floor(Math.random() * (prize.max - prize.min + 1)) + prize.min;
                 prizeDisplay.innerHTML = `<span>${amount}</span><img src="${prize.image}" alt="premio" class="w-8 h-8">`;
@@ -14619,6 +14642,8 @@ async function startGame(isRestart = false) {
             }
             if (prize.type === 'reroll') {
                 if (spinButton) spinButton.disabled = false;
+                if (prizeStar) prizeStar.classList.add('hidden');
+                prizeDisplay.classList.add('hidden');
                 return;
             }
             if (prize.type === 'chest') {
@@ -14648,6 +14673,7 @@ async function startGame(isRestart = false) {
             chestContent.classList.remove('hidden');
             wheelWrapper.classList.add('hidden');
             if (prizeDisplay) prizeDisplay.classList.add('hidden');
+            if (prizeStar) prizeStar.classList.add('hidden');
             if (actionButton) {
                 actionButton.textContent = 'Recoger';
                 actionButton.onclick = collectPrize;
@@ -14658,8 +14684,9 @@ async function startGame(isRestart = false) {
             if (actionButton) actionButton.classList.add('hidden');
             if (prizeDisplay) {
                 prizeDisplay.innerHTML = '';
-                prizeDisplay.classList.remove('hidden');
+                prizeDisplay.classList.add('hidden');
             }
+            if (prizeStar) prizeStar.classList.add('hidden');
             if (chestContent) chestContent.classList.add('hidden');
             if (wheelWrapper) wheelWrapper.classList.remove('hidden');
             if (wheelCanvas) {
@@ -14685,7 +14712,11 @@ async function startGame(isRestart = false) {
             const end = getWheelCooldown();
             const now = Date.now();
             if (now >= end) {
-                if (prizeDisplay) prizeDisplay.textContent = '';
+                if (prizeDisplay) {
+                    prizeDisplay.textContent = '';
+                    prizeDisplay.classList.add('hidden');
+                }
+                if (prizeStar) prizeStar.classList.add('hidden');
                 if (spinButton) spinButton.disabled = false;
                 if (wheelOverlay) {
                     wheelOverlay.classList.add('hidden');
@@ -14699,7 +14730,11 @@ async function startGame(isRestart = false) {
             const h = String(Math.floor(diff / 3600000)).padStart(2, '0');
             const m = String(Math.floor((diff % 3600000) / 60000)).padStart(2, '0');
             const s = String(Math.floor((diff % 60000) / 1000)).padStart(2, '0');
-            if (prizeDisplay) prizeDisplay.textContent = '';
+            if (prizeDisplay) {
+                prizeDisplay.textContent = '';
+                prizeDisplay.classList.add('hidden');
+            }
+            if (prizeStar) prizeStar.classList.add('hidden');
             if (wheelOverlay) wheelOverlay.textContent = `Disponible en ${h}:${m}:${s}`;
             setTimeout(updateCooldownDisplay, 1000);
         }
@@ -14708,6 +14743,7 @@ async function startGame(isRestart = false) {
             if (chestContent) chestContent.classList.add('hidden');
             if (wheelWrapper) wheelWrapper.classList.remove('hidden');
             if (actionButton) actionButton.classList.add('hidden');
+            if (prizeStar) prizeStar.classList.add('hidden');
             drawWheel();
             const end = getWheelCooldown();
             if (Date.now() < end) {
@@ -14715,7 +14751,7 @@ async function startGame(isRestart = false) {
             } else {
                 if (prizeDisplay) {
                     prizeDisplay.textContent = '';
-                    prizeDisplay.classList.remove('hidden');
+                    prizeDisplay.classList.add('hidden');
                 }
                 if (wheelOverlay) {
                     wheelOverlay.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Replace wheel spin button with a single image and center it on the wheel
- Add prize star overlay that shows rewards above the button after spinning
- Integrate press effect and hide overlay when prize is collected

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/juegoseducativos/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_689c9962fe14833395cfe5a444c3eeb5