### PR TITLE
Center menu buttons with reduced width

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1620,8 +1620,8 @@
             padding-left: calc(90px + 1rem);
         }
         .menu-option-button {
-            left: 15px;
-            width: calc(100% - 15px);
+            width: 80%;
+            margin: 0 auto;
         }
         .menu-option-button.with-icon .menu-button-icon {
             position: absolute;
@@ -1636,8 +1636,8 @@
 
         @media screen and (max-width: 600px) {
             .menu-option-button {
-                left: 15px;
-                width: calc(100% - 15px);
+                width: 90%;
+                margin: 0 auto;
             }
             .menu-option-button.with-icon {
                 padding-left: calc(60px + 1rem);

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -1625,7 +1625,7 @@
         }
         .menu-option-button.with-icon .menu-button-icon {
             position: absolute;
-            left: -15px;
+            left: 10px;
             top: 50%;
             width: 80px;
             height: 80px;
@@ -1643,7 +1643,7 @@
                 padding-left: calc(60px + 1rem);
             }
             .menu-option-button.with-icon .menu-button-icon {
-                left: -15px;
+                left: 5px;
                 width: 55px;
                 height: 55px;
             }


### PR DESCRIPTION
## Summary
- Reduce main menu button width and center them horizontally
- Adjust responsive styles for small screens

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689ee03ae4a08333bdf8eba2a84860b8