### PR TITLE
Aumenta y centra el texto RECOGER en la ruleta

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2544,6 +2544,9 @@
                 1px -1px 0 #D0B5E2,
                 -1px  1px 0 #D0B5E2,
                 1px  1px 0 #D0B5E2;
+            font-size: 1.25em;
+            justify-content: center;
+            text-align: center;
         }
         #confirmResetYes::before,
         #confirmResetNo::before {
@@ -4295,7 +4298,7 @@
                     <div class="reset-buttons">
                         <button id="confirmPurchaseYes">SI</button>
                         <button id="confirmPurchaseNo">NO</button>
-                        <button id="collectPurchaseReward" class="menu-option-button hidden"> RECOGER</button>
+                        <button id="collectPurchaseReward" class="menu-option-button hidden">RECOGER</button>
                     </div>
                 </div>
             </div>

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2548,6 +2548,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            text-align: center;
+            width: auto;
         }
         #confirmResetYes::before,
         #confirmResetNo::before {

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -2545,8 +2545,9 @@
                 -1px  1px 0 #D0B5E2,
                 1px  1px 0 #D0B5E2;
             font-size: 1.25em;
+            display: flex;
+            align-items: center;
             justify-content: center;
-            text-align: center;
         }
         #confirmResetYes::before,
         #confirmResetNo::before {


### PR DESCRIPTION
## Summary
- Agranda el texto del botón **RECOGER** de la ruleta y lo centra
- Corrige el espacio inicial en el contenido del botón para evitar desplazamientos

## Testing
- `npm test` *(falla: no se encontró package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f51a120908333b41569e0bd8c2e5b