### PR TITLE
Ampliar imagen de resultados de la ruleta

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3495,8 +3495,8 @@
             position: absolute;
             top: calc(50% - 30px);
             left: 50%;
-            width: 158px;
-            height: 158px;
+            width: 200px;
+            height: 200px;
             transform: translate(-50%, -50%);
             pointer-events: none;
             z-index: 10;
@@ -3515,7 +3515,7 @@
         }
         #action-button {
             position: absolute;
-            top: calc(50% + 55px);
+            top: calc(50% + 76px);
             left: 50%;
             transform: translateX(-50%);
             width: 60%;


### PR DESCRIPTION
## Summary
- Aumenta a 200px la imagen donde se muestra el premio de la ruleta
- Ajusta la posición vertical del botón de acción para respetar el nuevo tamaño

## Testing
- `npm test` *(falla: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689df4ec4e6c8333abb87059a71e6c2d