### PR TITLE
Ajustar tamaño y espacio de pestañas en menús

### DIFF
--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3234,11 +3234,11 @@
         .store-tab {
           font-family: 'Press Start 2P', sans-serif;
           font-size: 0.7rem;
-          padding: 4px 6px;
+          padding: 2px 4px;
           width: auto;
           height: auto;
-          min-width: 50px;
-          min-height: 50px;
+          min-width: 32px;
+          min-height: 32px;
         }
 
         .store-tab.active {
@@ -4116,7 +4116,7 @@
         </button>
     </div>
     <div class="panel-content">
-        <div id="profile-tabs" class="flex gap-2 mb-2">
+        <div id="profile-tabs" class="flex gap-1 mb-2">
             <button data-tab="general" id="profile-tab-general" class="store-tab menu-option-button active">PERFIL</button>
             <button data-tab="boosters" id="profile-tab-boosters" class="store-tab menu-option-button">
                 <img src="https://i.imgur.com/XsL7DwS.png" alt="Boosters">
@@ -4234,7 +4234,7 @@
                     </button>
                 </div>
                 <div class="panel-content">
-                    <div id="store-tabs" class="flex gap-1 mb-2">
+                    <div id="store-tabs" class="flex gap-0.5 mb-2">
                         <button data-tab="cofres" id="store-tab-cofres" class="store-tab menu-option-button active">
                             <img src="https://i.imgur.com/xXEFTFT.png" alt="Cofres">
                         </button>

--- a/Snake Github.html
+++ b/Snake Github.html
@@ -3247,9 +3247,20 @@
         }
 
         .store-tab img {
-          height: 32px;
+          height: 28px;
           width: auto;
           pointer-events: none;
+        }
+
+        #profile-tabs .store-tab {
+          font-size: 0.8rem;
+          padding: 4px 6px;
+          min-width: 40px;
+          min-height: 40px;
+        }
+
+        #profile-tabs .store-tab img {
+          height: 36px;
         }
 
         #purchase-item-preview {


### PR DESCRIPTION
## Summary
- Reducir relleno y tamaño mínimo de las pestañas para que quepan sin desplazamiento horizontal.
- Disminuir el espacio entre las pestañas de perfil y tienda.

## Testing
- `npm test` *(falla: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_b_689f53d1cda88333a3c55fc0dcf1e2aa