### PR TITLE
Add left-aligned icons to config menu buttons

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1614,6 +1614,22 @@
         .menu-option-button:hover { filter: brightness(0.95); }
         .menu-option-button:disabled { filter: brightness(0.6); cursor: not-allowed; }
         .menu-option-button.icon-button-pressed { filter: brightness(0.5); }
+        .menu-option-button.with-icon {
+            overflow: visible;
+            margin-left: -40px;
+            width: calc(100% + 40px);
+            padding-left: 40px;
+        }
+        .menu-option-button.with-icon .menu-button-icon {
+            position: absolute;
+            left: 0;
+            top: 50%;
+            width: 80px;
+            height: 80px;
+            transform: translateY(-50%);
+            z-index: 1;
+            pointer-events: none;
+        }
         .config-svg,
         .info-svg {
             height: 100%;
@@ -3992,11 +4008,26 @@
                     </button>
                 </div>
                 <div class="panel-content">
-                    <button class="menu-option-button" id="profile-menu-button">PERFIL</button>
-                    <button class="menu-option-button" id="store-menu-button">TIENDA</button>
-                    <button class="menu-option-button" id="achievements-menu-button">LOGROS</button>
-                    <button class="menu-option-button" id="daily-menu-button">PREMIOS DIARIOS</button>
-                    <button class="menu-option-button" id="wheel-menu-button">RULETA DE PREMIOS</button>
+                    <button class="menu-option-button with-icon" id="profile-menu-button">
+                        <img src="https://i.imgur.com/gxm0Ks4.png" alt="Perfil" class="menu-button-icon">
+                        PERFIL
+                    </button>
+                    <button class="menu-option-button with-icon" id="store-menu-button">
+                        <img src="https://i.imgur.com/9HHOgFe.png" alt="Tienda" class="menu-button-icon">
+                        TIENDA
+                    </button>
+                    <button class="menu-option-button with-icon" id="achievements-menu-button">
+                        <img src="https://i.imgur.com/Pq7mnkw.png" alt="Logros" class="menu-button-icon">
+                        LOGROS
+                    </button>
+                    <button class="menu-option-button with-icon" id="daily-menu-button">
+                        <img src="https://i.imgur.com/Dbe7XRx.png" alt="Premios diarios" class="menu-button-icon">
+                        PREMIOS DIARIOS
+                    </button>
+                    <button class="menu-option-button with-icon" id="wheel-menu-button">
+                        <img src="https://i.imgur.com/6V33A20.png" alt="Ruleta de premios" class="menu-button-icon">
+                        RULETA DE PREMIOS
+                    </button>
                 </div>
             </div>
             <div id="generic-menu-panel" class="generic-menu-panel-hidden">
@@ -14472,8 +14503,13 @@ async function startGame(isRestart = false) {
         addIconPressEvents(closeAchievementsPanelButton, closeAchievementsPanelButton);
         addIconPressEvents(closeOutOfLivesPanelButton, closeOutOfLivesPanelButton);
         addIconPressEvents(getLivesStoreButton, getLivesStoreButton);
+        addIconPressEvents(profileMenuButton, profileMenuButton);
+        addIconPressEvents(storeMenuButton, storeMenuButton);
+        addIconPressEvents(achievementsMenuButton, achievementsMenuButton);
+        addIconPressEvents(dailyMenuButton, dailyMenuButton);
+        addIconPressEvents(wheelMenuButton, wheelMenuButton);
 
-        // Original click listeners for D-Pad 
+        // Original click listeners for D-Pad
         upButton.addEventListener("click", () => changeDirection("up"));
         downButton.addEventListener("click", () => changeDirection("down"));
         leftButton.addEventListener("click", () => changeDirection("left"));

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1616,9 +1616,9 @@
         .menu-option-button.icon-button-pressed { filter: brightness(0.5); }
         .menu-option-button.with-icon {
             overflow: visible;
-            margin-left: -40px;
-            width: calc(100% + 40px);
-            padding-left: 40px;
+            margin-left: -15px;
+            width: calc(100% + 15px);
+            padding-left: 90px;
         }
         .menu-option-button.with-icon .menu-button-icon {
             position: absolute;
@@ -1672,6 +1672,12 @@
             padding-right: 0;
         }
         .scroll-padding { padding-right: 4px; }
+
+        #config-menu-panel .panel-content {
+            padding-top: 15px;
+            padding-bottom: 15px;
+            gap: 20px;
+        }
 
         #store-panel {
             max-height: 90vh;

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1616,9 +1616,11 @@
         .menu-option-button.icon-button-pressed { filter: brightness(0.5); }
         .menu-option-button.with-icon {
             overflow: visible;
-            margin-left: -15px;
-            width: calc(100% + 15px);
-            padding-left: 90px;
+            padding-left: 110px;
+        }
+        .menu-option-button.with-icon::after {
+            left: 40px;
+            width: calc(100% - 40px);
         }
         .menu-option-button.with-icon .menu-button-icon {
             position: absolute;


### PR DESCRIPTION
## Summary
- overlay circular icons for profile, store, achievements, daily rewards and prize wheel menu entries
- treat icon and label as one button using existing press animation

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ecdd0fbd083338b2f8450e277465c