### PR TITLE
Reduce booster image size in store and profile

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3007,8 +3007,8 @@
           top: 45%;
         }
         .store-item-img.booster-img {
-          width: 70%;
-          height: 70%;
+          width: 60%;
+          height: 60%;
           top: 45%;
         }
         .booster-preview-img {


### PR DESCRIPTION
## Summary
- Decrease booster image width/height from 70% to 60% to reduce visual size in store and profile.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/juegoseducativos/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_689ea313a298833388719cb1d5291173