### PR TITLE
Make game container responsive to viewport

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -8,17 +8,6 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.js"></script>
     <style>
-        /* Variable de ancho máximo para sincronizar Splash y juego */
-        :root {
-            --game-max-width: 520px;
-        }
-
-        @media (hover: hover) and (pointer: fine) {
-            :root {
-                --game-max-width: min(75vmin, 700px);
-            }
-        }
-
         /* Estilos base del cuerpo y contenedor del juego */
         html {
             height: 100%;
@@ -62,9 +51,10 @@
         }
 
         #splash-content {
-            width: 100%;
-            max-width: var(--game-max-width);
-            height: 100%;
+            width: 95vw;
+            height: 95vh;
+            max-width: 95vw;
+            max-height: 95vh;
             display: flex;
             background-color: #02010a;
             background-image: url(https://i.imgur.com/rYyiiMo.png);
@@ -83,7 +73,7 @@
 
         #splash-top-image {
             width: 95%;
-            max-width: var(--game-max-width); /* Límite para PC, un poco más grande que el juego */
+            max-width: 95vw; /* Límite para PC, un poco más grande que el juego */
             height: auto;
             object-fit: contain;
             box-sizing: border-box;
@@ -136,7 +126,7 @@
 
         #splash-bottom-image {
             width: 100%;
-            max-width: var(--game-max-width); /* Límite para PC, un poco más grande que el juego */
+            max-width: 95vw; /* Límite para PC, un poco más grande que el juego */
             height: auto;
             max-height: calc(25vh + 60px);
             object-fit: contain;
@@ -155,10 +145,11 @@
             padding-bottom: calc(10px + env(safe-area-inset-bottom));
             border-radius: 12px;
             box-shadow: 0 8px 16px rgba(0,0,0,0.3);
-            width: 100%;
-            max-width: var(--game-max-width);
+            width: 95vw;
+            height: 95vh;
+            max-width: 95vw;
+            max-height: 95vh;
             box-sizing: border-box;
-            height: 100%;
             display: flex;
             flex-direction: column;
         }
@@ -1637,8 +1628,8 @@
                 inset 0 4px 6px #D6BCE9,
                 0 2px 0 #422E58;
             z-index: 2100;
-            width: 100%;
-            max-width: var(--game-max-width);
+            width: 95vw;
+            max-width: 95vw;
             display: flex;
             flex-direction: column;
             gap: 10px;


### PR DESCRIPTION
## Summary
- Size splash and game containers to 95% of the viewport for consistent responsiveness
- Set UI panels to use viewport width for uniform scaling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689d9afe81f48333bd3dee32163399a6